### PR TITLE
feat(config): configure email provider from environment variables

### DIFF
--- a/MVP-PRD.md
+++ b/MVP-PRD.md
@@ -182,10 +182,11 @@ const valid = await verify(hashed, password);
 - [x] Store token hash in database (TTL: 24 hours)
 - [x] Email infrastructure ready (Resend, SMTP, Mock providers)
 - [x] React Email templates for verification emails
-- [ ] Send verification email on registration
-- [ ] Implement verify endpoint (`GET /auth/verify?token=...`)
-- [ ] Mark email as verified
-- [ ] Handle expired tokens
+- [x] Configure email provider from environment variables
+- [x] Send verification email on registration
+- [x] Implement verify endpoint (`GET /auth/verify?token=...`)
+- [x] Mark email as verified
+- [x] Handle expired tokens
 
 **API Endpoints**:
 
@@ -212,6 +213,8 @@ Response:
 
 **Acceptance Criteria**:
 
+- ✅ Email provider can be configured via environment variables (mock, resend, smtp)
+- ✅ Provider-specific configuration validated at startup
 - ✅ Verification email is sent on registration
 - ✅ Valid tokens verify the email
 - ✅ Expired tokens are rejected

--- a/apps/auth-server/src/app/app.ts
+++ b/apps/auth-server/src/app/app.ts
@@ -2,7 +2,7 @@ import AutoLoad from '@fastify/autoload';
 import cors from '@fastify/cors';
 import { cachePlugin } from '@qauth/fastify-plugin-cache';
 import { databasePlugin } from '@qauth/fastify-plugin-db';
-import { emailPlugin } from '@qauth/fastify-plugin-email';
+import { emailPlugin, type EmailProviderConfig } from '@qauth/fastify-plugin-email';
 import { passwordPlugin } from '@qauth/fastify-plugin-password';
 import { FastifyInstance } from 'fastify';
 import * as path from 'path';
@@ -49,11 +49,45 @@ export async function app(fastify: FastifyInstance, opts: object) {
     },
   });
 
+  // Configure email provider from environment variables
+  const emailProvider = env.EMAIL_PROVIDER;
+
+  // Build provider-specific configuration
+  let providerConfig: EmailProviderConfig | undefined;
+  if (emailProvider === 'resend') {
+    if (!env.RESEND_API_KEY) {
+      throw new Error(
+        'RESEND_API_KEY is required when EMAIL_PROVIDER is "resend". Please set it in your environment variables.'
+      );
+    }
+    providerConfig = {
+      apiKey: env.RESEND_API_KEY,
+      fromAddress: env.EMAIL_FROM_ADDRESS,
+    };
+  } else if (emailProvider === 'smtp') {
+    if (!env.SMTP_HOST || !env.SMTP_PORT || !env.SMTP_USER || !env.SMTP_PASSWORD) {
+      throw new Error(
+        'SMTP_HOST, SMTP_PORT, SMTP_USER, and SMTP_PASSWORD are required when EMAIL_PROVIDER is "smtp". Please set them in your environment variables.'
+      );
+    }
+    providerConfig = {
+      host: env.SMTP_HOST,
+      port: env.SMTP_PORT,
+      secure: env.SMTP_SECURE,
+      auth: {
+        user: env.SMTP_USER,
+        pass: env.SMTP_PASSWORD,
+      },
+      fromAddress: env.EMAIL_FROM_ADDRESS,
+    };
+  }
+  // For 'mock' provider, providerConfig is undefined (no config needed)
+
   await fastify.register(emailPlugin, {
-    provider: 'mock', // TODO: Configure based on environment (resend, smtp, mock)
+    provider: emailProvider,
+    providerConfig,
     serviceConfig: {
-      // TODO: Add email configuration from environment variables
-      // defaultFrom: env.EMAIL_FROM,
+      defaultFrom: env.EMAIL_FROM_ADDRESS,
       baseUrl: env.EMAIL_BASE_URL,
     },
   });


### PR DESCRIPTION
- Read EMAIL_PROVIDER from environment (mock, resend, smtp)
- Build provider-specific config based on provider type
- Validate required configuration for each provider:
  - Resend: requires RESEND_API_KEY
  - SMTP: requires SMTP_HOST, SMTP_PORT, SMTP_USER, SMTP_PASSWORD
- Use EMAIL_FROM_ADDRESS and EMAIL_BASE_URL in serviceConfig
- Update PRD Phase 1.3 to mark email provider configuration as completed

Closes #36