### PR TITLE
feat(config): create composable config library with Zod schemas

### DIFF
--- a/apps/auth-server/src/config/env.ts
+++ b/apps/auth-server/src/config/env.ts
@@ -1,30 +1,32 @@
-import * as dotenv from 'dotenv';
+import {
+  authEnvSchema,
+  baseEnvSchema,
+  databaseEnvSchema,
+  parseEnv,
+  passwordEnvSchema,
+  rateLimitEnvSchema,
+  redisEnvSchema,
+} from '@qauth/config';
 import { z } from 'zod';
 
-dotenv.config();
-
+/**
+ * Auth server environment schema
+ * Composes all required schemas and adds app-specific configuration
+ */
 const envSchema = z.object({
-  NODE_ENV: z.enum(['development', 'production', 'test']).default('development'),
-  HOST: z.string().default('0.0.0.0'),
-  PORT: z.coerce.number().int().min(1).max(65535).default(3000),
-  LOG_LEVEL: z.enum(['fatal', 'error', 'warn', 'info', 'debug', 'trace']).default('info'),
-  DATABASE_URL: z.url(),
-  REDIS_URL: z.url().optional(),
-  REDIS_HOST: z.string().optional(),
-  REDIS_PORT: z.coerce.number().int().min(1).max(65535).optional(),
+  ...baseEnvSchema.shape,
+  ...databaseEnvSchema.shape,
+  ...redisEnvSchema.shape,
+  ...passwordEnvSchema.shape,
+  ...authEnvSchema.shape,
+  ...rateLimitEnvSchema.shape,
+  /**
+   * CORS allowed origin (app-specific)
+   */
   CORS_ORIGIN: z.string().optional(),
-  // Rate Limiting
-  RATE_LIMIT_MAX: z.coerce.number().int().min(1).default(100),
-  RATE_LIMIT_WINDOW: z.coerce.number().int().min(1).default(3600),
-  REGISTRATION_RATE_LIMIT: z.coerce.number().int().min(1).default(3),
-  REGISTRATION_RATE_WINDOW: z.coerce.number().int().min(1).default(3600),
-  // Authentication
-  DEFAULT_REALM_NAME: z.string().min(1).default('master'),
-  // Password
-  PASSWORD_MIN_SCORE: z.coerce.number().int().min(0).max(4).default(2),
-  PASSWORD_MEMORY_COST: z.coerce.number().int().min(1).default(65536),
-  PASSWORD_TIME_COST: z.coerce.number().int().min(1).default(3),
-  PASSWORD_PARALLELISM: z.coerce.number().int().min(1).default(4),
 });
 
-export const env = envSchema.parse(process.env);
+/**
+ * Validated environment configuration
+ */
+export const env = parseEnv(envSchema);

