### PR TITLE
feat(oauth): add PKCE utilities library (@qauth/server-pkce)

### DIFF
--- a/libs/server/pkce/README.md
+++ b/libs/server/pkce/README.md
@@ -1,0 +1,7 @@
+# server-pkce
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test server-pkce` to execute the unit tests via [Vitest](https://vitest.dev/).

--- a/libs/server/pkce/project.json
+++ b/libs/server/pkce/project.json
@@ -1,0 +1,8 @@
+{
+  "name": "server-pkce",
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/server/pkce/src",
+  "projectType": "library",
+  "tags": ["scope:server", "type:utility"],
+  "// targets": "to see all targets run: nx show project server-pkce --web"
+}

--- a/libs/server/pkce/src/index.ts
+++ b/libs/server/pkce/src/index.ts
@@ -1,0 +1,2 @@
+export * from './lib/pkce';
+export type * from './types';

--- a/libs/server/pkce/src/lib/pkce.test.ts
+++ b/libs/server/pkce/src/lib/pkce.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  generateCodeChallenge,
+  generateCodeVerifier,
+  generatePkcePair,
+  isValidCodeVerifierFormat,
+  verifyCodeChallenge,
+} from './pkce';
+
+const RFC7636_VERIFIER = 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk';
+const RFC7636_CHALLENGE = 'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM';
+
+describe('generateCodeVerifier', () => {
+  it('should return a 43-character string', () => {
+    const v = generateCodeVerifier();
+    expect(v).toHaveLength(43);
+  });
+
+  it('should match [A-Za-z0-9._~-]{43}', () => {
+    const v = generateCodeVerifier();
+    expect(v).toMatch(/^[A-Za-z0-9._~-]{43}$/);
+  });
+
+  it('should produce different values each call', () => {
+    const v1 = generateCodeVerifier();
+    const v2 = generateCodeVerifier();
+    expect(v1).not.toBe(v2);
+  });
+
+  it('should produce verifiers that isValidCodeVerifierFormat accepts', () => {
+    const v = generateCodeVerifier();
+    expect(isValidCodeVerifierFormat(v)).toBe(true);
+  });
+});
+
+describe('generateCodeChallenge', () => {
+  it('should be deterministic: same verifier → same challenge', () => {
+    const v = generateCodeVerifier();
+    expect(generateCodeChallenge(v)).toBe(generateCodeChallenge(v));
+  });
+
+  it('should produce different challenges for different verifiers', () => {
+    const v1 = generateCodeVerifier();
+    const v2 = generateCodeVerifier();
+    expect(generateCodeChallenge(v1)).not.toBe(generateCodeChallenge(v2));
+  });
+
+  it('should output 43-char base64url string', () => {
+    const v = generateCodeVerifier();
+    const c = generateCodeChallenge(v);
+    expect(c).toHaveLength(43);
+    expect(c).toMatch(/^[A-Za-z0-9._~-]{43}$/);
+  });
+
+  it('should match RFC 7636 Appendix B S256 example', () => {
+    expect(generateCodeChallenge(RFC7636_VERIFIER)).toBe(RFC7636_CHALLENGE);
+  });
+
+  it('should throw for invalid verifier format', () => {
+    expect(() => generateCodeChallenge('short')).toThrow('Invalid code verifier format');
+    expect(() => generateCodeChallenge('')).toThrow('Invalid code verifier format');
+  });
+});
+
+describe('verifyCodeChallenge', () => {
+  it('should return true for matching verifier and stored challenge', () => {
+    const v = generateCodeVerifier();
+    const stored = generateCodeChallenge(v);
+    expect(verifyCodeChallenge(v, stored)).toBe(true);
+  });
+
+  it('should return false for wrong verifier', () => {
+    const v = generateCodeVerifier();
+    const stored = generateCodeChallenge(v);
+    const other = generateCodeVerifier();
+    expect(verifyCodeChallenge(other, stored)).toBe(false);
+  });
+
+  it('should return false for mismatched length (no throw)', () => {
+    const v = generateCodeVerifier();
+    const stored = generateCodeChallenge(v);
+    expect(verifyCodeChallenge(v, stored + 'x')).toBe(false);
+    expect(verifyCodeChallenge(v, stored.slice(0, -1))).toBe(false);
+  });
+
+  it('should return true for RFC 7636 Appendix B verifier/challenge pair', () => {
+    expect(verifyCodeChallenge(RFC7636_VERIFIER, RFC7636_CHALLENGE)).toBe(true);
+  });
+
+  it('should return false for invalid verifier format', () => {
+    expect(verifyCodeChallenge('short', RFC7636_CHALLENGE)).toBe(false);
+    expect(verifyCodeChallenge('', 'anything')).toBe(false);
+  });
+});
+
+describe('isValidCodeVerifierFormat', () => {
+  it('should accept valid 43–128 char verifier', () => {
+    expect(isValidCodeVerifierFormat(RFC7636_VERIFIER)).toBe(true);
+    expect(isValidCodeVerifierFormat('a'.repeat(43))).toBe(true);
+    expect(isValidCodeVerifierFormat('a'.repeat(128))).toBe(true);
+    expect(isValidCodeVerifierFormat('A-Za_z0.9~-'.repeat(4) + 'abc')).toBe(true);
+  });
+
+  it('should reject too short (<43)', () => {
+    expect(isValidCodeVerifierFormat('a'.repeat(42))).toBe(false);
+  });
+
+  it('should reject too long (>128)', () => {
+    expect(isValidCodeVerifierFormat('a'.repeat(129))).toBe(false);
+  });
+
+  it('should reject invalid characters', () => {
+    expect(isValidCodeVerifierFormat('a'.repeat(42) + '!')).toBe(false);
+    expect(isValidCodeVerifierFormat('a'.repeat(42) + ' ')).toBe(false);
+  });
+
+  it('should reject empty string, null, undefined', () => {
+    expect(isValidCodeVerifierFormat('')).toBe(false);
+    expect(isValidCodeVerifierFormat(null as unknown as string)).toBe(false);
+    expect(isValidCodeVerifierFormat(undefined as unknown as string)).toBe(false);
+  });
+});
+
+describe('generatePkcePair', () => {
+  it('should return { codeVerifier, codeChallenge }', () => {
+    const pair = generatePkcePair();
+    expect(pair).toHaveProperty('codeVerifier');
+    expect(pair).toHaveProperty('codeChallenge');
+  });
+
+  it('should satisfy verifyCodeChallenge(pair.codeVerifier, pair.codeChallenge)', () => {
+    const pair = generatePkcePair();
+    expect(verifyCodeChallenge(pair.codeVerifier, pair.codeChallenge)).toBe(true);
+  });
+
+  it('should produce a new pair each call', () => {
+    const p1 = generatePkcePair();
+    const p2 = generatePkcePair();
+    expect(p1.codeVerifier).not.toBe(p2.codeVerifier);
+    expect(p1.codeChallenge).not.toBe(p2.codeChallenge);
+  });
+});

--- a/libs/server/pkce/src/lib/pkce.ts
+++ b/libs/server/pkce/src/lib/pkce.ts
@@ -1,0 +1,116 @@
+import * as crypto from 'crypto';
+
+import type { PkcePair } from '../types/pkce';
+
+/** Regex for RFC 7636 code verifier: 43–128 chars [A-Za-z0-9._~-] */
+const CODE_VERIFIER_REGEX = /^[A-Za-z0-9._~-]{43,128}$/;
+
+/**
+ * Generate a cryptographically random code verifier (RFC 7636).
+ * Uses 32 octets (256 bits) random → base64url → 43 chars.
+ *
+ * @returns 43-character base64url-encoded string
+ * @see https://www.rfc-editor.org/rfc/rfc7636
+ *
+ * @example
+ * ```ts
+ * const verifier = generateCodeVerifier();
+ * // "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+ * ```
+ */
+export function generateCodeVerifier(): string {
+  const bytes = crypto.randomBytes(32);
+  return bytes.toString('base64url');
+}
+
+/**
+ * Validate code verifier format per RFC 7636.
+ * Must be 43–128 characters, matching [A-Za-z0-9._~-].
+ *
+ * @param verifier - Value to check (any type)
+ * @returns true if valid format
+ * @see https://www.rfc-editor.org/rfc/rfc7636
+ *
+ * @example
+ * ```ts
+ * isValidCodeVerifierFormat('dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk'); // true
+ * isValidCodeVerifierFormat('short'); // false
+ * isValidCodeVerifierFormat(null); // false
+ * ```
+ */
+export function isValidCodeVerifierFormat(verifier: unknown): boolean {
+  if (verifier == null || typeof verifier !== 'string') {
+    return false;
+  }
+  return CODE_VERIFIER_REGEX.test(verifier);
+}
+
+/**
+ * Compute S256 code challenge from code verifier (RFC 7636).
+ * challenge = BASE64URL(SHA256(ASCII(verifier))).
+ *
+ * @param verifier - Code verifier string
+ * @returns 43-character base64url code challenge
+ * @throws Error if verifier format is invalid
+ * @see https://www.rfc-editor.org/rfc/rfc7636
+ *
+ * @example
+ * ```ts
+ * const challenge = generateCodeChallenge('dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk');
+ * // "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
+ * ```
+ */
+export function generateCodeChallenge(verifier: string): string {
+  if (!isValidCodeVerifierFormat(verifier)) {
+    throw new Error('Invalid code verifier format');
+  }
+  const digest = crypto.createHash('sha256').update(verifier, 'utf8').digest();
+  return digest.toString('base64url');
+}
+
+/**
+ * Verify code verifier against stored challenge (RFC 7636 S256).
+ * Uses timing-safe comparison to prevent timing attacks.
+ * Returns false for invalid verifier format or length mismatch (no throw).
+ *
+ * @param verifier - Code verifier from client
+ * @param storedChallenge - Code challenge stored at authorize time
+ * @returns true if verifier matches challenge
+ * @see https://www.rfc-editor.org/rfc/rfc7636
+ *
+ * @example
+ * ```ts
+ * const ok = verifyCodeChallenge(verifier, storedChallenge);
+ * ```
+ */
+export function verifyCodeChallenge(verifier: string, storedChallenge: string): boolean {
+  if (!isValidCodeVerifierFormat(verifier)) {
+    return false;
+  }
+  const computed = generateCodeChallenge(verifier);
+  const computedBuf = Buffer.from(computed, 'utf8');
+  const storedBuf = Buffer.from(storedChallenge, 'utf8');
+  if (computedBuf.length !== storedBuf.length) {
+    return false;
+  }
+  return crypto.timingSafeEqual(computedBuf, storedBuf);
+}
+
+/**
+ * Generate a PKCE pair (verifier + challenge) for OAuth 2.1 (RFC 7636).
+ * Client stores codeVerifier, sends codeChallenge in authorize request.
+ *
+ * @returns `{ codeVerifier, codeChallenge }`
+ * @see https://www.rfc-editor.org/rfc/rfc7636
+ *
+ * @example
+ * ```ts
+ * const { codeVerifier, codeChallenge } = generatePkcePair();
+ * // Store codeVerifier; send code_challenge=codeChallenge to /oauth/authorize
+ * ```
+ */
+export function generatePkcePair(): PkcePair {
+  const codeVerifier = generateCodeVerifier();
+  const codeChallenge = generateCodeChallenge(codeVerifier);
+  return { codeVerifier, codeChallenge };
+}

