### PR TITLE
feat(db): migrate email verification tokens to use token_hash

### DIFF
--- a/.cursor/rules/zod.mdc
+++ b/.cursor/rules/zod.mdc
@@ -1,5 +1,5 @@
 ---
-description: Use this rule while working with zod
+alwaysApply: true
 ---
 
 # Schema Documentation

--- a/.env.example
+++ b/.env.example
@@ -95,15 +95,26 @@ PASSWORD_TIME_COST=3
 PASSWORD_PARALLELISM=4
 
 # Email Configuration
+# Email verification token expiry in seconds (default: 86400 = 24 hours)
+EMAIL_VERIFICATION_TOKEN_EXPIRY=86400
+
+# Whether to invalidate existing tokens when resending verification email
+# If true, only the latest token is valid (more secure)
+# If false, multiple tokens can be active (user can use any valid token)
+EMAIL_VERIFICATION_INVALIDATE_EXISTING_ON_RESEND=true
+
 # Email provider type: 'mock', 'resend', or 'smtp'
 # Default: 'mock' (logs to console, no actual emails sent)
 EMAIL_PROVIDER=mock
 
-# Default sender email address
-# EMAIL_FROM=noreply@example.com
+# Default sender email address (required)
+EMAIL_FROM_ADDRESS=noreply@example.com
 
-# Base URL for email links (e.g., verification links)
-# EMAIL_BASE_URL=https://example.com
+# Default sender name (default: 'QAuth')
+EMAIL_FROM_NAME=QAuth
+
+# Base URL for email links (e.g., verification links) (required)
+EMAIL_BASE_URL=https://example.com
 
 # Resend Provider Configuration (required if EMAIL_PROVIDER=resend)
 # Get your API key from https://resend.com
@@ -112,7 +123,7 @@ EMAIL_PROVIDER=mock
 # SMTP Provider Configuration (required if EMAIL_PROVIDER=smtp)
 # SMTP_HOST=smtp.example.com
 # SMTP_PORT=587
-# SMTP_SECURE=false
+# SMTP_SECURE=true
 # SMTP_USER=user@example.com
 # SMTP_PASSWORD=your_smtp_password
 

