### PR TITLE
feat(auth): add resend verification email endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -81,6 +81,21 @@ VERIFICATION_RATE_LIMIT=10
 # Email verification endpoint rate limit - time window in seconds
 VERIFICATION_RATE_WINDOW=900
 
+# Resend verification endpoint rate limit - maximum number of requests per time window (per-IP)
+RESEND_VERIFICATION_RATE_LIMIT=100
+
+# Resend verification endpoint rate limit - time window in seconds
+RESEND_VERIFICATION_RATE_WINDOW=60
+
+# Per-email resend verification limit - maximum requests per email address per window
+RESEND_VERIFICATION_EMAIL_LIMIT=3
+
+# Per-email resend verification rate limit window in seconds (default: 3600 = 1 hour)
+RESEND_VERIFICATION_EMAIL_WINDOW=3600
+
+# Minimum interval between resend requests to same email in seconds
+RESEND_VERIFICATION_MIN_INTERVAL=60
+
 # Authentication Configuration
 # Default realm name for new user registrations
 DEFAULT_REALM_NAME=master

--- a/apps/auth-server/src/app/constants/index.ts
+++ b/apps/auth-server/src/app/constants/index.ts
@@ -1,0 +1,2 @@
+export * from './messages';
+export * from './redis-keys';

--- a/apps/auth-server/src/app/constants/messages.ts
+++ b/apps/auth-server/src/app/constants/messages.ts
@@ -1,0 +1,14 @@
+/**
+ * Error messages used across the application
+ */
+export const ERROR_MESSAGES = {
+  RATE_LIMIT_EXCEEDED: 'Please wait before requesting another verification email',
+} as const;
+
+/**
+ * Success messages used across the application
+ */
+export const SUCCESS_MESSAGES = {
+  RESEND_VERIFICATION:
+    'If the email exists and is not verified, a verification email has been sent',
+} as const;

--- a/apps/auth-server/src/app/constants/redis-keys.ts
+++ b/apps/auth-server/src/app/constants/redis-keys.ts
@@ -1,0 +1,9 @@
+/**
+ * Redis key generators for rate limiting and caching
+ */
+export const REDIS_KEYS = {
+  /** Rate limit counter for resend verification requests per email */
+  RESEND_RATE_LIMIT: (email: string) => `rate-limit:resend:${email}`,
+  /** Last email sent timestamp for minimum interval check */
+  LAST_EMAIL_SENT: (email: string) => `last-email-sent:${email}`,
+} as const;

--- a/apps/auth-server/src/app/helpers/realm.ts
+++ b/apps/auth-server/src/app/helpers/realm.ts
@@ -1,0 +1,21 @@
+import type { FastifyInstance } from 'fastify';
+
+import { env } from '../../config/env';
+
+/**
+ * Get or create default realm
+ * Helper function to get the default realm for user operations
+ */
+export async function getOrCreateDefaultRealm(fastify: FastifyInstance) {
+  const defaultRealmName = env.DEFAULT_REALM_NAME;
+  let realm = await fastify.repositories.realms.findByName(defaultRealmName);
+
+  if (!realm) {
+    realm = await fastify.repositories.realms.create({
+      name: defaultRealmName,
+      enabled: true,
+    });
+  }
+
+  return realm;
+}

--- a/apps/auth-server/src/app/plugins/error-handler.ts
+++ b/apps/auth-server/src/app/plugins/error-handler.ts
@@ -5,6 +5,7 @@ import {
   NotFoundError,
   TokenAlreadyUsedError,
   TokenExpiredError,
+  TooManyRequestsError,
   UniqueConstraintError,
   WeakPasswordError,
 } from '@qauth/shared-errors';
