### PR TITLE
feat(db): implement refresh token repository

### DIFF
--- a/libs/infra/db/src/lib/repositories/index.ts
+++ b/libs/infra/db/src/lib/repositories/index.ts
@@ -6,4 +6,5 @@ export * from './audit-logs.repository';
 export * from './email-verification-tokens.repository';
 export * from './oauth-clients.repository';
 export * from './realms.repository';
+export * from './refresh-tokens.repository';
 export * from './users.repository';

--- a/libs/infra/db/src/lib/repositories/refresh-tokens.repository.ts
+++ b/libs/infra/db/src/lib/repositories/refresh-tokens.repository.ts
@@ -1,0 +1,158 @@
+import { NotFoundError } from '@qauth/shared-errors';
+import { and, eq, gt, lt } from 'drizzle-orm';
+
+import type { NewRefreshToken, RefreshToken, RefreshTokensRepository } from '../../types';
+import { DbClient } from '../db';
+import { refreshTokens } from '../schema/tokens';
+
+/**
+ * Factory function that creates a refresh tokens repository
+ *
+ * @param defaultDb - Database client to use for queries
+ * @returns Repository object with token methods
+ */
+export function createRefreshTokensRepository(defaultDb: DbClient): RefreshTokensRepository {
+  return {
+    /**
+     * Create a new refresh token
+     *
+     * @param data - Token data to create
+     * @param tx - Optional transaction client
+     * @returns Created token
+     */
+    async create(data: NewRefreshToken, tx?: DbClient): Promise<RefreshToken> {
+      const invoker = tx ?? defaultDb;
+      const [token] = await invoker.insert(refreshTokens).values(data).returning();
+      return token;
+    },
+
+    /**
+     * Find a token by its token hash
+     * Only returns tokens that are not revoked and not expired
+     *
+     * @param tokenHash - SHA-256 hash of the token
+     * @param tx - Optional transaction client
+     * @returns Token if found and valid, undefined otherwise
+     */
+    async findByTokenHash(tokenHash: string, tx?: DbClient): Promise<RefreshToken | undefined> {
+      const invoker = tx ?? defaultDb;
+      const now = Date.now();
+
+      const [result] = await invoker
+        .select()
+        .from(refreshTokens)
+        .where(
+          and(
+            eq(refreshTokens.tokenHash, tokenHash),
+            eq(refreshTokens.revoked, false),
+            gt(refreshTokens.expiresAt, now)
+          )
+        )
+        .limit(1);
+
+      return result;
+    },
+
+    /**
+     * Find all active tokens for a user
+     * Returns tokens that are not revoked and not expired
+     *
+     * @param userId - User ID to find tokens for
+     * @param tx - Optional transaction client
+     * @returns Array of active tokens for the user
+     */
+    async findByUserId(userId: string, tx?: DbClient): Promise<RefreshToken[]> {
+      const invoker = tx ?? defaultDb;
+      const now = Date.now();
+
+      return await invoker
+        .select()
+        .from(refreshTokens)
+        .where(
+          and(
+            eq(refreshTokens.userId, userId),
+            eq(refreshTokens.revoked, false),
+            gt(refreshTokens.expiresAt, now)
+          )
+        );
+    },
+
+    /**
+     * Revoke a token by ID
+     * Sets revoked=true, revokedAt=now, and optional revocation reason
+     *
+     * @param id - Token ID to revoke
+     * @param reason - Optional reason for revocation
+     * @param tx - Optional transaction client
+     * @returns Updated token
+     * @throws NotFoundError if token is not found
+     */
+    async revoke(id: string, reason?: string, tx?: DbClient): Promise<RefreshToken> {
+      const invoker = tx ?? defaultDb;
+      const now = Date.now();
+
+      const [token] = await invoker
+        .update(refreshTokens)
+        .set({
+          revoked: true,
+          revokedAt: now,
+          revokedReason: reason ?? null,
+        })
+        .where(eq(refreshTokens.id, id))
+        .returning();
+
+      if (!token) {
+        throw new NotFoundError('RefreshToken', id);
+      }
+
+      return token;
+    },
+
+    /**
+     * Revoke all active tokens for a user
+     * Useful for "logout all sessions" functionality
+     *
+     * @param userId - User ID whose tokens should be revoked
+     * @param reason - Optional reason for revocation
+     * @param tx - Optional transaction client
+     */
+    async revokeAllForUser(userId: string, reason?: string, tx?: DbClient): Promise<void> {
+      const invoker = tx ?? defaultDb;
+      const now = Date.now();
+
+      await invoker
+        .update(refreshTokens)
+        .set({
+          revoked: true,
+          revokedAt: now,
+          revokedReason: reason ?? null,
+        })
+        .where(
+          and(
+            eq(refreshTokens.userId, userId),
+            eq(refreshTokens.revoked, false),
+            gt(refreshTokens.expiresAt, now)
+          )
+        );
+    },
+
+    /**
+     * Delete expired tokens
+     * Useful for cleanup operations
+     *
+     * @param tx - Optional transaction client
+     * @returns Count of deleted tokens
+     */
+    async deleteExpired(tx?: DbClient): Promise<number> {
+      const invoker = tx ?? defaultDb;
+      const now = Date.now();
+
+      const deleted = await invoker
+        .delete(refreshTokens)
+        .where(lt(refreshTokens.expiresAt, now))
+        .returning();
+
+      return deleted.length;
+    },
+  };
+}

