### PR TITLE
feat(config): add JWT configuration schema with hybrid file path support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -96,9 +96,66 @@ RESEND_VERIFICATION_EMAIL_WINDOW=3600
 # Minimum interval between resend requests to same email in seconds
 RESEND_VERIFICATION_MIN_INTERVAL=60
 
+# Login endpoint rate limit - maximum number of requests per time window
+LOGIN_RATE_LIMIT=5
+
+# Login endpoint rate limit - time window in seconds (default: 900 = 15 minutes)
+LOGIN_RATE_WINDOW=900
+
 # Authentication Configuration
 # Default realm name for new user registrations
 DEFAULT_REALM_NAME=master
+
+# System OAuth client ID (optional, default: "system")
+# Used for internal/system operations
+# SYSTEM_CLIENT_ID=system
+
+# JWT Configuration
+# Supports both environment variables and file paths
+
+# Option 1: Environment Variables
+# EdDSA private key in PEM format (required if JWT_PRIVATE_KEY_PATH is not set)
+# Used to sign JWT tokens
+# Generate with: openssl genpkey -algorithm Ed25519 -out private.pem
+# Example format:
+# JWT_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----
+# MC4CAQAwBQYDK2VwBCIEI...
+# -----END PRIVATE KEY-----"
+
+# EdDSA public key in PEM format (optional if JWT_PUBLIC_KEY_PATH is not set)
+# If not provided, can be derived from private key
+# Extract with: openssl pkey -in private.pem -pubout -out public.pem
+# Example format:
+# JWT_PUBLIC_KEY="-----BEGIN PUBLIC KEY-----
+# MCowBQYDK2VwAyEA...
+# -----END PUBLIC KEY-----"
+
+# Option 2: File Paths (Recommended for production, Kubernetes/Docker secrets)
+# Path to EdDSA private key file in PEM format (required if JWT_PRIVATE_KEY is not set)
+# Used to sign JWT tokens
+# Generate with: openssl genpkey -algorithm Ed25519 -out private.pem
+# For Kubernetes: Mount secret as volume and set path (e.g., /etc/secrets/jwt-private.pem)
+# For Docker: Mount secret file and set path
+# JWT_PRIVATE_KEY_PATH=/path/to/private.pem
+
+# Path to EdDSA public key file in PEM format (optional if JWT_PUBLIC_KEY is not set)
+# If not provided, can be derived from private key
+# Extract with: openssl pkey -in private.pem -pubout -out public.pem
+# JWT_PUBLIC_KEY_PATH=/path/to/public.pem
+
+# Note: Provide either JWT_PRIVATE_KEY or JWT_PRIVATE_KEY_PATH (one is required)
+# Note: Provide either JWT_PUBLIC_KEY or JWT_PUBLIC_KEY_PATH (both are optional)
+# File paths take precedence if both are provided for the same key type
+
+# JWT issuer URL (required)
+# Used as the 'iss' claim in JWT tokens
+JWT_ISSUER=https://auth.qauth.dev
+
+# Access token expiration in seconds (default: 900 = 15 minutes)
+ACCESS_TOKEN_LIFESPAN=900
+
+# Refresh token expiration in seconds (default: 604800 = 7 days)
+REFRESH_TOKEN_LIFESPAN=604800
 
 # Password Configuration
 # Minimum password strength score (0-4, where 0=very weak, 4=strong)