@@ -28,6 +29,7 @@ const SimpleErrorClasses = [
   TokenExpiredError,
   TokenAlreadyUsedError,
   EmailAlreadyVerifiedError,
+  TooManyRequestsError,
 ] as const;
 
 /**

--- a/apps/auth-server/src/app/routes/auth/register.ts
+++ b/apps/auth-server/src/app/routes/auth/register.ts
@@ -4,24 +4,8 @@ import type { FastifyInstance } from 'fastify';
 import { ZodTypeProvider } from 'fastify-type-provider-zod';
 
 import { env } from '../../../config/env';
+import { getOrCreateDefaultRealm } from '../../helpers/realm';
 import { registerResponseSchema, registerSchema } from '../../schemas/auth';
-
-/**
- * Get or create default realm
- */
-async function getOrCreateDefaultRealm(fastify: FastifyInstance) {
-  const defaultRealmName = env.DEFAULT_REALM_NAME;
-  let realm = await fastify.repositories.realms.findByName(defaultRealmName);
-
-  if (!realm) {
-    realm = await fastify.repositories.realms.create({
-      name: defaultRealmName,
-      enabled: true,
-    });
-  }
-
-  return realm;
-}
 
 /**
  * Registration route

--- a/apps/auth-server/src/app/routes/auth/register.ts
+++ b/apps/auth-server/src/app/routes/auth/register.ts
@@ -1,5 +1,5 @@
 import { BadRequestError, WeakPasswordError } from '@qauth/shared-errors';
-import { validateEmail } from '@qauth/shared-validation';
+import { normalizeEmail } from '@qauth/shared-validation';
 import type { FastifyInstance } from 'fastify';
 import { ZodTypeProvider } from 'fastify-type-provider-zod';
 
@@ -31,8 +31,8 @@ export default async function (fastify: FastifyInstance) {
     async (request, reply) => {
       const { email, password, realmId } = request.body;
 
-      // Validate email format and normalize
-      const normalizedEmail = validateEmail(email);
+      // Email is already validated by Zod schema, just normalize it
+      const normalizedEmail = normalizeEmail(email);
 
       // Validate password strength using injected validator
       const passwordStrength = fastify.passwordValidator.validatePasswordStrength(password);

--- a/apps/auth-server/src/app/routes/auth/resend-verification.ts
+++ b/apps/auth-server/src/app/routes/auth/resend-verification.ts
@@ -1,5 +1,6 @@
 import { generateVerificationToken } from '@qauth/server-email';
 import { TooManyRequestsError } from '@qauth/shared-errors';
+import { normalizeEmail } from '@qauth/shared-validation';
 import type { FastifyInstance } from 'fastify';
 import { ZodTypeProvider } from 'fastify-type-provider-zod';
 
@@ -20,7 +21,8 @@ const MIN_RESPONSE_TIME_MS = 200;
  * - Per-IP rate limiting (RESEND_VERIFICATION_RATE_LIMIT) prevents DDoS attacks
  * - Per-email rate limiting (RESEND_VERIFICATION_EMAIL_LIMIT) prevents inbox bombing
  * - Minimum interval (RESEND_VERIFICATION_MIN_INTERVAL) prevents rapid requests
- * - Atomic Redis operations prevent race conditions in rate limiting
+ * - Atomic Redis INCR prevents race conditions in rate limiting
+ * - TTL set only on first request to prevent sliding window bypass
  * - Rate limit counters increment for ALL requests (even non-existent users)
  *   to prevent email enumeration via timing/behavior differences
  * - Fixed minimum response time prevents timing-based email enumeration
@@ -52,22 +54,23 @@ export default async function (fastify: FastifyInstance) {
       const { email } = request.body;
 
       // Email is already validated by Zod schema, just normalize it
-      const normalizedEmail = email.toLowerCase().trim();
+      const normalizedEmail = normalizeEmail(email);
 
-      // Per-email rate limiting using atomic INCR + EXPIRE to prevent race conditions
+      // Per-email rate limiting using atomic INCR
       // This counter is incremented for ALL requests (even if user doesn't exist)
       // to prevent email enumeration via rate limit behavior differences
       const emailRateLimitKey = REDIS_KEYS.RESEND_RATE_LIMIT(normalizedEmail);
 
-      // Atomic increment and expire using Redis multi to prevent TTL race condition
-      const results = await fastify.redis
-        .multi()
-        .incr(emailRateLimitKey)
-        .expire(emailRateLimitKey, env.RESEND_VERIFICATION_EMAIL_WINDOW)
-        .exec();
+      // INCR is atomic - returns unique incrementing value per request
+      // TTL is set only on first request (count=1) to ensure window doesn't reset
+      // Note: If EXPIRE fails after INCR=1, key will persist without TTL.
+      // This is acceptable as it's a conservative failure (blocks more, not less)
+      const emailRateLimitCount = await fastify.redis.incr(emailRateLimitKey);
 
-      // Get the count from multi result: [[null, count], [null, 1]]
-      const emailRateLimitCount = results?.[0]?.[1] as number;
+      if (emailRateLimitCount === 1) {
+        // Set TTL only on first request to prevent window reset on subsequent requests
+        await fastify.redis.expire(emailRateLimitKey, env.RESEND_VERIFICATION_EMAIL_WINDOW);
+      }
 
       if (emailRateLimitCount > env.RESEND_VERIFICATION_EMAIL_LIMIT) {
         throw new TooManyRequestsError(ERROR_MESSAGES.RATE_LIMIT_EXCEEDED);

--- a/apps/auth-server/src/app/routes/auth/resend-verification.ts
+++ b/apps/auth-server/src/app/routes/auth/resend-verification.ts
@@ -1,0 +1,147 @@
+import { generateVerificationToken } from '@qauth/server-email';
+import { TooManyRequestsError } from '@qauth/shared-errors';
+import type { FastifyInstance } from 'fastify';
+import { ZodTypeProvider } from 'fastify-type-provider-zod';
+
+import { env } from '../../../config/env';
+import { ERROR_MESSAGES, REDIS_KEYS, SUCCESS_MESSAGES } from '../../constants';
+import { getOrCreateDefaultRealm } from '../../helpers/realm';
+import { resendVerificationResponseSchema, resendVerificationSchema } from '../../schemas/auth';
+import { errorResponseSchema } from '../../schemas/common';
+
+/** Minimum response time in milliseconds to prevent timing attacks */
+const MIN_RESPONSE_TIME_MS = 200;
+
+/**
+ * Resend verification email route
+ * Allows users to request a new verification email
+ *
+ * Security considerations:
+ * - Per-IP rate limiting (RESEND_VERIFICATION_RATE_LIMIT) prevents DDoS attacks
+ * - Per-email rate limiting (RESEND_VERIFICATION_EMAIL_LIMIT) prevents inbox bombing
+ * - Minimum interval (RESEND_VERIFICATION_MIN_INTERVAL) prevents rapid requests
+ * - Atomic Redis operations prevent race conditions in rate limiting
+ * - Rate limit counters increment for ALL requests (even non-existent users)
+ *   to prevent email enumeration via timing/behavior differences
+ * - Fixed minimum response time prevents timing-based email enumeration
+ * - Always returns success message to prevent email enumeration
+ * - Tokens are hashed (SHA-256) before storage
+ * - Optional token invalidation (EMAIL_VERIFICATION_INVALIDATE_EXISTING_ON_RESEND)
+ */
+export default async function (fastify: FastifyInstance) {
+  fastify.withTypeProvider<ZodTypeProvider>().post(
+    '/auth/resend-verification',
+    {
+      schema: {
+        body: resendVerificationSchema,
+        response: {
+          200: resendVerificationResponseSchema,
+          429: errorResponseSchema,
+        },
+      },
+      config: {
+        rateLimit: {
+          max: env.RESEND_VERIFICATION_RATE_LIMIT,
+          timeWindow: env.RESEND_VERIFICATION_RATE_WINDOW * 1000,
+          keyGenerator: (request) => request.ip || 'unknown',
+        },
+      },
+    },
+    async (request) => {
+      const startTime = Date.now();
+      const { email } = request.body;
+
+      // Email is already validated by Zod schema, just normalize it
+      const normalizedEmail = email.toLowerCase().trim();
+
+      // Per-email rate limiting using atomic INCR + EXPIRE to prevent race conditions
+      // This counter is incremented for ALL requests (even if user doesn't exist)
+      // to prevent email enumeration via rate limit behavior differences
+      const emailRateLimitKey = REDIS_KEYS.RESEND_RATE_LIMIT(normalizedEmail);
+
+      // Atomic increment and expire using Redis multi to prevent TTL race condition
+      const results = await fastify.redis
+        .multi()
+        .incr(emailRateLimitKey)
+        .expire(emailRateLimitKey, env.RESEND_VERIFICATION_EMAIL_WINDOW)
+        .exec();
+
+      // Get the count from multi result: [[null, count], [null, 1]]
+      const emailRateLimitCount = results?.[0]?.[1] as number;
+
+      if (emailRateLimitCount > env.RESEND_VERIFICATION_EMAIL_LIMIT) {
+        throw new TooManyRequestsError(ERROR_MESSAGES.RATE_LIMIT_EXCEEDED);
+      }
+
+      // Minimum interval check between sends to same email
+      const lastSentKey = REDIS_KEYS.LAST_EMAIL_SENT(normalizedEmail);
+      const lastSent = await fastify.redis.get(lastSentKey);
+
+      if (lastSent) {
+        const timeSinceLastSent = Date.now() - parseInt(lastSent, 10);
+        if (timeSinceLastSent < env.RESEND_VERIFICATION_MIN_INTERVAL * 1000) {
+          throw new TooManyRequestsError(ERROR_MESSAGES.RATE_LIMIT_EXCEEDED);
+        }
+      }
+
+      // Get default realm for user lookup
+      const realm = await getOrCreateDefaultRealm(fastify);
+
+      // Find user by email (don't expose if not found - prevent enumeration)
+      // Note: findByEmail internally normalizes email, but we already have it normalized
+      const user = await fastify.repositories.users.findByEmail(realm.id, normalizedEmail);
+
+      // If user exists and email is not verified, send verification email
+      if (user && !user.emailVerified) {
+        // Invalidate existing tokens if config is enabled
+        if (env.EMAIL_VERIFICATION_INVALIDATE_EXISTING_ON_RESEND) {
+          await fastify.repositories.emailVerificationTokens.invalidateUserTokens(user.id);
+        }
+
+        // Generate new verification token
+        const { token, tokenHash } = generateVerificationToken();
+
+        // Calculate expiration time
+        const expiresAt = Date.now() + env.EMAIL_VERIFICATION_TOKEN_EXPIRY * 1000;
+
+        // Store token hash in database
+        await fastify.repositories.emailVerificationTokens.create({
+          userId: user.id,
+          tokenHash,
+          expiresAt,
+          used: false,
+        });
+
+        // Send verification email (don't fail if email send fails)
+        try {
+          await fastify.emailService.sendVerificationEmail(user.email, token);
+        } catch (error) {
+          fastify.log.error(error, 'Failed to send verification email');
+          // Don't fail the request - user can try again later
+        }
+      }
+      // If user doesn't exist or email is already verified, still return success
+      // This prevents email enumeration attacks
+
+      // Update last sent timestamp for minimum interval check
+      await fastify.redis.set(
+        lastSentKey,
+        Date.now().toString(),
+        'EX',
+        env.RESEND_VERIFICATION_MIN_INTERVAL
+      );
+
+      // Enforce minimum response time to prevent timing-based email enumeration
+      // This ensures consistent response time regardless of whether user exists
+      const elapsed = Date.now() - startTime;
+      if (elapsed < MIN_RESPONSE_TIME_MS) {
+        await new Promise((resolve) => setTimeout(resolve, MIN_RESPONSE_TIME_MS - elapsed));
+      }
+
+      // Always return success with generic message (prevent email enumeration)
+      return {
+        message: SUCCESS_MESSAGES.RESEND_VERIFICATION,
+      };
+    }
+  );
+}