--- a/libs/server/pkce/src/types/index.ts
+++ b/libs/server/pkce/src/types/index.ts
@@ -1,0 +1,1 @@
+export type * from './pkce';

--- a/libs/server/pkce/src/types/pkce.ts
+++ b/libs/server/pkce/src/types/pkce.ts
@@ -1,0 +1,10 @@
+/**
+ * PKCE pair for OAuth 2.1 Authorization Code Flow (RFC 7636).
+ * Client generates, stores codeVerifier, sends codeChallenge in authorize request.
+ */
+export interface PkcePair {
+  /** Cryptographically random string (43 chars base64url); send to token endpoint */
+  codeVerifier: string;
+  /** BASE64URL(SHA256(codeVerifier)); send in authorize request as code_challenge */
+  codeChallenge: string;
+}

--- a/libs/server/pkce/tsconfig.json
+++ b/libs/server/pkce/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "importHelpers": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/libs/server/pkce/tsconfig.lib.json
+++ b/libs/server/pkce/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "declaration": true,
+    "composite": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/libs/server/pkce/vitest.config.ts
+++ b/libs/server/pkce/vitest.config.ts
@@ -1,0 +1,3 @@
+import baseConfig from '../../../vitest.config';
+
+export default baseConfig;

--- a/nx.json
+++ b/nx.json
@@ -35,7 +35,8 @@
         "libs/server/password/*",
         "libs/shared/validation/*",
         "libs/shared/testing/*",