--- a/apps/auth-server/src/config/env.ts
+++ b/apps/auth-server/src/config/env.ts
@@ -2,6 +2,7 @@ import {
   authEnvSchema,
   baseEnvSchema,
   databaseEnvSchema,
+  emailEnvSchema,
   parseEnv,
   passwordEnvSchema,
   rateLimitEnvSchema,
@@ -20,6 +21,7 @@ const envSchema = z.object({
   ...passwordEnvSchema.shape,
   ...authEnvSchema.shape,
   ...rateLimitEnvSchema.shape,
+  ...emailEnvSchema.shape,
   /**
    * CORS allowed origin (app-specific)
    */

--- a/libs/fastify/plugins/db/src/lib/fastify-plugin-db.ts
+++ b/libs/fastify/plugins/db/src/lib/fastify-plugin-db.ts
@@ -1,9 +1,11 @@
 import {
   createDatabase,
+  createEmailVerificationTokensRepository,
   createRealmsRepository,
   createUsersRepository,
   type DatabasePool,
   type DbClient,
+  type EmailVerificationTokensRepository,
   type RealmsRepository,
   type UsersRepository,
 } from '@qauth/infra-db';
@@ -19,6 +21,7 @@ declare module 'fastify' {
     repositories: {
       users: UsersRepository;
       realms: RealmsRepository;
+      emailVerificationTokens: EmailVerificationTokensRepository;
     };
   }
 }
@@ -52,6 +55,7 @@ export const databasePlugin = fp<DatabasePluginOptions>(
     fastify.decorate('repositories', {
       users: createUsersRepository(database.db),
       realms: createRealmsRepository(database.db),
+      emailVerificationTokens: createEmailVerificationTokensRepository(database.db),
     });
 
     fastify.addHook('onReady', async () => {

--- a/libs/infra/db/drizzle/0000_young_vermin.sql
+++ b/libs/infra/db/drizzle/0000_young_vermin.sql
@@ -140,18 +140,18 @@ CREATE TABLE "authorization_codes" (
 --> statement-breakpoint
 CREATE TABLE "email_verification_tokens" (
 	"id" uuid PRIMARY KEY DEFAULT uuidv7() NOT NULL,
-	"token" varchar(255) NOT NULL,
+	"token_hash" varchar(64) NOT NULL,
 	"user_id" uuid NOT NULL,
 	"expires_at" bigint NOT NULL,
 	"used" boolean DEFAULT false NOT NULL,
 	"used_at" bigint,
 	"created_at" bigint DEFAULT (EXTRACT(EPOCH FROM NOW())::bigint * 1000) NOT NULL,
-	CONSTRAINT "email_verification_tokens_token_unique" UNIQUE("token")
+	CONSTRAINT "email_verification_tokens_token_hash_unique" UNIQUE("token_hash")
 );
 --> statement-breakpoint
 CREATE TABLE "refresh_tokens" (
 	"id" uuid PRIMARY KEY DEFAULT uuidv7() NOT NULL,
-	"token_hash" text NOT NULL,
+	"token_hash" varchar(64) NOT NULL,
 	"user_id" uuid NOT NULL,
 	"oauth_client_id" uuid NOT NULL,
 	"scopes" jsonb DEFAULT '[]'::jsonb NOT NULL,
@@ -159,7 +159,7 @@ CREATE TABLE "refresh_tokens" (
 	"revoked" boolean DEFAULT false NOT NULL,
 	"revoked_at" bigint,
 	"revoked_reason" varchar(255),
-	"previous_token_hash" text,
+	"previous_token_hash" varchar(64),
 	"created_at" bigint DEFAULT (EXTRACT(EPOCH FROM NOW())::bigint * 1000) NOT NULL,
 	"last_used_at" bigint,
 	CONSTRAINT "refresh_tokens_token_hash_unique" UNIQUE("token_hash")
@@ -203,6 +203,7 @@ CREATE INDEX "idx_users_realm_id" ON "users" USING btree ("realm_id");--> statem
 CREATE INDEX "idx_users_enabled" ON "users" USING btree ("enabled") WHERE "users"."enabled" = true;--> statement-breakpoint
 CREATE INDEX "idx_users_realm_email_enabled" ON "users" USING btree ("realm_id","email_normalized","enabled");--> statement-breakpoint
 CREATE UNIQUE INDEX "idx_roles_realm_name_unique" ON "roles" USING btree ("realm_id","name","oauth_client_id");--> statement-breakpoint
+CREATE INDEX "idx_roles_name" ON "roles" USING btree ("name");--> statement-breakpoint
 CREATE INDEX "idx_roles_realm_id" ON "roles" USING btree ("realm_id");--> statement-breakpoint
 CREATE INDEX "idx_roles_oauth_client_id" ON "roles" USING btree ("oauth_client_id");--> statement-breakpoint
 CREATE INDEX "idx_user_roles_user_id" ON "user_roles" USING btree ("user_id");--> statement-breakpoint
@@ -217,7 +218,7 @@ CREATE INDEX "idx_authorization_codes_expires_at" ON "authorization_codes" USING
 CREATE INDEX "idx_authorization_codes_user_id" ON "authorization_codes" USING btree ("user_id");--> statement-breakpoint
 CREATE INDEX "idx_authorization_codes_oauth_client_id" ON "authorization_codes" USING btree ("oauth_client_id");--> statement-breakpoint
 CREATE INDEX "idx_email_verification_tokens_user_id" ON "email_verification_tokens" USING btree ("user_id");--> statement-breakpoint
-CREATE INDEX "idx_email_verification_tokens_active" ON "email_verification_tokens" USING btree ("token","expires_at") WHERE "email_verification_tokens"."used" = false;--> statement-breakpoint
+CREATE INDEX "idx_email_verification_tokens_active" ON "email_verification_tokens" USING btree ("token_hash","expires_at") WHERE "email_verification_tokens"."used" = false;--> statement-breakpoint
 CREATE INDEX "idx_email_verification_tokens_expires_at" ON "email_verification_tokens" USING btree ("expires_at");--> statement-breakpoint
 CREATE INDEX "idx_refresh_tokens_active" ON "refresh_tokens" USING btree ("token_hash","expires_at") WHERE "refresh_tokens"."revoked" = false;--> statement-breakpoint
 CREATE INDEX "idx_refresh_tokens_expires_at" ON "refresh_tokens" USING btree ("expires_at");--> statement-breakpoint

--- a/libs/infra/db/drizzle/meta/0000_snapshot.json
+++ b/libs/infra/db/drizzle/meta/0000_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "id": "cb332a38-574d-47da-ad4e-b906efab5af8",
+  "id": "9037b9e4-8e88-472c-a2fe-498ee6a19f54",
   "prevId": "00000000-0000-0000-0000-000000000000",
   "version": "7",
   "dialect": "postgresql",
@@ -1541,9 +1541,9 @@
           "notNull": true,
           "default": "uuidv7()"
         },
-        "token": {
-          "name": "token",
-          "type": "varchar(255)",
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
           "primaryKey": false,
           "notNull": true
         },
@@ -1600,7 +1600,7 @@
           "name": "idx_email_verification_tokens_active",
           "columns": [
             {
-              "expression": "token",
+              "expression": "token_hash",
               "isExpression": false,
               "asc": true,
               "nulls": "last"
@@ -1647,10 +1647,10 @@
       },
       "compositePrimaryKeys": {},
       "uniqueConstraints": {
-        "email_verification_tokens_token_unique": {
-          "name": "email_verification_tokens_token_unique",
+        "email_verification_tokens_token_hash_unique": {
+          "name": "email_verification_tokens_token_hash_unique",
           "nullsNotDistinct": false,
-          "columns": ["token"]
+          "columns": ["token_hash"]
         }
       },
       "policies": {},
@@ -1670,7 +1670,7 @@
         },
         "token_hash": {
           "name": "token_hash",
-          "type": "text",
+          "type": "varchar(64)",
           "primaryKey": false,
           "notNull": true
         },
@@ -1720,7 +1720,7 @@
         },
         "previous_token_hash": {
           "name": "previous_token_hash",
-          "type": "text",
+          "type": "varchar(64)",
           "primaryKey": false,
           "notNull": false
         },

--- a/libs/infra/db/drizzle/meta/_journal.json
+++ b/libs/infra/db/drizzle/meta/_journal.json
@@ -5,8 +5,8 @@
     {
       "idx": 0,
       "version": "7",
-      "when": 1766603755116,
-      "tag": "0000_glamorous_valkyrie",
+      "when": 1767256756723,
+      "tag": "0000_young_vermin",
       "breakpoints": true
     }
   ]

--- a/libs/infra/db/src/lib/repositories/email-verification-tokens.repository.ts
+++ b/libs/infra/db/src/lib/repositories/email-verification-tokens.repository.ts
@@ -1,11 +1,13 @@
 import { NotFoundError } from '@qauth/shared-errors';
-import { and, eq, gt, InferInsertModel, InferSelectModel, lt } from 'drizzle-orm';
+import { and, eq, gt, lt } from 'drizzle-orm';
 
+import type {
+  EmailVerificationToken,
+  EmailVerificationTokensRepository,
+  NewEmailVerificationToken,
+} from '../../types';
 import { DbClient } from '../db';
 import { emailVerificationTokens } from '../schema/tokens';
-
-export type EmailVerificationToken = InferSelectModel<typeof emailVerificationTokens>;
-export type NewEmailVerificationToken = InferInsertModel<typeof emailVerificationTokens>;
 
 /**
  * Factory function that creates an email verification tokens repository
@@ -13,7 +15,9 @@ export type NewEmailVerificationToken = InferInsertModel<typeof emailVerificatio
  * @param defaultDb - Database client to use for queries
  * @returns Repository object with token methods
  */
-export function createEmailVerificationTokensRepository(defaultDb: DbClient) {
+export function createEmailVerificationTokensRepository(
+  defaultDb: DbClient
+): EmailVerificationTokensRepository {
   return {
     /**
      * Create a new email verification token
@@ -29,14 +33,17 @@ export function createEmailVerificationTokensRepository(defaultDb: DbClient) {
     },
 
     /**
-     * Find a token by its token value
+     * Find a token by its token hash
      * Only returns tokens that are not used and not expired
      *
-     * @param token - Token value
+     * @param tokenHash - SHA-256 hash of the token
      * @param tx - Optional transaction client
      * @returns Token if found and valid, undefined otherwise
      */
-    async findByToken(token: string, tx?: DbClient): Promise<EmailVerificationToken | undefined> {
+    async findByTokenHash(
+      tokenHash: string,
+      tx?: DbClient
+    ): Promise<EmailVerificationToken | undefined> {
       const invoker = tx ?? defaultDb;
       // Use current timestamp directly in the query
       const now = Date.now();
@@ -46,7 +53,7 @@ export function createEmailVerificationTokensRepository(defaultDb: DbClient) {
         .from(emailVerificationTokens)
         .where(
           and(
-            eq(emailVerificationTokens.token, token),
+            eq(emailVerificationTokens.tokenHash, tokenHash),
             eq(emailVerificationTokens.used, false),
             gt(emailVerificationTokens.expiresAt, now)
           )
@@ -82,6 +89,36 @@ export function createEmailVerificationTokensRepository(defaultDb: DbClient) {
       }
 
       return token;
+    },
+
+    /**
+     * Invalidate all active tokens for a user
+     * Marks all unused, non-expired tokens for the user as used
+     *
+     * @param userId - User ID whose tokens should be invalidated
+     * @param tx - Optional transaction client
+     * @returns Number of tokens invalidated
+     */
+    async invalidateUserTokens(userId: string, tx?: DbClient): Promise<number> {
+      const invoker = tx ?? defaultDb;
+      const now = Date.now();
+
+      const result = await invoker
+        .update(emailVerificationTokens)
+        .set({
+          used: true,
+          usedAt: now,
+        })
+        .where(
+          and(
+            eq(emailVerificationTokens.userId, userId),
+            eq(emailVerificationTokens.used, false),
+            gt(emailVerificationTokens.expiresAt, now)
+          )
+        )
+        .returning();
+
+      return result.length;
     },
 
     /**

--- a/libs/infra/db/src/lib/schema/tokens.ts
+++ b/libs/infra/db/src/lib/schema/tokens.ts
@@ -12,7 +12,8 @@ export const emailVerificationTokens = pgTable(
     id: uuid('id')
       .primaryKey()
       .default(sql`uuidv7()`),
-    token: varchar('token', { length: 255 }).notNull().unique(),
+    /** SHA-256 hash of the verification token (64 hex characters) */
+    tokenHash: varchar('token_hash', { length: 64 }).notNull().unique(),
     userId: uuid('user_id')
       .notNull()
       .references(() => users.id, { onDelete: 'cascade' }),
@@ -24,7 +25,7 @@ export const emailVerificationTokens = pgTable(
   (t) => [
     index('idx_email_verification_tokens_user_id').on(t.userId),
     index('idx_email_verification_tokens_active')
-      .on(t.token, t.expiresAt)
+      .on(t.tokenHash, t.expiresAt)
       .where(sql`${t.used} = false`),
     index('idx_email_verification_tokens_expires_at').on(t.expiresAt),
   ]
@@ -70,7 +71,8 @@ export const refreshTokens = pgTable(
     id: uuid('id')
       .primaryKey()
       .default(sql`uuidv7()`),
-    tokenHash: text('token_hash').notNull().unique(),
+    /** SHA-256 hash of the refresh token (64 hex characters) */
+    tokenHash: varchar('token_hash', { length: 64 }).notNull().unique(),
     userId: uuid('user_id')
       .notNull()
       .references(() => users.id, { onDelete: 'cascade' }),
@@ -82,7 +84,8 @@ export const refreshTokens = pgTable(
     revoked: boolean('revoked').notNull().default(false),
     revokedAt: bigint('revoked_at', { mode: 'number' }),
     revokedReason: varchar('revoked_reason', { length: 255 }),
-    previousTokenHash: text('previous_token_hash'),
+    /** SHA-256 hash of the previous token for rotation tracking (64 hex characters) */
+    previousTokenHash: varchar('previous_token_hash', { length: 64 }),
     createdAt: bigint('created_at', { mode: 'number' }).notNull().default(EPOCH_MS_NOW),
     lastUsedAt: bigint('last_used_at', { mode: 'number' }),
   },

--- a/libs/infra/db/src/types/repository.ts
+++ b/libs/infra/db/src/types/repository.ts
@@ -1,4 +1,13 @@
+import type { InferInsertModel, InferSelectModel } from 'drizzle-orm';
+
+import type { emailVerificationTokens } from '../lib/schema/tokens';
 import type { DbClient } from './database';
+
+/**
+ * Email verification token types
+ */
+export type EmailVerificationToken = InferSelectModel<typeof emailVerificationTokens>;
+export type NewEmailVerificationToken = InferInsertModel<typeof emailVerificationTokens>;
 
 /**
  * Base repository interface for common CRUD operations
@@ -16,4 +25,30 @@ export interface BaseRepository<TSelect, TInsert, TUpdate> {
   update(id: string, data: TUpdate, tx?: DbClient): Promise<TSelect>;
   /** Delete an entity by ID @returns True if deleted, false if not found */
   delete(id: string, tx?: DbClient): Promise<boolean>;
+}
+
+/**
+ * Email verification tokens repository interface
+ */
+export interface EmailVerificationTokensRepository {
+  /**
+   * Create a new email verification token
+   */
+  create(data: NewEmailVerificationToken, tx?: DbClient): Promise<EmailVerificationToken>;
+  /**
+   * Find a token by its token hash
+   */
+  findByTokenHash(tokenHash: string, tx?: DbClient): Promise<EmailVerificationToken | undefined>;
+  /**
+   * Mark a token as used
+   */
+  markUsed(id: string, tx?: DbClient): Promise<EmailVerificationToken>;
+  /**
+   * Invalidate all active tokens for a user
+   */
+  invalidateUserTokens(userId: string, tx?: DbClient): Promise<number>;
+  /**
+   * Delete expired tokens
+   */
+  deleteExpired(tx?: DbClient): Promise<EmailVerificationToken[]>;
 }

--- a/libs/server/config/src/lib/schemas/email.ts
+++ b/libs/server/config/src/lib/schemas/email.ts
@@ -5,19 +5,36 @@ import { z } from 'zod';
  */
 export const emailEnvSchema = z.object({
   /**
+   * Email verification token expiry in seconds (default: 86400 = 24 hours)
+   */
+  EMAIL_VERIFICATION_TOKEN_EXPIRY: z.coerce.number().int().min(3600).default(86400),
+
+  /**
+   * Whether to invalidate existing tokens when resending verification email
+   * If true, only the latest token is valid (more secure)
+   * If false, multiple tokens can be active (user can use any valid token)
+   */
+  EMAIL_VERIFICATION_INVALIDATE_EXISTING_ON_RESEND: z.coerce.boolean().default(true),
+
+  /**
    * Email provider type
    */
   EMAIL_PROVIDER: z.enum(['mock', 'resend', 'smtp']).default('mock'),
 
   /**
-   * Default sender email address
+   * Default sender email address (required)
    */
-  EMAIL_FROM: z.string().email().optional(),
+  EMAIL_FROM_ADDRESS: z.email(),
+
+  /**
+   * Default sender name (default: 'QAuth')
+   */
+  EMAIL_FROM_NAME: z.string().default('QAuth'),
 
   /**
    * Base URL for email links (e.g., verification links)
    */
-  EMAIL_BASE_URL: z.string().url().optional(),
+  EMAIL_BASE_URL: z.url(),
 
   /**
    * Resend API key (required if EMAIL_PROVIDER is 'resend')
@@ -37,11 +54,7 @@ export const emailEnvSchema = z.object({
   /**
    * SMTP secure connection (TLS/SSL)
    */
-  SMTP_SECURE: z
-    .string()
-    .transform((val) => val === 'true' || val === '1')
-    .pipe(z.boolean())
-    .default(false),
+  SMTP_SECURE: z.coerce.boolean().default(true),
 
   /**
    * SMTP username (required if EMAIL_PROVIDER is 'smtp')


### PR DESCRIPTION
- Change email_verification_tokens.token to token_hash (varchar(64))
- Update refresh_tokens.token_hash to varchar(64) from text
- Add email verification tokens repository to database plugin
- Add email configuration environment variables
- Update email config schema with new options
- Apply zod rule as alwaysApply

Closes #24