### PR TITLE
feat(oauth): implement GET /oauth/authorize for OAuth 2.1 auth code flow

### DIFF
--- a/apps/auth-server/qauth-api.postman_collection.json
+++ b/apps/auth-server/qauth-api.postman_collection.json
@@ -19,6 +19,26 @@
       "key": "refreshToken",
       "value": "",
       "type": "string"
+    },
+    {
+      "key": "oauthClientId",
+      "value": "web-app",
+      "type": "string"
+    },
+    {
+      "key": "oauthRedirectUri",
+      "value": "http://localhost:3000/oauth/callback",
+      "type": "string"
+    },
+    {
+      "key": "oauthCodeChallenge",
+      "value": "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
+      "type": "string"
+    },
+    {
+      "key": "oauthState",
+      "value": "postman_test_state",
+      "type": "string"
     }
   ],
   "item": [
@@ -223,6 +243,55 @@
               "path": ["auth", "resend-verification"]
             },
             "description": "Request a new verification email.\n\nAlways returns success to prevent email enumeration.\nRate limited per IP and per email address."
+          }
+        }
+      ]
+    },
+    {
+      "name": "OAuth",
+      "item": [
+        {
+          "name": "GET /oauth/authorize",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{accessToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/oauth/authorize?response_type=code&client_id={{oauthClientId}}&redirect_uri={{oauthRedirectUri}}&code_challenge={{oauthCodeChallenge}}&code_challenge_method=S256&state={{oauthState}}",
+              "host": ["{{baseUrl}}"],
+              "path": ["oauth", "authorize"],
+              "query": [
+                {
+                  "key": "response_type",
+                  "value": "code"
+                },
+                {
+                  "key": "client_id",
+                  "value": "{{oauthClientId}}"
+                },
+                {
+                  "key": "redirect_uri",
+                  "value": "{{oauthRedirectUri}}"
+                },
+                {
+                  "key": "code_challenge",
+                  "value": "{{oauthCodeChallenge}}"
+                },
+                {
+                  "key": "code_challenge_method",
+                  "value": "S256"
+                },
+                {
+                  "key": "state",
+                  "value": "{{oauthState}}"
+                }
+              ]
+            },
+            "description": "OAuth 2.1 Authorization Code Flow with PKCE.\n\nRequires Authorization: Bearer <access_token>. Run **Login** first to set `accessToken`.\n\nPrerequisites:\n- An OAuth client registered with `client_id` (e.g. web-app), `redirect_uri` in whitelist, `authorization_code` grant, `code` response type.\n- Variables: `oauthClientId`, `oauthRedirectUri`, `oauthCodeChallenge`, `oauthState` (collection or environment).\n\n`oauthCodeChallenge` uses RFC 7636 Appendix B example (S256). For real flows, generate a PKCE pair and use that challenge here; use the matching verifier at POST /oauth/token.\n\nOn success: 302 redirect to `redirect_uri?code=...&state=...`. Disable **Follow redirects** to inspect the Location header."
           }
         }
       ]

--- a/apps/auth-server/src/app/constants/security.ts
+++ b/apps/auth-server/src/app/constants/security.ts
@@ -2,6 +2,9 @@
  * Security-related constants
  */
 
+/** Authorization code TTL in milliseconds (5 minutes, OAuth 2.1) */
+export const AUTHORIZATION_CODE_TTL_MS = 5 * 60 * 1000;
+
 /**
  * Minimum response time in milliseconds to prevent timing attacks
  * Used in authentication endpoints to prevent user enumeration

--- a/apps/auth-server/src/app/helpers/oauth-redirect.ts
+++ b/apps/auth-server/src/app/helpers/oauth-redirect.ts
@@ -1,0 +1,18 @@
+/**
+ * Build redirect URL for authorize success or error (RFC 6749 4.1.2, 4.1.2.1).
+ * redirect_uri is exact; we append ?key=value&...
+ * Fragment is stripped (OAuth 2.1).
+ */
+export function buildRedirectUrl(
+  redirectUri: string,
+  params:
+    | { code: string; state?: string }
+    | { error: string; error_description?: string; state?: string }
+): string {
+  const u = new URL(redirectUri);
+  u.hash = '';
+  for (const [k, v] of Object.entries(params)) {
+    if (v != null && v !== '') u.searchParams.set(k, v);
+  }
+  return u.toString();
+}