-        "libs/server/jwt/*"
+        "libs/server/jwt/*",
+        "libs/server/pkce/*"
       ]
     },
     {
@@ -54,7 +55,8 @@
         "libs/server/password/*",
         "libs/shared/validation/*",
         "libs/shared/testing/*",
-        "libs/server/jwt/*"
+        "libs/server/jwt/*",
+        "libs/server/pkce/*"
       ],
       "options": {
         "typecheck": {

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -22,7 +22,8 @@
       "@qauth/server-password": ["libs/server/password/src/index.ts"],
       "@qauth/server-email": ["libs/server/email/src/index.ts"],
       "@qauth/server-config": ["libs/server/config/src/index.ts"],
-      "@qauth/server-jwt": ["libs/server/jwt/src/index.ts"]
+      "@qauth/server-jwt": ["libs/server/jwt/src/index.ts"],
+      "@qauth/server-pkce": ["libs/server/pkce/src/index.ts"]
     },
     "esModuleInterop": true,
     "strict": true,


### PR DESCRIPTION
- Add generateCodeVerifier, generateCodeChallenge, verifyCodeChallenge, isValidCodeVerifierFormat, generatePkcePair (RFC 7636, S256 only)
- Add PkcePair type; use Node crypto, timing-safe verification
- Add unit tests including RFC 7636 Appendix B S256 example
- Wire @qauth/server-pkce in tsconfig.base.json

Closes #60