### PR TITLE
feat(auth): implement system OAuth client helper

### DIFF
--- a/apps/auth-server/src/app/helpers/oauth-client.ts
+++ b/apps/auth-server/src/app/helpers/oauth-client.ts
@@ -1,0 +1,36 @@
+import { randomBytes } from 'crypto';
+import type { FastifyInstance } from 'fastify';
+
+import { env } from '../../config/env';
+
+/**
+ * Get or create system OAuth client
+ * Helper function to get the system OAuth client for direct login operations
+ */
+export async function getOrCreateSystemClient(realmId: string, fastify: FastifyInstance) {
+  const systemClientId = env.SYSTEM_CLIENT_ID || 'system';
+
+  let client = await fastify.repositories.oauthClients.findByClientId(realmId, systemClientId);
+
+  if (!client) {
+    // Generate random client secret (32 bytes = 64 hex characters)
+    const clientSecret = randomBytes(32).toString('hex');
+
+    // Hash the secret using password hasher
+    const clientSecretHash = await fastify.passwordHasher.hashPassword(clientSecret);
+
+    // Create system client with required configuration
+    client = await fastify.repositories.oauthClients.create({
+      realmId,
+      clientId: systemClientId,
+      clientSecretHash,
+      name: 'System Client',
+      redirectUris: [],
+      grantTypes: ['refresh_token'],
+      requirePkce: false,
+      developerId: null,
+    });
+  }
+
+  return client;
+}

--- a/libs/fastify/plugins/db/src/lib/fastify-plugin-db.ts
+++ b/libs/fastify/plugins/db/src/lib/fastify-plugin-db.ts
@@ -1,11 +1,13 @@
 import {
   createDatabase,
   createEmailVerificationTokensRepository,
+  createOAuthClientsRepository,
   createRealmsRepository,
   createUsersRepository,
   type DatabasePool,
   type DbClient,
   type EmailVerificationTokensRepository,
+  OAuthClientsRepository,
   type RealmsRepository,
   type UsersRepository,
 } from '@qauth/infra-db';
@@ -22,6 +24,7 @@ declare module 'fastify' {
       users: UsersRepository;
       realms: RealmsRepository;
       emailVerificationTokens: EmailVerificationTokensRepository;
+      oauthClients: OAuthClientsRepository;
     };
   }
 }
@@ -56,6 +59,7 @@ export const databasePlugin = fp<DatabasePluginOptions>(
       users: createUsersRepository(database.db),
       realms: createRealmsRepository(database.db),
       emailVerificationTokens: createEmailVerificationTokensRepository(database.db),
+      oauthClients: createOAuthClientsRepository(database.db),
     });
 
     fastify.addHook('onReady', async () => {

--- a/libs/server/config/src/lib/schemas/auth.ts
+++ b/libs/server/config/src/lib/schemas/auth.ts
@@ -11,6 +11,12 @@ export const authEnvSchema = z.object({
   DEFAULT_REALM_NAME: z.string().min(1).default('master'),
 
   /**
+   * System OAuth client ID (defaults to "system")
+   * Used for direct login operations (not OAuth flow)
+   */
+  SYSTEM_CLIENT_ID: z.string().optional().default('system'),
+
+  /**
    * Maximum registration attempts per window
    */
   REGISTRATION_RATE_LIMIT: z.coerce.number().int().min(1).default(3),


### PR DESCRIPTION
- Add SYSTEM_CLIENT_ID to authEnvSchema (optional, defaults to 'system')
- Create getOrCreateSystemClient helper following getOrCreateDefaultRealm pattern
- Register OAuth clients repository in Fastify instance
- Helper generates random secret, hashes it, creates system client with refresh_token

Closes #42