--- a/libs/infra/db/src/lib/repositories/refresh-tokens.repository.ts
+++ b/libs/infra/db/src/lib/repositories/refresh-tokens.repository.ts
@@ -150,7 +150,7 @@ export function createRefreshTokensRepository(defaultDb: DbClient): RefreshToken
       const deleted = await invoker
         .delete(refreshTokens)
         .where(lt(refreshTokens.expiresAt, now))
-        .returning();
+        .returning({ id: refreshTokens.id });
 
       return deleted.length;
     },

--- a/libs/infra/db/src/types/repository.ts
+++ b/libs/infra/db/src/types/repository.ts
@@ -1,7 +1,7 @@
 import type { InferInsertModel, InferSelectModel } from 'drizzle-orm';
 
 import type { oauthClients } from '../lib/schema/core';
-import type { emailVerificationTokens } from '../lib/schema/tokens';
+import type { emailVerificationTokens, refreshTokens } from '../lib/schema/tokens';
 import type { DbClient } from './database';
 
 /**
@@ -18,6 +18,12 @@ export type UpdateOAuthClient = Partial<Omit<NewOAuthClient, 'id' | 'createdAt' 
  */
 export type EmailVerificationToken = InferSelectModel<typeof emailVerificationTokens>;
 export type NewEmailVerificationToken = InferInsertModel<typeof emailVerificationTokens>;
+
+/**
+ * Refresh token types inferred from schema
+ */
+export type RefreshToken = InferSelectModel<typeof refreshTokens>;
+export type NewRefreshToken = InferInsertModel<typeof refreshTokens>;
 
 /**
  * Base repository interface for common CRUD operations
@@ -79,4 +85,39 @@ export interface EmailVerificationTokensRepository {
    * Delete expired tokens
    */
   deleteExpired(tx?: DbClient): Promise<EmailVerificationToken[]>;
+}
+
+/**
+ * Refresh tokens repository interface
+ */
+export interface RefreshTokensRepository {
+  /**
+   * Create a new refresh token
+   */
+  create(data: NewRefreshToken, tx?: DbClient): Promise<RefreshToken>;
+  /**
+   * Find a token by its token hash
+   * Only returns tokens that are not revoked and not expired
+   */
+  findByTokenHash(tokenHash: string, tx?: DbClient): Promise<RefreshToken | undefined>;
+  /**
+   * Find all active tokens for a user
+   * Returns tokens that are not revoked and not expired
+   */
+  findByUserId(userId: string, tx?: DbClient): Promise<RefreshToken[]>;
+  /**
+   * Revoke a token by ID
+   * Sets revoked=true, revokedAt=now, and optional revocation reason
+   */
+  revoke(id: string, reason?: string, tx?: DbClient): Promise<RefreshToken>;
+  /**
+   * Revoke all active tokens for a user
+   * Useful for "logout all sessions" functionality
+   */
+  revokeAllForUser(userId: string, reason?: string, tx?: DbClient): Promise<void>;
+  /**
+   * Delete expired tokens
+   * Returns count of deleted tokens
+   */
+  deleteExpired(tx?: DbClient): Promise<number>;
 }


### PR DESCRIPTION
- Add RefreshToken and NewRefreshToken types inferred from schema
- Add RefreshTokensRepository interface with all required methods
- Implement createRefreshTokensRepository factory function
- Add methods: create, findByTokenHash, findByUserId, revoke, revokeAllForUser, deleteExpired
- Follow email verification token repository pattern for consistency
- Support transaction parameter for all methods
- Filter active tokens by revoked=false and expiresAt>now
- Export repository from repositories index

Closes #41