--- a/apps/auth-server/tsconfig.app.json
+++ b/apps/auth-server/tsconfig.app.json
@@ -10,6 +10,9 @@
   "exclude": ["src/**/*.test.ts", "src/**/*.spec.ts", "src/test/**/*"],
   "references": [
     {
+      "path": "../../libs/server/config/tsconfig.lib.json"
+    },
+    {
       "path": "../../libs/common/validation/tsconfig.lib.json"
     },
     {

--- a/libs/server/config/README.md
+++ b/libs/server/config/README.md
@@ -1,0 +1,178 @@
+# @qauth/config
+
+Composable Zod schemas for environment variable validation. This library provides type-safe, reusable configuration schemas that apps can compose based on their needs.
+
+## Installation
+
+This library is part of the QAuth monorepo. It's automatically available via the `@qauth/config` import path.
+
+## Usage
+
+### Basic Usage
+
+```typescript
+import { z } from 'zod';
+import { baseEnvSchema, databaseEnvSchema, parseEnv } from '@qauth/config';
+
+// Compose only the schemas you need using spread syntax
+const envSchema = z.object({
+  ...baseEnvSchema.shape,
+  ...databaseEnvSchema.shape,
+});
+
+// Parse and validate environment variables
+const env = parseEnv(envSchema);
+
+// env is fully typed
+console.log(env.PORT); // number
+console.log(env.DATABASE_URL); // string
+```
+
+### Full Composition Example
+
+```typescript
+import { z } from 'zod';
+import {
+  authEnvSchema,
+  baseEnvSchema,
+  databaseEnvSchema,
+  parseEnv,
+  passwordEnvSchema,
+  rateLimitEnvSchema,
+  redisEnvSchema,
+} from '@qauth/config';
+
+// Compose all schemas with app-specific extensions using spread syntax
+const envSchema = z.object({
+  ...baseEnvSchema.shape,
+  ...databaseEnvSchema.shape,
+  ...redisEnvSchema.shape,
+  ...passwordEnvSchema.shape,
+  ...authEnvSchema.shape,
+  ...rateLimitEnvSchema.shape,
+  // App-specific env vars
+  CORS_ORIGIN: z.string().optional(),
+});
+
+export const env = parseEnv(envSchema);
+```
+
+## Available Schemas
+
+### baseEnvSchema
+
+Common server configuration.
+
+| Variable    | Type   | Default       | Description         |
+| ----------- | ------ | ------------- | ------------------- |
+| `NODE_ENV`  | enum   | `development` | Node environment    |
+| `HOST`      | string | `0.0.0.0`     | Server host address |
+| `PORT`      | number | `3000`        | Server port         |
+| `LOG_LEVEL` | enum   | `info`        | Logging level       |
+
+### databaseEnvSchema
+
+PostgreSQL database configuration.
+
+| Variable                     | Type   | Default | Description               |
+| ---------------------------- | ------ | ------- | ------------------------- |
+| `DATABASE_URL`               | url    | -       | PostgreSQL connection URL |
+| `DB_POOL_MAX`                | number | `20`    | Max connections in pool   |
+| `DB_POOL_MIN`                | number | `2`     | Min connections in pool   |
+| `DB_POOL_IDLE_TIMEOUT`       | number | `10000` | Idle timeout (ms)         |
+| `DB_POOL_CONNECTION_TIMEOUT` | number | `2000`  | Connection timeout (ms)   |
+
+### redisEnvSchema
+
+Redis cache configuration.
+
+| Variable                   | Type   | Default | Description             |
+| -------------------------- | ------ | ------- | ----------------------- |
+| `REDIS_URL`                | url    | -       | Redis connection URL    |
+| `REDIS_HOST`               | string | -       | Redis host (if no URL)  |
+| `REDIS_PORT`               | number | -       | Redis port (if no URL)  |
+| `REDIS_PASSWORD`           | string | -       | Redis password          |
+| `REDIS_DB`                 | number | -       | Redis database number   |
+| `REDIS_MAX_RETRIES`        | number | `3`     | Max retries per request |
+| `REDIS_RETRY_DELAY`        | number | `1000`  | Retry delay (ms)        |
+| `REDIS_CONNECTION_TIMEOUT` | number | `10000` | Connection timeout (ms) |
+| `REDIS_COMMAND_TIMEOUT`    | number | `5000`  | Command timeout (ms)    |
+
+### passwordEnvSchema
+
+Password hashing and validation configuration.
+
+| Variable               | Type   | Default | Description              |
+| ---------------------- | ------ | ------- | ------------------------ |
+| `PASSWORD_MIN_SCORE`   | number | `2`     | Min strength score (0-4) |
+| `PASSWORD_MEMORY_COST` | number | `65536` | Argon2 memory cost (KB)  |
+| `PASSWORD_TIME_COST`   | number | `3`     | Argon2 iterations        |
+| `PASSWORD_PARALLELISM` | number | `4`     | Argon2 parallelism       |
+
+### authEnvSchema
+
+Authentication-specific configuration.
+
+| Variable                   | Type   | Default  | Description               |
+| -------------------------- | ------ | -------- | ------------------------- |
+| `DEFAULT_REALM_NAME`       | string | `master` | Default realm name        |
+| `REGISTRATION_RATE_LIMIT`  | number | `3`      | Max registrations/window  |
+| `REGISTRATION_RATE_WINDOW` | number | `3600`   | Registration window (sec) |
+
+### rateLimitEnvSchema
+
+Global rate limiting configuration.
+
+| Variable            | Type   | Default | Description             |
+| ------------------- | ------ | ------- | ----------------------- |
+| `RATE_LIMIT_MAX`    | number | `100`   | Max requests/window     |
+| `RATE_LIMIT_WINDOW` | number | `3600`  | Rate limit window (sec) |
+
+## API
+
+### parseEnv(schema)
+
+Parses and validates environment variables against a Zod schema.
+
+- Loads `.env` file using dotenv
+- Validates `process.env` against the schema
+- Returns a fully typed configuration object
+- Throws `ZodError` if validation fails
+
+```typescript
+import { baseEnvSchema, parseEnv } from '@qauth/config';
+
+const env = parseEnv(baseEnvSchema);
+```
+
+## Type Exports
+
+Each schema exports its corresponding TypeScript type:
+
+```typescript
+import type {
+  AuthEnv,
+  BaseEnv,
+  DatabaseEnv,
+  PasswordEnv,
+  RateLimitEnv,
+  RedisEnv,
+} from '@qauth/config';
+```
+
+## Error Handling
+
+If required environment variables are missing or invalid, `parseEnv` throws a `ZodError` with detailed validation messages:
+
+```typescript
+import { ZodError } from 'zod';
+
+try {
+  const env = parseEnv(databaseEnvSchema);
+} catch (error) {
+  if (error instanceof ZodError) {
+    console.error('Invalid environment configuration:', error.format());
+    process.exit(1);
+  }
+}
+```

--- a/libs/server/config/project.json
+++ b/libs/server/config/project.json
@@ -1,0 +1,9 @@
+{
+  "name": "config",
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/server/config/src",
+  "projectType": "library",
+  "tags": [],
+  "// targets": "to see all targets run: nx show project config --web",
+  "targets": {}
+}

--- a/libs/server/config/src/index.ts
+++ b/libs/server/config/src/index.ts
@@ -1,0 +1,18 @@
+// Schema exports
+export {
+  type AuthEnv,
+  authEnvSchema,
+  type BaseEnv,
+  baseEnvSchema,
+  type DatabaseEnv,
+  databaseEnvSchema,
+  type PasswordEnv,
+  passwordEnvSchema,
+  type RateLimitEnv,
+  rateLimitEnvSchema,
+  type RedisEnv,
+  redisEnvSchema,
+} from './lib/schemas';
+
+// Utility exports
+export { parseEnv } from './lib/parse-env';

--- a/libs/server/config/src/lib/parse-env.ts
+++ b/libs/server/config/src/lib/parse-env.ts
@@ -1,0 +1,31 @@
+import * as dotenv from 'dotenv';
+import { z } from 'zod';
+
+/**
+ * Parse and validate environment variables against a Zod schema
+ *
+ * This function:
+ * 1. Loads environment variables from .env file using dotenv
+ * 2. Validates process.env against the provided Zod schema
+ * 3. Returns a type-safe configuration object
+ *
+ * @param schema - Zod schema to validate against
+ * @returns Parsed and validated environment configuration
+ * @throws ZodError if validation fails
+ *
+ * @example
+ * ```typescript
+ * import { baseEnvSchema, databaseEnvSchema, parseEnv } from '@qauth/config';
+ *
+ * const envSchema = baseEnvSchema.merge(databaseEnvSchema);
+ * const env = parseEnv(envSchema);
+ * // env is typed as BaseEnv & DatabaseEnv
+ * ```
+ */
+export function parseEnv<T extends z.ZodTypeAny>(schema: T): z.infer<T> {
+  // Load environment variables from .env file
+  dotenv.config();
+
+  // Parse and validate against the schema
+  return schema.parse(process.env);
+}

--- a/libs/server/config/src/lib/parse-env.ts
+++ b/libs/server/config/src/lib/parse-env.ts
@@ -15,11 +15,15 @@ import { z } from 'zod';
  *
  * @example
  * ```typescript
+ * import { z } from 'zod';
  * import { baseEnvSchema, databaseEnvSchema, parseEnv } from '@qauth/config';
  *
- * const envSchema = baseEnvSchema.merge(databaseEnvSchema);
+ * const envSchema = z.object({
+ *   ...baseEnvSchema.shape,
+ *   ...databaseEnvSchema.shape,
+ * });
  * const env = parseEnv(envSchema);
- * // env is typed as BaseEnv & DatabaseEnv
+ * // env is fully typed
  * ```
  */
 export function parseEnv<T extends z.ZodTypeAny>(schema: T): z.infer<T> {

--- a/libs/server/config/src/lib/schemas/auth.ts
+++ b/libs/server/config/src/lib/schemas/auth.ts
@@ -1,0 +1,27 @@
+import { z } from 'zod';
+
+/**
+ * Authentication environment configuration schema
+ * Auth-specific settings
+ */
+export const authEnvSchema = z.object({
+  /**
+   * Default realm name for new installations
+   */
+  DEFAULT_REALM_NAME: z.string().min(1).default('master'),
+
+  /**
+   * Maximum registration attempts per window
+   */
+  REGISTRATION_RATE_LIMIT: z.coerce.number().int().min(1).default(3),
+
+  /**
+   * Registration rate limit window in seconds
+   */
+  REGISTRATION_RATE_WINDOW: z.coerce.number().int().min(1).default(3600),
+});
+
+/**
+ * Auth environment configuration type
+ */
+export type AuthEnv = z.infer<typeof authEnvSchema>;

--- a/libs/server/config/src/lib/schemas/base.ts
+++ b/libs/server/config/src/lib/schemas/base.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod';
+
+/**
+ * Base server environment configuration schema
+ * Common settings for all server applications
+ */
+export const baseEnvSchema = z.object({
+  /**
+   * Node environment
+   */
+  NODE_ENV: z.enum(['development', 'production', 'test']).default('development'),
+
+  /**
+   * Server host address
+   */
+  HOST: z.string().default('0.0.0.0'),
+
+  /**
+   * Server port number
+   */
+  PORT: z.coerce.number().int().min(1).max(65535).default(3000),
+
+  /**
+   * Logging level
+   */
+  LOG_LEVEL: z.enum(['fatal', 'error', 'warn', 'info', 'debug', 'trace']).default('info'),
+});
+
+/**
+ * Base environment configuration type
+ */
+export type BaseEnv = z.infer<typeof baseEnvSchema>;

--- a/libs/server/config/src/lib/schemas/database.ts
+++ b/libs/server/config/src/lib/schemas/database.ts
@@ -1,0 +1,37 @@
+import { z } from 'zod';
+
+/**
+ * Database environment configuration schema
+ * PostgreSQL connection and pool settings
+ */
+export const databaseEnvSchema = z.object({
+  /**
+   * PostgreSQL connection URL (required)
+   */
+  DATABASE_URL: z.url(),
+
+  /**
+   * Maximum number of connections in the pool
+   */
+  DB_POOL_MAX: z.coerce.number().int().min(1).default(20),
+
+  /**
+   * Minimum number of connections in the pool
+   */
+  DB_POOL_MIN: z.coerce.number().int().min(1).default(2),
+
+  /**
+   * Idle connection timeout in milliseconds
+   */
+  DB_POOL_IDLE_TIMEOUT: z.coerce.number().int().min(1).default(10000),
+
+  /**
+   * Connection timeout in milliseconds
+   */
+  DB_POOL_CONNECTION_TIMEOUT: z.coerce.number().int().min(1).default(2000),
+});
+
+/**
+ * Database environment configuration type
+ */
+export type DatabaseEnv = z.infer<typeof databaseEnvSchema>;

--- a/libs/server/config/src/lib/schemas/index.ts
+++ b/libs/server/config/src/lib/schemas/index.ts
@@ -1,0 +1,7 @@
+// Schema exports
+export { type AuthEnv, authEnvSchema } from './auth';
+export { type BaseEnv, baseEnvSchema } from './base';
+export { type DatabaseEnv, databaseEnvSchema } from './database';
+export { type PasswordEnv, passwordEnvSchema } from './password';
+export { type RateLimitEnv, rateLimitEnvSchema } from './rate-limit';
+export { type RedisEnv, redisEnvSchema } from './redis';

--- a/libs/server/config/src/lib/schemas/password.ts
+++ b/libs/server/config/src/lib/schemas/password.ts
@@ -1,0 +1,33 @@
+import { z } from 'zod';
+
+/**
+ * Password configuration schema
+ * Password validation and hashing settings
+ */
+export const passwordEnvSchema = z.object({
+  /**
+   * Minimum password strength score (0-4)
+   * 0: Very weak, 1: Weak, 2: Fair, 3: Good, 4: Strong
+   */
+  PASSWORD_MIN_SCORE: z.coerce.number().int().min(0).max(4).default(2),
+
+  /**
+   * Argon2 memory cost in KB (default: 64MB)
+   */
+  PASSWORD_MEMORY_COST: z.coerce.number().int().min(1).default(65536),
+
+  /**
+   * Argon2 time cost / iterations
+   */
+  PASSWORD_TIME_COST: z.coerce.number().int().min(1).default(3),
+
+  /**
+   * Argon2 parallelism / threads
+   */
+  PASSWORD_PARALLELISM: z.coerce.number().int().min(1).default(4),
+});
+
+/**
+ * Password environment configuration type
+ */
+export type PasswordEnv = z.infer<typeof passwordEnvSchema>;

--- a/libs/server/config/src/lib/schemas/rate-limit.ts
+++ b/libs/server/config/src/lib/schemas/rate-limit.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod';
+
+/**
+ * Rate limiting environment configuration schema
+ * Global rate limiting settings
+ */
+export const rateLimitEnvSchema = z.object({
+  /**
+   * Maximum requests per window
+   */
+  RATE_LIMIT_MAX: z.coerce.number().int().min(1).default(100),
+
+  /**
+   * Rate limit window in seconds
+   */
+  RATE_LIMIT_WINDOW: z.coerce.number().int().min(1).default(3600),
+});
+
+/**
+ * Rate limit environment configuration type
+ */
+export type RateLimitEnv = z.infer<typeof rateLimitEnvSchema>;

--- a/libs/server/config/src/lib/schemas/redis.ts
+++ b/libs/server/config/src/lib/schemas/redis.ts
@@ -1,0 +1,57 @@
+import { z } from 'zod';
+
+/**
+ * Redis environment configuration schema
+ * Redis connection and pool settings
+ */
+export const redisEnvSchema = z.object({
+  /**
+   * Redis connection URL (optional, takes precedence over individual settings)
+   */
+  REDIS_URL: z.url().optional(),
+
+  /**
+   * Redis host address (used if REDIS_URL is not set)
+   */
+  REDIS_HOST: z.string().optional(),
+
+  /**
+   * Redis port number (used if REDIS_URL is not set)
+   */
+  REDIS_PORT: z.coerce.number().int().min(1).max(65535).optional(),
+
+  /**
+   * Redis password (optional)
+   */
+  REDIS_PASSWORD: z.string().optional(),
+
+  /**
+   * Redis database number
+   */
+  REDIS_DB: z.coerce.number().int().min(0).optional(),
+
+  /**
+   * Maximum retries per request
+   */
+  REDIS_MAX_RETRIES: z.coerce.number().int().min(1).default(3),
+
+  /**
+   * Retry delay on failover in milliseconds
+   */
+  REDIS_RETRY_DELAY: z.coerce.number().int().min(1).default(1000),
+
+  /**
+   * Connection timeout in milliseconds
+   */
+  REDIS_CONNECTION_TIMEOUT: z.coerce.number().int().min(1).default(10000),
+
+  /**
+   * Command timeout in milliseconds
+   */
+  REDIS_COMMAND_TIMEOUT: z.coerce.number().int().min(1).default(5000),
+});
+
+/**
+ * Redis environment configuration type
+ */
+export type RedisEnv = z.infer<typeof redisEnvSchema>;

--- a/libs/server/config/tsconfig.json
+++ b/libs/server/config/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "importHelpers": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/libs/server/config/tsconfig.lib.json
+++ b/libs/server/config/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "declaration": true,
+    "composite": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/nx.json
+++ b/nx.json
@@ -28,7 +28,8 @@
         "libs/fastify-plugin/cache/*",
         "libs/common/errors/*",
         "libs/common/validation/*",
-        "libs/common/password/*"
+        "libs/common/password/*",
+        "libs/server/config/*"
       ]
     },
     {
@@ -40,7 +41,8 @@
         "libs/fastify-plugin/cache/*",
         "libs/common/errors/*",
         "libs/common/validation/*",
-        "libs/common/password/*"
+        "libs/common/password/*",
+        "libs/server/config/*"
       ],
       "options": {
         "typecheck": {

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -15,7 +15,8 @@
       "@qauth/fastify-plugin-cache": ["libs/fastify-plugin/cache/src/index.ts"],
       "@qauth/errors": ["libs/common/errors/src/index.ts"],
       "@qauth/password": ["libs/common/password/src/index.ts"],
-      "@qauth/validation": ["libs/common/validation/src/index.ts"]
+      "@qauth/validation": ["libs/common/validation/src/index.ts"],
+      "@qauth/config": ["libs/server/config/src/index.ts"]
     },
     "esModuleInterop": true,
     "strict": true,


### PR DESCRIPTION
- Create @qauth/config library with 6 composable schema modules:
  - base: NODE_ENV, HOST, PORT, LOG_LEVEL
  - database: DATABASE_URL, DB_POOL_*
  - redis: REDIS_URL, REDIS_HOST, REDIS_PORT, etc.
  - password: PASSWORD_MIN_SCORE, PASSWORD_*_COST
  - auth: DEFAULT_REALM_NAME, REGISTRATION_RATE_*
  - rate-limit: RATE_LIMIT_MAX, RATE_LIMIT_WINDOW

- Add parseEnv utility function for type-safe env validation
- Refactor auth-server env.ts to use composed schemas with spread syntax (Zod v4 compatible)
- Add comprehensive README documentation with usage examples
- Update TypeScript configs and Nx workspace configuration

Closes #12