--- a/apps/auth-server/src/app/schemas/auth.ts
+++ b/apps/auth-server/src/app/schemas/auth.ts
@@ -59,3 +59,27 @@ export const verifyResponseSchema = z.object({
  * Email verification response type
  */
 export type VerifyResponse = z.infer<typeof verifyResponseSchema>;
+
+/**
+ * Resend verification request schema
+ */
+export const resendVerificationSchema = z.object({
+  email: z.email('Invalid email format'),
+});
+
+/**
+ * Resend verification request type
+ */
+export type ResendVerificationRequest = z.infer<typeof resendVerificationSchema>;
+
+/**
+ * Resend verification response schema
+ */
+export const resendVerificationResponseSchema = z.object({
+  message: z.string(),
+});
+
+/**
+ * Resend verification response type
+ */
+export type ResendVerificationResponse = z.infer<typeof resendVerificationResponseSchema>;

--- a/apps/auth-server/src/app/schemas/common.ts
+++ b/apps/auth-server/src/app/schemas/common.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod';
+
+/**
+ * Error response schema (matches error handler output)
+ */
+export const errorResponseSchema = z.object({
+  error: z.string(),
+  statusCode: z.number(),
+});
+
+/**
+ * Error response type
+ */
+export type ErrorResponse = z.infer<typeof errorResponseSchema>;

--- a/libs/server/config/src/lib/schemas/auth.ts
+++ b/libs/server/config/src/lib/schemas/auth.ts
@@ -31,6 +31,34 @@ export const authEnvSchema = z.object({
    * Note: Converted to milliseconds in route handlers (value * 1000)
    */
   VERIFICATION_RATE_WINDOW: z.coerce.number().int().min(1).default(900),
+
+  /**
+   * Maximum resend verification attempts per window (per-IP)
+   */
+  RESEND_VERIFICATION_RATE_LIMIT: z.coerce.number().int().min(1).default(100),
+
+  /**
+   * Resend verification rate limit window in seconds (default: 60 = 1 minute)
+   * Note: Converted to milliseconds in route handlers (value * 1000)
+   */
+  RESEND_VERIFICATION_RATE_WINDOW: z.coerce.number().int().min(1).default(60),
+
+  /**
+   * Maximum resend verification attempts per email address per window
+   * Prevents inbox bombing attacks
+   */
+  RESEND_VERIFICATION_EMAIL_LIMIT: z.coerce.number().int().min(1).default(3),
+
+  /**
+   * Per-email resend verification rate limit window in seconds (default: 3600 = 1 hour)
+   */
+  RESEND_VERIFICATION_EMAIL_WINDOW: z.coerce.number().int().min(1).default(3600),
+
+  /**
+   * Minimum interval between resend requests to same email in seconds (default: 60)
+   * Prevents rapid repeated requests
+   */
+  RESEND_VERIFICATION_MIN_INTERVAL: z.coerce.number().int().min(1).default(60),
 });
 
 /**

--- a/libs/shared/errors/src/lib/common/index.ts
+++ b/libs/shared/errors/src/lib/common/index.ts
@@ -1,2 +1,3 @@
 export * from './bad-request.error';
 export * from './not-found.error';
+export * from './too-many-requests.error';

--- a/libs/shared/errors/src/lib/common/too-many-requests.error.ts
+++ b/libs/shared/errors/src/lib/common/too-many-requests.error.ts
@@ -1,0 +1,18 @@
+/**
+ * Error thrown when rate limit is exceeded
+ * This is a common error that can occur across different domains
+ */
+export class TooManyRequestsError extends Error {
+  readonly statusCode = 429;
+
+  constructor(message = 'Too many requests') {
+    super(message);
+    this.name = 'TooManyRequestsError';
+    // Ensure proper prototype chain for instanceof checks
+    Object.setPrototypeOf(this, TooManyRequestsError.prototype);
+    // Maintains proper stack trace for where our error was thrown (only available on V8)
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, TooManyRequestsError);
+    }
+  }
+}


### PR DESCRIPTION
- Add POST /auth/resend-verification endpoint
- Implement per-IP and per-email rate limiting
- Add minimum interval check between requests
- Prevent email enumeration attacks with consistent responses
- Add TooManyRequestsError for rate limit handling
- Extract getOrCreateDefaultRealm helper function
- Add error and success message constants
- Add Redis key generators for rate limiting
- Add error response schema for common error handling

Closes #26