--- a/apps/auth-server/src/app/routes/oauth/authorize.ts
+++ b/apps/auth-server/src/app/routes/oauth/authorize.ts
@@ -1,0 +1,255 @@
+import { BadRequestError, isUniqueConstraintError } from '@qauth/shared-errors';
+import { randomBytes } from 'crypto';
+import type { FastifyInstance } from 'fastify';
+import { ZodTypeProvider } from 'fastify-type-provider-zod';
+
+import { env } from '../../../config/env';
+import { AUTHORIZATION_CODE_TTL_MS } from '../../constants';
+import { buildRedirectUrl } from '../../helpers/oauth-redirect';
+import { getOrCreateDefaultRealm } from '../../helpers/realm';
+import { authorizeQuerySchema } from '../../schemas/oauth';
+
+/**
+ * GET /oauth/authorize
+ * OAuth 2.1 Authorization Code Flow with PKCE.
+ * Requires Authorization: Bearer <access_token> for user context (MVP).
+ */
+export default async function (fastify: FastifyInstance) {
+  fastify.withTypeProvider<ZodTypeProvider>().get(
+    '/authorize',
+    {
+      schema: {
+        querystring: authorizeQuerySchema,
+      },
+      config: {
+        rateLimit: {
+          max: env.AUTHORIZE_RATE_LIMIT,
+          timeWindow: env.AUTHORIZE_RATE_WINDOW * 1000,
+          keyGenerator: (req) => req.ip || 'unknown',
+        },
+      },
+    },
+    async (request, reply) => {
+      const query = request.query;
+      const redirectUri = query.redirect_uri;
+      const state = query.state;
+
+      const realm = await getOrCreateDefaultRealm(fastify);
+
+      const client = await fastify.repositories.oauthClients.findByClientId(
+        realm.id,
+        query.client_id
+      );
+
+      if (!client) {
+        await fastify.repositories.auditLogs.create({
+          userId: null,
+          oauthClientId: null,
+          event: 'oauth.authorize.failure',
+          eventType: 'token',
+          success: false,
+          ipAddress: request.ip,
+          userAgent: request.headers['user-agent'] || null,
+          metadata: { error: 'invalid_client', client_id: query.client_id },
+        });
+        throw new BadRequestError('invalid_client');
+      }
+
+      if (!client.redirectUris.includes(redirectUri)) {
+        await fastify.repositories.auditLogs.create({
+          userId: null,
+          oauthClientId: client.id,
+          event: 'oauth.authorize.failure',
+          eventType: 'token',
+          success: false,
+          ipAddress: request.ip,
+          userAgent: request.headers['user-agent'] || null,
+          metadata: { error: 'redirect_uri not registered', client_id: query.client_id },
+        });
+        throw new BadRequestError('redirect_uri not registered');
+      }
+
+      if (!client.enabled) {
+        await fastify.repositories.auditLogs.create({
+          userId: null,
+          oauthClientId: client.id,
+          event: 'oauth.authorize.failure',
+          eventType: 'token',
+          success: false,
+          ipAddress: request.ip,
+          userAgent: request.headers['user-agent'] || null,
+          metadata: { error: 'unauthorized_client', client_id: query.client_id },
+        });
+        return reply.redirect(
+          buildRedirectUrl(redirectUri, {
+            error: 'unauthorized_client',
+            state: state ?? undefined,
+          }),
+          302
+        );
+      }
+
+      if (!client.grantTypes.includes('authorization_code')) {
+        await fastify.repositories.auditLogs.create({
+          userId: null,
+          oauthClientId: client.id,
+          event: 'oauth.authorize.failure',
+          eventType: 'token',
+          success: false,
+          ipAddress: request.ip,
+          userAgent: request.headers['user-agent'] || null,
+          metadata: { error: 'unauthorized_client', client_id: query.client_id },
+        });
+        return reply.redirect(
+          buildRedirectUrl(redirectUri, {
+            error: 'unauthorized_client',
+            state: state ?? undefined,
+          }),
+          302
+        );
+      }
+
+      if (!client.responseTypes.includes('code')) {
+        await fastify.repositories.auditLogs.create({
+          userId: null,
+          oauthClientId: client.id,
+          event: 'oauth.authorize.failure',
+          eventType: 'token',
+          success: false,
+          ipAddress: request.ip,
+          userAgent: request.headers['user-agent'] || null,
+          metadata: { error: 'unauthorized_client', client_id: query.client_id },
+        });
+        return reply.redirect(
+          buildRedirectUrl(redirectUri, {
+            error: 'unauthorized_client',
+            state: state ?? undefined,
+          }),
+          302
+        );
+      }
+
+      if (client.requirePkce && (!query.code_challenge || query.code_challenge_method !== 'S256')) {
+        await fastify.repositories.auditLogs.create({
+          userId: null,
+          oauthClientId: client.id,
+          event: 'oauth.authorize.failure',
+          eventType: 'token',
+          success: false,
+          ipAddress: request.ip,
+          userAgent: request.headers['user-agent'] || null,
+          metadata: { error: 'invalid_request', client_id: query.client_id },
+        });
+        return reply.redirect(
+          buildRedirectUrl(redirectUri, {
+            error: 'invalid_request',
+            error_description: 'PKCE required',
+            state: state ?? undefined,
+          }),
+          302
+        );
+      }
+
+      const token = fastify.jwtUtils.extractFromHeader(request.headers.authorization);
+      if (!token) {
+        await fastify.repositories.auditLogs.create({
+          userId: null,
+          oauthClientId: client.id,
+          event: 'oauth.authorize.failure',
+          eventType: 'token',
+          success: false,
+          ipAddress: request.ip,
+          userAgent: request.headers['user-agent'] || null,
+          metadata: { error: 'access_denied', client_id: query.client_id },
+        });
+        return reply.redirect(
+          buildRedirectUrl(redirectUri, {
+            error: 'access_denied',
+            error_description: 'Missing or invalid Authorization header',
+            state: state ?? undefined,
+          }),
+          302
+        );
+      }
+
+      let userId: string;
+      try {
+        const payload = await fastify.jwtUtils.verifyAccessToken(token);
+        userId = payload.sub;
+      } catch {
+        await fastify.repositories.auditLogs.create({
+          userId: null,
+          oauthClientId: client.id,
+          event: 'oauth.authorize.failure',
+          eventType: 'token',
+          success: false,
+          ipAddress: request.ip,
+          userAgent: request.headers['user-agent'] || null,
+          metadata: { error: 'access_denied', client_id: query.client_id },
+        });
+        return reply.redirect(
+          buildRedirectUrl(redirectUri, {
+            error: 'access_denied',
+            error_description: 'Invalid or expired token',
+            state: state ?? undefined,
+          }),
+          302
+        );
+      }
+
+      const requestedScopes = query.scope
+        ? query.scope.split(/\s+/).filter((s) => s.length > 0)
+        : [];
+      const scopes =
+        client.scopes.length > 0
+          ? requestedScopes.filter((s) => client.scopes.includes(s))
+          : requestedScopes;
+
+      const expiresAt = Date.now() + AUTHORIZATION_CODE_TTL_MS;
+
+      const createCode = async (): Promise<string> => {
+        const code = randomBytes(32).toString('base64url');
+        await fastify.repositories.authorizationCodes.create({
+          code,
+          oauthClientId: client.id,
+          userId,
+          redirectUri,
+          codeChallenge: query.code_challenge,
+          codeChallengeMethod: 'S256',
+          nonce: query.nonce ?? null,
+          scopes,
+          state: query.state ?? null,
+          expiresAt,
+        });
+        return code;
+      };
+
+      let code: string;
+      try {
+        code = await createCode();
+      } catch (err) {
+        if (isUniqueConstraintError(err)) {
+          code = await createCode();
+        } else {
+          throw err;
+        }
+      }
+
+      await fastify.repositories.auditLogs.create({
+        userId,
+        oauthClientId: client.id,
+        event: 'oauth.authorize.success',
+        eventType: 'token',
+        success: true,
+        ipAddress: request.ip,
+        userAgent: request.headers['user-agent'] || null,
+        metadata: { redirectUri },
+      });
+
+      return reply.redirect(
+        buildRedirectUrl(redirectUri, { code, state: state ?? undefined }),
+        302
+      );
+    }
+  );
+}

