### PR TITLE
feat(auth): integrate email verification into registration endpoint

### DIFF
--- a/apps/auth-server/src/app/app.ts
+++ b/apps/auth-server/src/app/app.ts
@@ -54,7 +54,7 @@ export async function app(fastify: FastifyInstance, opts: object) {
     serviceConfig: {
       // TODO: Add email configuration from environment variables
       // defaultFrom: env.EMAIL_FROM,
-      // baseUrl: env.EMAIL_BASE_URL,
+      baseUrl: env.EMAIL_BASE_URL,
     },
   });
 

--- a/apps/auth-server/src/app/routes/auth/register.ts
+++ b/apps/auth-server/src/app/routes/auth/register.ts
@@ -70,6 +70,32 @@ export default async function (fastify: FastifyInstance) {
         emailVerified: false,
       });
 
+      // Generate verification token pair (token + tokenHash)
+      const { token, tokenHash } = fastify.emailVerificationTokenUtils.generateVerificationToken();
+
+      // Calculate expiration time
+      const expiresAt = Date.now() + env.EMAIL_VERIFICATION_TOKEN_EXPIRY * 1000;
+
+      // Store tokenHash in database (NOT plain token)
+      await fastify.repositories.emailVerificationTokens.create({
+        userId: user.id,
+        tokenHash,
+        expiresAt,
+        used: false,
+      });
+
+      // Send verification email (don't fail registration if this fails)
+      try {
+        await fastify.emailService.sendVerificationEmail(user.email, token);
+        fastify.log.info({ userId: user.id, email: user.email }, 'Verification email sent');
+      } catch (error) {
+        fastify.log.error(
+          { err: error, userId: user.id, email: user.email },
+          'Failed to send verification email during registration'
+        );
+        // Don't throw - registration succeeded, user can request resend
+      }
+
       // Return user data without password_hash
       // Type is automatically inferred from registerResponseSchema
       return reply.code(201).send({

--- a/apps/auth-server/src/app/routes/auth/resend-verification.ts
+++ b/apps/auth-server/src/app/routes/auth/resend-verification.ts
@@ -1,4 +1,3 @@
-import { generateVerificationToken } from '@qauth/server-email';
 import { TooManyRequestsError } from '@qauth/shared-errors';
 import { normalizeEmail } from '@qauth/shared-validation';
 import type { FastifyInstance } from 'fastify';
@@ -102,7 +101,8 @@ export default async function (fastify: FastifyInstance) {
         }
 
         // Generate new verification token
-        const { token, tokenHash } = generateVerificationToken();
+        const { token, tokenHash } =
+          fastify.emailVerificationTokenUtils.generateVerificationToken();
 
         // Calculate expiration time
         const expiresAt = Date.now() + env.EMAIL_VERIFICATION_TOKEN_EXPIRY * 1000;

--- a/apps/auth-server/src/app/routes/auth/verify.ts
+++ b/apps/auth-server/src/app/routes/auth/verify.ts
@@ -1,4 +1,3 @@
-import { hashToken } from '@qauth/server-email';
 import { EmailAlreadyVerifiedError, InvalidTokenError, NotFoundError } from '@qauth/shared-errors';
 import type { FastifyInstance } from 'fastify';
 import { ZodTypeProvider } from 'fastify-type-provider-zod';
@@ -46,7 +45,7 @@ export default async function (fastify: FastifyInstance) {
       // This prevents CVE-2025-12374 style attacks at schema level
 
       // 1. Hash token before database lookup
-      const tokenHash = hashToken(token);
+      const tokenHash = fastify.emailVerificationTokenUtils.hashToken(token);
 
       // 2. Find token in database (returns undefined if not found, expired, or used)
       const verificationToken =

--- a/apps/auth-server/tsconfig.app.json
+++ b/apps/auth-server/tsconfig.app.json
@@ -13,9 +13,6 @@
       "path": "../../libs/server/config/tsconfig.lib.json"
     },
     {
-      "path": "../../libs/server/email/tsconfig.lib.json"
-    },
-    {
       "path": "../../libs/shared/validation/tsconfig.lib.json"
     },
     {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -76,15 +76,10 @@ export default [
             },
             // Application layer (top layer)
             // Applications are the entry points and can use all layers
-            // Can depend on: fastify plugins, server libs, infra libs, shared libs
+            // Can depend on: fastify plugins, shared libs
             {
               sourceTag: 'scope:app',
-              onlyDependOnLibsWithTags: [
-                'scope:fastify',
-                'scope:server',
-                'scope:infra',
-                'scope:shared',
-              ],
+              onlyDependOnLibsWithTags: ['scope:fastify', 'scope:shared', 'scope:server-config'],
             },
           ],
         },

--- a/libs/fastify/plugins/email/src/lib/fastify-plugin-email.ts
+++ b/libs/fastify/plugins/email/src/lib/fastify-plugin-email.ts
@@ -1,7 +1,11 @@
 import {
+  constantTimeCompare,
   createEmailService,
   type EmailProvider,
   type EmailService,
+  generateVerificationToken,
+  hashToken,
+  isValidTokenFormat,
   MockEmailProvider,
   ResendEmailProvider,
   type ResendProviderConfig,
@@ -11,11 +15,17 @@ import {
 import type { FastifyInstance } from 'fastify';
 import fp from 'fastify-plugin';
 
-import type { EmailPluginOptions, EmailProviderConfig, EmailProviderType } from '../types';
+import type {
+  EmailPluginOptions,
+  EmailProviderConfig,
+  EmailProviderType,
+  EmailVerificationTokenUtils,
+} from '../types';
 
 declare module 'fastify' {
   interface FastifyInstance {
     emailService: EmailService;
+    emailVerificationTokenUtils: EmailVerificationTokenUtils;
   }
 }
 
@@ -75,6 +85,12 @@ export const emailPlugin = fp<EmailPluginOptions>(
     const emailService = createEmailService(provider, options.serviceConfig);
 
     fastify.decorate('emailService', emailService);
+    fastify.decorate('emailVerificationTokenUtils', {
+      generateVerificationToken,
+      hashToken,
+      isValidTokenFormat,
+      constantTimeCompare,
+    });
 
     fastify.log.debug({ provider: providerType }, 'Email plugin registered');
   },

--- a/libs/fastify/plugins/email/src/types.ts
+++ b/libs/fastify/plugins/email/src/types.ts
@@ -3,6 +3,12 @@ import type {
   ResendProviderConfig,
   SmtpProviderConfig,
 } from '@qauth/server-email';
+import {
+  constantTimeCompare,
+  generateVerificationToken,
+  hashToken,
+  isValidTokenFormat,
+} from '@qauth/server-email';
 import type { FastifyPluginOptions } from 'fastify';
 
 /**
@@ -26,4 +32,15 @@ export interface EmailPluginOptions extends FastifyPluginOptions {
   providerConfig?: EmailProviderConfig;
   /** Email service configuration (optional, missing values will use defaults) */
   serviceConfig?: Partial<EmailServiceConfig>;
+}
+
+/**
+ * Email verification token utilities interface
+ * Provides token generation and validation utilities for email verification
+ */
+export interface EmailVerificationTokenUtils {
+  generateVerificationToken: typeof generateVerificationToken;
+  hashToken: typeof hashToken;
+  isValidTokenFormat: typeof isValidTokenFormat;
+  constantTimeCompare: typeof constantTimeCompare;
 }

--- a/libs/server/config/project.json
+++ b/libs/server/config/project.json
@@ -3,6 +3,6 @@
   "$schema": "../../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "libs/server/config/src",
   "projectType": "library",
-  "tags": ["scope:server", "type:config"],
+  "tags": ["scope:server", "scope:server-config", "type:config"],
   "// targets": "to see all targets run: nx show project server-config --web"
 }


### PR DESCRIPTION
- Generate and store verification token after user creation
- Send verification email with graceful error handling
- Add emailVerificationTokenUtils to email plugin
- Configure email service baseUrl
- Refactor routes to use plugin-based token utilities

Closes #27