--- a/apps/auth-server/src/config/env.ts
+++ b/apps/auth-server/src/config/env.ts
@@ -3,6 +3,7 @@ import {
   baseEnvSchema,
   databaseEnvSchema,
   emailEnvSchema,
+  jwtEnvSchema,
   parseEnv,
   passwordEnvSchema,
   rateLimitEnvSchema,
@@ -20,6 +21,7 @@ const envSchema = z.object({
   ...redisEnvSchema.shape,
   ...passwordEnvSchema.shape,
   ...authEnvSchema.shape,
+  ...jwtEnvSchema,
   ...rateLimitEnvSchema.shape,
   ...emailEnvSchema.shape,
   /**

--- a/libs/server/config/src/lib/schemas/auth.ts
+++ b/libs/server/config/src/lib/schemas/auth.ts
@@ -59,6 +59,17 @@ export const authEnvSchema = z.object({
    * Prevents rapid repeated requests
    */
   RESEND_VERIFICATION_MIN_INTERVAL: z.coerce.number().int().min(1).default(60),
+
+  /**
+   * Maximum login attempts per window
+   */
+  LOGIN_RATE_LIMIT: z.coerce.number().int().min(1).default(5),
+
+  /**
+   * Login rate limit window in seconds (default: 900 = 15 minutes)
+   * Note: Converted to milliseconds in route handlers (value * 1000)
+   */
+  LOGIN_RATE_WINDOW: z.coerce.number().int().min(1).default(900),
 });
 
 /**

--- a/libs/server/config/src/lib/schemas/index.ts
+++ b/libs/server/config/src/lib/schemas/index.ts
@@ -3,6 +3,7 @@ export { type AuthEnv, authEnvSchema } from './auth';
 export { type BaseEnv, baseEnvSchema } from './base';
 export { type DatabaseEnv, databaseEnvSchema } from './database';
 export { type EmailEnv, emailEnvSchema } from './email';
+export { type JwtEnv, jwtEnvSchema } from './jwt';
 export { type PasswordEnv, passwordEnvSchema } from './password';
 export { type RateLimitEnv, rateLimitEnvSchema } from './rate-limit';
 export { type RedisEnv, redisEnvSchema } from './redis';

--- a/libs/server/config/src/lib/schemas/jwt.ts
+++ b/libs/server/config/src/lib/schemas/jwt.ts
@@ -1,0 +1,113 @@
+import { readFileSync } from 'node:fs';
+
+import { z } from 'zod';
+
+/**
+ * Helper function to read key from file path
+ */
+function readKeyFromFile(filePath: string): string {
+  try {
+    const content = readFileSync(filePath, 'utf-8');
+    return content.trim();
+  } catch (error) {
+    if (error instanceof Error) {
+      if ('code' in error && error.code === 'ENOENT') {
+        throw new Error(`JWT key file not found: ${filePath}`);
+      }
+      if ('code' in error && error.code === 'EACCES') {
+        throw new Error(`Permission denied reading JWT key file: ${filePath}`);
+      }
+      throw new Error(`Failed to read JWT key file ${filePath}: ${error.message}`);
+    }
+    throw error;
+  }
+}
+
+/**
+ * JWT environment configuration schema
+ * JWT token generation and validation settings
+ *
+ * Supports both environment variables and file paths:
+ * - JWT_PRIVATE_KEY or JWT_PRIVATE_KEY_PATH (one required)
+ * - JWT_PUBLIC_KEY or JWT_PUBLIC_KEY_PATH (both optional)
+ */
+export const jwtEnvSchema = z
+  .object({
+    /**
+     * EdDSA private key in PEM format (optional if JWT_PRIVATE_KEY_PATH is provided)
+     * Used to sign JWT tokens
+     */
+    JWT_PRIVATE_KEY: z.string().optional(),
+
+    /**
+     * Path to EdDSA private key file in PEM format (optional if JWT_PRIVATE_KEY is provided)
+     * Used to sign JWT tokens
+     */
+    JWT_PRIVATE_KEY_PATH: z.string().optional(),
+
+    /**
+     * EdDSA public key in PEM format (optional)
+     * If not provided, can be derived from private key
+     */
+    JWT_PUBLIC_KEY: z.string().optional(),
+
+    /**
+     * Path to EdDSA public key file in PEM format (optional)
+     * If not provided, can be derived from private key
+     */
+    JWT_PUBLIC_KEY_PATH: z.string().optional(),
+
+    /**
+     * JWT issuer URL (required)
+     * Used as the 'iss' claim in JWT tokens
+     */
+    JWT_ISSUER: z.url('JWT issuer must be a valid URL'),
+
+    /**
+     * Access token expiration in seconds (default: 900 = 15 minutes)
+     */
+    ACCESS_TOKEN_LIFESPAN: z.coerce.number().int().positive().default(900),
+
+    /**
+     * Refresh token expiration in seconds (default: 604800 = 7 days)
+     */
+    REFRESH_TOKEN_LIFESPAN: z.coerce.number().int().positive().default(604800),
+  })
+  .transform((data) => {
+    // Resolve private key: prefer direct key, fallback to file path
+    let privateKey: string | undefined;
+    if (data.JWT_PRIVATE_KEY && data.JWT_PRIVATE_KEY.trim().length > 0) {
+      privateKey = data.JWT_PRIVATE_KEY.trim();
+    } else if (data.JWT_PRIVATE_KEY_PATH) {
+      privateKey = readKeyFromFile(data.JWT_PRIVATE_KEY_PATH);
+    }
+
+    // Validate private key is provided
+    if (!privateKey || privateKey.length === 0) {
+      throw new Error(
+        'JWT private key is required. Provide either JWT_PRIVATE_KEY or JWT_PRIVATE_KEY_PATH'
+      );
+    }
+
+    // Resolve public key: prefer direct key, fallback to file path
+    let publicKey: string | undefined;
+    if (data.JWT_PUBLIC_KEY && data.JWT_PUBLIC_KEY.trim().length > 0) {
+      publicKey = data.JWT_PUBLIC_KEY.trim();
+    } else if (data.JWT_PUBLIC_KEY_PATH) {
+      publicKey = readKeyFromFile(data.JWT_PUBLIC_KEY_PATH);
+    }
+
+    // Return resolved configuration
+    return {
+      JWT_PRIVATE_KEY: privateKey,
+      JWT_PUBLIC_KEY: publicKey,
+      JWT_ISSUER: data.JWT_ISSUER,
+      ACCESS_TOKEN_LIFESPAN: data.ACCESS_TOKEN_LIFESPAN,
+      REFRESH_TOKEN_LIFESPAN: data.REFRESH_TOKEN_LIFESPAN,
+    };
+  });
+
+/**
+ * JWT environment configuration type
+ */
+export type JwtEnv = z.infer<typeof jwtEnvSchema>;

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "fastify-plugin": "^5.1.0",
     "fastify-type-provider-zod": "^6.1.0",
     "ioredis": "^5.8.2",
+    "jose": "^6.1.3",
     "nodemailer": "^7.0.12",
     "pg": "^8.16.3",
     "react": "^19.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       ioredis:
         specifier: ^5.8.2
         version: 5.8.2
+      jose:
+        specifier: ^6.1.3
+        version: 6.1.3
       nodemailer:
         specifier: ^7.0.12
         version: 7.0.12
@@ -4784,6 +4787,9 @@ packages:
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
+
+  jose@6.1.3:
+    resolution: {integrity: sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -11684,6 +11690,8 @@ snapshots:
       supports-color: 8.1.1
 
   jiti@2.6.1: {}
+
+  jose@6.1.3: {}
 
   js-tokens@4.0.0: {}
 


### PR DESCRIPTION
- Add jwtEnvSchema with JWT keys, issuer, and token lifespans
- Add LOGIN_RATE_LIMIT and LOGIN_RATE_WINDOW to auth schema
- Support env vars and file paths for JWT keys
- Add jose package dependency
- Update .env.example with JWT config documentation
- Integrate jwtEnvSchema into auth-server config

Closes #38