--- a/apps/auth-server/src/app/routes/oauth/authorize.ts
+++ b/apps/auth-server/src/app/routes/oauth/authorize.ts
@@ -129,27 +129,6 @@ export default async function (fastify: FastifyInstance) {
         );
       }
 
-      if (client.requirePkce && (!query.code_challenge || query.code_challenge_method !== 'S256')) {
-        await fastify.repositories.auditLogs.create({
-          userId: null,
-          oauthClientId: client.id,
-          event: 'oauth.authorize.failure',
-          eventType: 'token',
-          success: false,
-          ipAddress: request.ip,
-          userAgent: request.headers['user-agent'] || null,
-          metadata: { error: 'invalid_request', client_id: query.client_id },
-        });
-        return reply.redirect(
-          buildRedirectUrl(redirectUri, {
-            error: 'invalid_request',
-            error_description: 'PKCE required',
-            state: state ?? undefined,
-          }),
-          302
-        );
-      }
-
       const token = fastify.jwtUtils.extractFromHeader(request.headers.authorization);
       if (!token) {
         await fastify.repositories.auditLogs.create({
@@ -224,16 +203,18 @@ export default async function (fastify: FastifyInstance) {
         return code;
       };
 
-      let code: string;
-      try {
-        code = await createCode();
-      } catch (err) {
-        if (isUniqueConstraintError(err)) {
+      const MAX_CREATE_ATTEMPTS = 3;
+      let code: string | null = null;
+      for (let attempt = 0; attempt < MAX_CREATE_ATTEMPTS; attempt++) {
+        try {
           code = await createCode();
-        } else {
-          throw err;
+          break;
+        } catch (err) {
+          if (!isUniqueConstraintError(err)) throw err;
+          if (attempt === MAX_CREATE_ATTEMPTS - 1) throw err;
         }
       }
+      if (!code) throw new Error('Unreachable');
 
       await fastify.repositories.auditLogs.create({
         userId,

--- a/apps/auth-server/src/app/schemas/oauth.ts
+++ b/apps/auth-server/src/app/schemas/oauth.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod';
+
+/**
+ * OAuth 2.1 authorize query parameters (GET /oauth/authorize).
+ * RFC 6749 4.1.1, RFC 7636 PKCE.
+ */
+export const authorizeQuerySchema = z.object({
+  response_type: z.literal('code'),
+  client_id: z.string().min(1),
+  redirect_uri: z.url(),
+  code_challenge: z
+    .string()
+    .min(43)
+    .max(128)
+    .regex(/^[A-Za-z0-9._~-]+$/),
+  code_challenge_method: z.literal('S256'),
+  state: z.string().max(255).optional(),
+  scope: z.string().optional(),
+  nonce: z.string().max(255).optional(),
+});
+
+export type AuthorizeQuery = z.infer<typeof authorizeQuerySchema>;

--- a/libs/server/config/src/lib/schemas/auth.ts
+++ b/libs/server/config/src/lib/schemas/auth.ts
@@ -98,6 +98,16 @@ export const authEnvSchema = z.object({
    * Note: Converted to milliseconds in route handlers (value * 1000)
    */
   LOGOUT_RATE_WINDOW: z.coerce.number().int().min(1).default(60),
+
+  /**
+   * Maximum authorize attempts per window
+   */
+  AUTHORIZE_RATE_LIMIT: z.coerce.number().int().min(1).default(60),
+
+  /**
+   * Authorize rate limit window in seconds (default: 60 = 1 minute)
+   */
+  AUTHORIZE_RATE_WINDOW: z.coerce.number().int().min(1).default(60),
 });
 
 /**


### PR DESCRIPTION
- Add AUTHORIZE_RATE_LIMIT and AUTHORIZE_RATE_WINDOW to auth config schema
- Add AUTHORIZATION_CODE_TTL_MS constant (5 min)
- Create authorizeQuerySchema (Zod v4) and buildRedirectUrl helper
- Add GET /oauth/authorize: validation, client lookup, redirect_uri whitelist, Bearer JWT, PKCE, scope intersection, auth code creation, redirect, audit logging
- Add OAuth section to Postman collection with GET /oauth/authorize

Closes #61