### PR TITLE
feat(auth): implement POST /oauth/token endpoint 

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+# Force unix line endings for shell scripts (fixes Windows execution issues)
+*.sh text eol=lf
+*.bash text eol=lf
+*.js text eol=lf
+*.ts text eol=lf
+*.json text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+*.md text eol=lf

--- a/MVP-PRD.md
+++ b/MVP-PRD.md
@@ -1010,6 +1010,14 @@ These features are NOT part of the MVP:
 - Horizontal scaling
 - CDN integration
 
+### Phase 8: Agent Authentication & Authorization (TBD)
+
+- "Agent" client type on QAuth (register and identify agents)
+- Agent session state / mode (ReadOnly, Admin, Exec)
+- Granular scopes (e.g. `fs:read`, `fs:write`, `exec:run`) enforced per client/mode
+- Step-up auth (MFA/OTP) before critical operations (e.g. destructive or high-impact)
+- QAuth-side audit log of agent actions by mode for compliance
+
 ---
 
 ## 📊 MVP Development Timeline

--- a/apps/auth-server/Dockerfile
+++ b/apps/auth-server/Dockerfile
@@ -43,7 +43,9 @@ COPY --from=builder /app/node_modules ./node_modules
 
 # Copy entrypoint script
 COPY apps/auth-server/docker-entrypoint.sh ./docker-entrypoint.sh
-RUN chmod +x ./docker-entrypoint.sh
+# Fix Windows line endings (CRLF) and permissions
+RUN sed -i 's/\r$//' ./docker-entrypoint.sh && \
+    chmod +x ./docker-entrypoint.sh
 
 # Create non-root user
 RUN addgroup -g 1001 -S nodejs && \

--- a/apps/auth-server/qauth-api.postman_collection.json
+++ b/apps/auth-server/qauth-api.postman_collection.json
@@ -39,6 +39,24 @@
       "key": "oauthState",
       "value": "postman_test_state",
       "type": "string"
+    },
+    {
+      "key": "oauthCodeVerifier",
+      "value": "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk",
+      "type": "string",
+      "description": "PKCE code_verifier (RFC 7636). Must match the code_challenge used in GET /oauth/authorize. This value pairs with the default oauthCodeChallenge."
+    },
+    {
+      "key": "oauthClientSecret",
+      "value": "",
+      "type": "string",
+      "description": "OAuth client secret (client_secret_post). Set for the client identified by oauthClientId."
+    },
+    {
+      "key": "authorizationCode",
+      "value": "",
+      "type": "string",
+      "description": "Authorization code from GET /oauth/authorize redirect (Location: redirect_uri?code=...&state=...). Copy the 'code' param, then run this request."
     }
   ],
   "item": [
@@ -292,6 +310,43 @@
               ]
             },
             "description": "OAuth 2.1 Authorization Code Flow with PKCE.\n\nRequires Authorization: Bearer <access_token>. Run **Login** first to set `accessToken`.\n\nPrerequisites:\n- An OAuth client registered with `client_id` (e.g. web-app), `redirect_uri` in whitelist, `authorization_code` grant, `code` response type.\n- Variables: `oauthClientId`, `oauthRedirectUri`, `oauthCodeChallenge`, `oauthState` (collection or environment).\n\n`oauthCodeChallenge` uses RFC 7636 Appendix B example (S256). For real flows, generate a PKCE pair and use that challenge here; use the matching verifier at POST /oauth/token.\n\nOn success: 302 redirect to `redirect_uri?code=...&state=...`. Disable **Follow redirects** to inspect the Location header."
+          }
+        },
+        {
+          "name": "POST /oauth/token",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "if (pm.response.code === 200) {",
+                  "    const response = pm.response.json();",
+                  "    pm.collectionVariables.set('accessToken', response.access_token);",
+                  "    pm.collectionVariables.set('refreshToken', response.refresh_token);",
+                  "}"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"grant_type\": \"authorization_code\",\n  \"code\": \"{{authorizationCode}}\",\n  \"redirect_uri\": \"{{oauthRedirectUri}}\",\n  \"client_id\": \"{{oauthClientId}}\",\n  \"code_verifier\": \"{{oauthCodeVerifier}}\",\n  \"client_secret\": \"{{oauthClientSecret}}\"\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/oauth/token",
+              "host": ["{{baseUrl}}"],
+              "path": ["oauth", "token"]
+            },
+            "description": "OAuth 2.1 token endpoint. Exchange authorization code for access and refresh tokens (Authorization Code Grant with PKCE, client_secret_post).\n\n**Flow:**\n1. Run **GET /oauth/authorize** (with valid Bearer token).\n2. Copy the `code` from the redirect Location (disable Follow redirects): `redirect_uri?code=...&state=...`.\n3. Set collection variable `authorizationCode` to that code (or paste in body).\n4. Set `oauthClientSecret` for your OAuth client.\n5. Run this request.\n\n**Variables:** `authorizationCode`, `oauthRedirectUri`, `oauthClientId`, `oauthCodeVerifier`, `oauthClientSecret`.\n\nOn success: 200 with `access_token`, `refresh_token`, `expires_in`, `token_type: Bearer`. Tokens are stored in collection variables for subsequent requests."
           }
         }
       ]

--- a/apps/auth-server/src/app/app.ts
+++ b/apps/auth-server/src/app/app.ts
@@ -5,6 +5,7 @@ import { databasePlugin } from '@qauth/fastify-plugin-db';
 import { emailPlugin, type EmailProviderConfig } from '@qauth/fastify-plugin-email';
 import { jwtPlugin } from '@qauth/fastify-plugin-jwt';
 import { passwordPlugin } from '@qauth/fastify-plugin-password';
+import { pkcePlugin } from '@qauth/fastify-plugin-pkce';
 import type { FastifyInstance } from 'fastify';
 import * as path from 'path';
 
@@ -49,6 +50,8 @@ export async function app(fastify: FastifyInstance, opts: object) {
       minScore: env.PASSWORD_MIN_SCORE,
     },
   });
+
+  await fastify.register(pkcePlugin);
 
   // Configure email provider from environment variables
   const emailProvider = env.EMAIL_PROVIDER;

--- a/apps/auth-server/src/app/constants/security.ts
+++ b/apps/auth-server/src/app/constants/security.ts
@@ -16,4 +16,6 @@ export const MIN_RESPONSE_TIME_MS = {
   RESEND_VERIFICATION: 200,
   /** Refresh endpoint minimum response time (300ms) */
   REFRESH: 300,
+  /** Token endpoint minimum response time (300ms) */
+  TOKEN: 300,
 } as const;

--- a/apps/auth-server/src/app/routes/oauth/token.ts
+++ b/apps/auth-server/src/app/routes/oauth/token.ts
@@ -1,5 +1,3 @@
-// eslint-disable-next-line @nx/enforce-module-boundaries
-import { verifyCodeChallenge } from '@qauth/server-pkce';
 import { InvalidCredentialsError, InvalidTokenError, NotFoundError } from '@qauth/shared-errors';
 import { randomUUID } from 'crypto';
 import type { FastifyInstance } from 'fastify';
@@ -28,8 +26,8 @@ export default async function (fastify: FastifyInstance) {
       },
       config: {
         rateLimit: {
-          max: (env as typeof env & { TOKEN_RATE_LIMIT: number }).TOKEN_RATE_LIMIT,
-          timeWindow: (env as typeof env & { TOKEN_RATE_WINDOW: number }).TOKEN_RATE_WINDOW * 1000,
+          max: env.TOKEN_RATE_LIMIT,
+          timeWindow: env.TOKEN_RATE_WINDOW * 1000,
           keyGenerator: (req) => req.ip || 'unknown',
         },
       },
@@ -49,7 +47,6 @@ export default async function (fastify: FastifyInstance) {
         );
 
         if (!client) {
-          await ensureMinimumResponseTime(startTime, MIN_RESPONSE_TIME_MS.TOKEN);
           await fastify.repositories.auditLogs.create({
             userId: null,
             oauthClientId: null,
@@ -65,7 +62,6 @@ export default async function (fastify: FastifyInstance) {
 
         // Client checks
         if (!client.enabled || !client.grantTypes.includes('authorization_code')) {
-          await ensureMinimumResponseTime(startTime, MIN_RESPONSE_TIME_MS.TOKEN);
           await fastify.repositories.auditLogs.create({
             userId: null,
             oauthClientId: client.id,
@@ -86,7 +82,6 @@ export default async function (fastify: FastifyInstance) {
         );
 
         if (!clientSecretValid) {
-          await ensureMinimumResponseTime(startTime, MIN_RESPONSE_TIME_MS.TOKEN);
           await fastify.repositories.auditLogs.create({
             userId: null,
             oauthClientId: client.id,
@@ -104,7 +99,6 @@ export default async function (fastify: FastifyInstance) {
         const authCode = await fastify.repositories.authorizationCodes.findByCode(body.code);
 
         if (!authCode) {
-          await ensureMinimumResponseTime(startTime, MIN_RESPONSE_TIME_MS.TOKEN);
           await fastify.repositories.auditLogs.create({
             userId: null,
             oauthClientId: client.id,
@@ -120,7 +114,6 @@ export default async function (fastify: FastifyInstance) {
 
         // Code–client match
         if (authCode.oauthClientId !== client.id) {
-          await ensureMinimumResponseTime(startTime, MIN_RESPONSE_TIME_MS.TOKEN);
           await fastify.repositories.auditLogs.create({
             userId: null,
             oauthClientId: client.id,
@@ -136,7 +129,6 @@ export default async function (fastify: FastifyInstance) {
 
         // Redirect URI match
         if (body.redirect_uri !== authCode.redirectUri) {
-          await ensureMinimumResponseTime(startTime, MIN_RESPONSE_TIME_MS.TOKEN);
           await fastify.repositories.auditLogs.create({
             userId: null,
             oauthClientId: client.id,
@@ -151,10 +143,12 @@ export default async function (fastify: FastifyInstance) {
         }
 
         // PKCE verification
-        const pkceValid = verifyCodeChallenge(body.code_verifier, authCode.codeChallenge);
+        const pkceValid = fastify.pkceUtils.verifyCodeChallenge(
+          body.code_verifier,
+          authCode.codeChallenge
+        );
 
         if (!pkceValid) {
-          await ensureMinimumResponseTime(startTime, MIN_RESPONSE_TIME_MS.TOKEN);
           await fastify.repositories.auditLogs.create({
             userId: null,
             oauthClientId: client.id,
@@ -175,7 +169,6 @@ export default async function (fastify: FastifyInstance) {
         const user = await fastify.repositories.users.findById(authCode.userId);
 
         if (!user) {
-          await ensureMinimumResponseTime(startTime, MIN_RESPONSE_TIME_MS.TOKEN);
           await fastify.repositories.auditLogs.create({
             userId: null,
             oauthClientId: client.id,

--- a/apps/auth-server/src/app/routes/oauth/token.ts
+++ b/apps/auth-server/src/app/routes/oauth/token.ts
@@ -1,0 +1,285 @@
+// eslint-disable-next-line @nx/enforce-module-boundaries
+import { verifyCodeChallenge } from '@qauth/server-pkce';
+import { InvalidCredentialsError, InvalidTokenError, NotFoundError } from '@qauth/shared-errors';
+import { randomUUID } from 'crypto';
+import type { FastifyInstance } from 'fastify';
+import { ZodTypeProvider } from 'fastify-type-provider-zod';
+
+import { env } from '../../../config/env';
+import { MIN_RESPONSE_TIME_MS } from '../../constants';
+import { getOrCreateDefaultRealm } from '../../helpers/realm';
+import { ensureMinimumResponseTime } from '../../helpers/timing';
+import { tokenExchangeBodySchema, tokenExchangeResponseSchema } from '../../schemas/oauth';
+
+/**
+ * POST /oauth/token
+ * OAuth 2.1 Authorization Code Grant with PKCE.
+ * Exchanges authorization code for access and refresh tokens.
+ */
+export default async function (fastify: FastifyInstance) {
+  fastify.withTypeProvider<ZodTypeProvider>().post(
+    '/token',
+    {
+      schema: {
+        body: tokenExchangeBodySchema,
+        response: {
+          200: tokenExchangeResponseSchema,
+        },
+      },
+      config: {
+        rateLimit: {
+          max: (env as typeof env & { TOKEN_RATE_LIMIT: number }).TOKEN_RATE_LIMIT,
+          timeWindow: (env as typeof env & { TOKEN_RATE_WINDOW: number }).TOKEN_RATE_WINDOW * 1000,
+          keyGenerator: (req) => req.ip || 'unknown',
+        },
+      },
+    },
+    async (request, reply) => {
+      const startTime = Date.now();
+      const body = request.body;
+
+      try {
+        // Realm
+        const realm = await getOrCreateDefaultRealm(fastify);
+
+        // Client lookup
+        const client = await fastify.repositories.oauthClients.findByClientId(
+          realm.id,
+          body.client_id
+        );
+
+        if (!client) {
+          await ensureMinimumResponseTime(startTime, MIN_RESPONSE_TIME_MS.TOKEN);
+          await fastify.repositories.auditLogs.create({
+            userId: null,
+            oauthClientId: null,
+            event: 'oauth.token.exchange.failure',
+            eventType: 'token',
+            success: false,
+            ipAddress: request.ip,
+            userAgent: request.headers['user-agent'] || null,
+            metadata: { error: 'Client authentication failed' },
+          });
+          throw new InvalidCredentialsError('Client authentication failed');
+        }
+
+        // Client checks
+        if (!client.enabled || !client.grantTypes.includes('authorization_code')) {
+          await ensureMinimumResponseTime(startTime, MIN_RESPONSE_TIME_MS.TOKEN);
+          await fastify.repositories.auditLogs.create({
+            userId: null,
+            oauthClientId: client.id,
+            event: 'oauth.token.exchange.failure',
+            eventType: 'token',
+            success: false,
+            ipAddress: request.ip,
+            userAgent: request.headers['user-agent'] || null,
+            metadata: { error: 'Client authentication failed' },
+          });
+          throw new InvalidCredentialsError('Client authentication failed');
+        }
+
+        // Client authentication (client_secret_post)
+        const clientSecretValid = await fastify.passwordHasher.verifyPassword(
+          client.clientSecretHash,
+          body.client_secret
+        );
+
+        if (!clientSecretValid) {
+          await ensureMinimumResponseTime(startTime, MIN_RESPONSE_TIME_MS.TOKEN);
+          await fastify.repositories.auditLogs.create({
+            userId: null,
+            oauthClientId: client.id,
+            event: 'oauth.token.exchange.failure',
+            eventType: 'token',
+            success: false,
+            ipAddress: request.ip,
+            userAgent: request.headers['user-agent'] || null,
+            metadata: { error: 'Client authentication failed' },
+          });
+          throw new InvalidCredentialsError('Client authentication failed');
+        }
+
+        // Authorization code lookup
+        const authCode = await fastify.repositories.authorizationCodes.findByCode(body.code);
+
+        if (!authCode) {
+          await ensureMinimumResponseTime(startTime, MIN_RESPONSE_TIME_MS.TOKEN);
+          await fastify.repositories.auditLogs.create({
+            userId: null,
+            oauthClientId: client.id,
+            event: 'oauth.token.exchange.failure',
+            eventType: 'token',
+            success: false,
+            ipAddress: request.ip,
+            userAgent: request.headers['user-agent'] || null,
+            metadata: { error: 'Invalid or expired authorization code' },
+          });
+          throw new InvalidTokenError('Invalid or expired authorization code');
+        }
+
+        // Code–client match
+        if (authCode.oauthClientId !== client.id) {
+          await ensureMinimumResponseTime(startTime, MIN_RESPONSE_TIME_MS.TOKEN);
+          await fastify.repositories.auditLogs.create({
+            userId: null,
+            oauthClientId: client.id,
+            event: 'oauth.token.exchange.failure',
+            eventType: 'token',
+            success: false,
+            ipAddress: request.ip,
+            userAgent: request.headers['user-agent'] || null,
+            metadata: { error: 'Invalid or expired authorization code' },
+          });
+          throw new InvalidTokenError('Invalid or expired authorization code');
+        }
+
+        // Redirect URI match
+        if (body.redirect_uri !== authCode.redirectUri) {
+          await ensureMinimumResponseTime(startTime, MIN_RESPONSE_TIME_MS.TOKEN);
+          await fastify.repositories.auditLogs.create({
+            userId: null,
+            oauthClientId: client.id,
+            event: 'oauth.token.exchange.failure',
+            eventType: 'token',
+            success: false,
+            ipAddress: request.ip,
+            userAgent: request.headers['user-agent'] || null,
+            metadata: { error: 'Invalid or expired authorization code' },
+          });
+          throw new InvalidTokenError('Invalid or expired authorization code');
+        }
+
+        // PKCE verification
+        const pkceValid = verifyCodeChallenge(body.code_verifier, authCode.codeChallenge);
+
+        if (!pkceValid) {
+          await ensureMinimumResponseTime(startTime, MIN_RESPONSE_TIME_MS.TOKEN);
+          await fastify.repositories.auditLogs.create({
+            userId: null,
+            oauthClientId: client.id,
+            event: 'oauth.token.exchange.failure',
+            eventType: 'token',
+            success: false,
+            ipAddress: request.ip,
+            userAgent: request.headers['user-agent'] || null,
+            metadata: { error: 'Invalid or expired authorization code' },
+          });
+          throw new InvalidTokenError('Invalid or expired authorization code');
+        }
+
+        // Mark code as used
+        await fastify.repositories.authorizationCodes.markUsed(authCode.id);
+
+        // Get user
+        const user = await fastify.repositories.users.findById(authCode.userId);
+
+        if (!user) {
+          await ensureMinimumResponseTime(startTime, MIN_RESPONSE_TIME_MS.TOKEN);
+          await fastify.repositories.auditLogs.create({
+            userId: null,
+            oauthClientId: client.id,
+            event: 'oauth.token.exchange.failure',
+            eventType: 'token',
+            success: false,
+            ipAddress: request.ip,
+            userAgent: request.headers['user-agent'] || null,
+            metadata: { error: 'User not found' },
+          });
+          throw new NotFoundError('User', authCode.userId);
+        }
+
+        // Issue tokens
+        const accessToken = await fastify.jwtUtils.signAccessToken({
+          sub: user.id,
+          email: user.email,
+          email_verified: user.emailVerified,
+        });
+
+        const { token: refreshToken, tokenHash } = fastify.jwtUtils.generateRefreshToken();
+
+        const accessTokenExpiresIn = fastify.jwtUtils.getAccessTokenLifespan();
+        const refreshTokenExpiresAt =
+          Date.now() + fastify.jwtUtils.getRefreshTokenLifespan() * 1000;
+
+        await fastify.repositories.refreshTokens.create({
+          userId: user.id,
+          oauthClientId: client.id,
+          tokenHash,
+          expiresAt: refreshTokenExpiresAt,
+          scopes: authCode.scopes,
+        });
+
+        // Session management (optional)
+        let sessionId: string | undefined;
+        try {
+          sessionId = randomUUID();
+          await fastify.sessionUtils.setSession(
+            sessionId,
+            {
+              userId: user.id,
+              email: user.email,
+              sessionId,
+              createdAt: Date.now(),
+            },
+            accessTokenExpiresIn
+          );
+        } catch (sessionError) {
+          // Session management is optional for token exchange
+          // Log but don't fail the request
+          fastify.log.warn({ err: sessionError }, 'Failed to manage session during token exchange');
+        }
+
+        // Audit success
+        await fastify.repositories.auditLogs.create({
+          userId: user.id,
+          oauthClientId: client.id,
+          event: 'oauth.token.exchange.success',
+          eventType: 'token',
+          success: true,
+          ipAddress: request.ip,
+          userAgent: request.headers['user-agent'] || null,
+          metadata: { authCodeId: authCode.id },
+        });
+
+        // Return tokens
+        return reply.send({
+          access_token: accessToken,
+          refresh_token: refreshToken,
+          expires_in: accessTokenExpiresIn,
+          token_type: 'Bearer' as const,
+        });
+      } catch (error) {
+        // If error is already handled (InvalidTokenError, InvalidCredentialsError, NotFoundError),
+        // ensure minimum response time then rethrow
+        if (
+          error instanceof InvalidTokenError ||
+          error instanceof InvalidCredentialsError ||
+          error instanceof NotFoundError
+        ) {
+          await ensureMinimumResponseTime(startTime, MIN_RESPONSE_TIME_MS.TOKEN);
+          throw error;
+        }
+
+        // Log other errors as failed token exchange attempts
+        await fastify.repositories.auditLogs.create({
+          userId: null,
+          oauthClientId: null,
+          event: 'oauth.token.exchange.failure',
+          eventType: 'token',
+          success: false,
+          ipAddress: request.ip,
+          userAgent: request.headers['user-agent'] || null,
+          metadata: {
+            error: error instanceof Error ? error.message : 'Unknown error',
+          },
+        });
+
+        // Ensure minimum response time even on errors
+        await ensureMinimumResponseTime(startTime, MIN_RESPONSE_TIME_MS.TOKEN);
+
+        throw error;
+      }
+    }
+  );
+}

--- a/apps/auth-server/src/app/schemas/oauth.ts
+++ b/apps/auth-server/src/app/schemas/oauth.ts
@@ -20,3 +20,35 @@ export const authorizeQuerySchema = z.object({
 });
 
 export type AuthorizeQuery = z.infer<typeof authorizeQuerySchema>;
+
+/**
+ * OAuth 2.1 token exchange body (POST /oauth/token, authorization_code grant).
+ * RFC 6749 4.1.3, RFC 7636 PKCE. client_secret_post (MVP).
+ */
+export const tokenExchangeBodySchema = z.object({
+  grant_type: z.literal('authorization_code'),
+  code: z.string().min(1),
+  redirect_uri: z.string().min(1),
+  client_id: z.string().min(1),
+  code_verifier: z
+    .string()
+    .min(43)
+    .max(128)
+    .regex(/^[A-Za-z0-9._~-]+$/),
+  client_secret: z.string().min(1),
+});
+
+export type TokenExchangeBody = z.infer<typeof tokenExchangeBodySchema>;
+
+/**
+ * OAuth token response (same shape as login/refresh).
+ * RFC 6749 5.1.
+ */
+export const tokenExchangeResponseSchema = z.object({
+  access_token: z.string(),
+  refresh_token: z.string(),
+  expires_in: z.number(),
+  token_type: z.literal('Bearer'),
+});
+
+export type TokenExchangeResponse = z.infer<typeof tokenExchangeResponseSchema>;

--- a/apps/auth-server/src/config/env.ts
+++ b/apps/auth-server/src/config/env.ts
@@ -32,4 +32,7 @@ const envSchema = z.object({
 /**
  * Validated environment configuration
  */
-export const env = { ...parseEnv(envSchema), ...parseEnv(jwtEnvSchema) };
+export const env: z.infer<typeof envSchema> & z.infer<typeof jwtEnvSchema> = {
+  ...parseEnv(envSchema),
+  ...parseEnv(jwtEnvSchema),
+};

--- a/apps/auth-server/tsconfig.app.json
+++ b/apps/auth-server/tsconfig.app.json
@@ -13,6 +13,9 @@
       "path": "../../libs/server/config/tsconfig.lib.json"
     },
     {
+      "path": "../../libs/server/pkce/tsconfig.lib.json"
+    },
+    {
       "path": "../../libs/shared/validation/tsconfig.lib.json"
     },
     {

--- a/apps/auth-server/tsconfig.app.json
+++ b/apps/auth-server/tsconfig.app.json
@@ -13,7 +13,7 @@
       "path": "../../libs/server/config/tsconfig.lib.json"
     },
     {
-      "path": "../../libs/server/pkce/tsconfig.lib.json"
+      "path": "../../libs/fastify/plugins/pkce/tsconfig.lib.json"
     },
     {
       "path": "../../libs/shared/validation/tsconfig.lib.json"

--- a/apps/migration-runner/Dockerfile
+++ b/apps/migration-runner/Dockerfile
@@ -23,7 +23,9 @@ COPY apps ./apps
 
 # Copy entrypoint script
 COPY apps/migration-runner/docker-entrypoint.sh ./docker-entrypoint.sh
-RUN chmod +x ./docker-entrypoint.sh
+# Fix Windows line endings (CRLF) and permissions
+RUN sed -i 's/\r$//' ./docker-entrypoint.sh && \
+    chmod +x ./docker-entrypoint.sh
 
 # Create non-root user
 RUN addgroup -g 1001 -S nodejs && \

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,7 +1,6 @@
 # Development override: dev image, nx serve --watch, Compose Watch (sync).
 # Use: docker compose -f docker-compose.yml -f docker-compose.dev.yml up --watch
 # Set NODE_ENV=development and LOG_LEVEL=debug in .env for dev.
-# If you get "no space left on device": close Nx graph/IDE watchers, or run without --watch.
 
 services:
   auth-server:
@@ -9,31 +8,37 @@ services:
       context: .
       dockerfile: apps/auth-server/Dockerfile.dev
     command: ['pnpm', 'nx', 'serve', 'auth-server', '--watch']
+    environment:
+      # Fix for Prisma/NX finding schema in monorepo structure inside container
+      NX_DAEMON: 'false'
     develop:
       watch:
+        # Sync source code changes immediately (Hot Reload)
         - action: sync
           path: ./apps/auth-server
           target: /app/apps/auth-server
-          initial_sync: true
           ignore:
             - node_modules
             - dist
         - action: sync
           path: ./libs
           target: /app/libs
-          initial_sync: true
           ignore:
             - node_modules
             - dist
-        - action: rebuild
+
+        # Sync config files but DO NOT trigger full rebuilds automatically
+        # This prevents "soft-locks" on every save.
+        # If dependencies change, run: docker compose down && docker compose up --build
+        - action: sync
           path: ./package.json
-        - action: rebuild
+          target: /app/package.json
+        - action: sync
           path: ./pnpm-lock.yaml
-        - action: rebuild
-          path: ./pnpm-workspace.yaml
-        - action: rebuild
+          target: /app/pnpm-lock.yaml
+        - action: sync
           path: ./nx.json
-        - action: rebuild
+          target: /app/nx.json
+        - action: sync
           path: ./tsconfig.base.json
-        - action: rebuild
-          path: ./vitest.config.ts
+          target: /app/tsconfig.base.json

--- a/libs/fastify/plugins/pkce/README.md
+++ b/libs/fastify/plugins/pkce/README.md
@@ -1,0 +1,25 @@
+# fastify-plugin-pkce
+
+Fastify plugin wrapping `@qauth/server-pkce` for OAuth 2.1 PKCE operations.
+
+## Usage
+
+```typescript
+import { pkcePlugin } from '@qauth/fastify-plugin-pkce';
+
+await fastify.register(pkcePlugin);
+
+// Verify code challenge at token endpoint
+const isValid = fastify.pkceUtils.verifyCodeChallenge(codeVerifier, storedChallenge);
+
+// Generate PKCE pair (for testing/client utilities)
+const { codeVerifier, codeChallenge } = fastify.pkceUtils.generatePkcePair();
+```
+
+## Decorated Properties
+
+- `fastify.pkceUtils.generateCodeVerifier()` - Generate random code verifier
+- `fastify.pkceUtils.generateCodeChallenge(verifier)` - Compute S256 challenge
+- `fastify.pkceUtils.generatePkcePair()` - Generate verifier + challenge pair
+- `fastify.pkceUtils.isValidCodeVerifierFormat(verifier)` - Validate format
+- `fastify.pkceUtils.verifyCodeChallenge(verifier, challenge)` - Verify PKCE (timing-safe)

--- a/libs/fastify/plugins/pkce/project.json
+++ b/libs/fastify/plugins/pkce/project.json
@@ -1,0 +1,8 @@
+{
+  "name": "fastify-plugin-pkce",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/fastify/plugins/pkce/src",
+  "projectType": "library",
+  "tags": ["scope:fastify", "type:pkce"],
+  "// targets": "to see all targets run: nx show project fastify-plugin-pkce --web"
+}

--- a/libs/fastify/plugins/pkce/src/index.ts
+++ b/libs/fastify/plugins/pkce/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/pkce-plugin';

--- a/libs/fastify/plugins/pkce/src/lib/pkce-plugin.ts
+++ b/libs/fastify/plugins/pkce/src/lib/pkce-plugin.ts
@@ -1,0 +1,58 @@
+import {
+  generateCodeChallenge,
+  generateCodeVerifier,
+  generatePkcePair,
+  isValidCodeVerifierFormat,
+  verifyCodeChallenge,
+} from '@qauth/server-pkce';
+import type { FastifyInstance } from 'fastify';
+import fp from 'fastify-plugin';
+
+/**
+ * PKCE utilities interface exposed on Fastify instance
+ */
+export interface PkceUtils {
+  generateCodeVerifier: typeof generateCodeVerifier;
+  generateCodeChallenge: typeof generateCodeChallenge;
+  generatePkcePair: typeof generatePkcePair;
+  isValidCodeVerifierFormat: typeof isValidCodeVerifierFormat;
+  verifyCodeChallenge: typeof verifyCodeChallenge;
+}
+
+declare module 'fastify' {
+  interface FastifyInstance {
+    pkceUtils: PkceUtils;
+  }
+}
+
+/**
+ * Fastify plugin for PKCE (Proof Key for Code Exchange) utilities.
+ * Decorates fastify instance with pkceUtils for OAuth 2.1 PKCE operations.
+ *
+ * @example
+ * ```typescript
+ * await fastify.register(pkcePlugin);
+ *
+ * // Use in routes
+ * const isValid = fastify.pkceUtils.verifyCodeChallenge(verifier, challenge);
+ * const pair = fastify.pkceUtils.generatePkcePair();
+ * ```
+ */
+export const pkcePlugin = fp(
+  async (fastify: FastifyInstance) => {
+    const pkceUtils: PkceUtils = {
+      generateCodeVerifier,
+      generateCodeChallenge,
+      generatePkcePair,
+      isValidCodeVerifierFormat,
+      verifyCodeChallenge,
+    };
+
+    fastify.decorate('pkceUtils', pkceUtils);
+
+    fastify.log.debug('PKCE plugin registered');
+  },
+  {
+    name: '@qauth/fastify-plugin-pkce',
+  }
+);

--- a/libs/fastify/plugins/pkce/tsconfig.json
+++ b/libs/fastify/plugins/pkce/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "importHelpers": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/libs/fastify/plugins/pkce/tsconfig.lib.json
+++ b/libs/fastify/plugins/pkce/tsconfig.lib.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "composite": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "references": [
+    {
+      "path": "../../../server/pkce/tsconfig.lib.json"
+    }
+  ]
+}

--- a/libs/infra/db/src/lib/repositories/authorization-codes.repository.ts
+++ b/libs/infra/db/src/lib/repositories/authorization-codes.repository.ts
@@ -60,13 +60,14 @@ export function createAuthorizationCodesRepository(
     },
 
     /**
-     * Mark a code as used
-     * Sets used=true and usedAt=now
+     * Mark a code as used (atomic operation)
+     * Sets used=true and usedAt=now only if not already used.
+     * Prevents race conditions where two concurrent requests could both use the same code.
      *
      * @param id - Authorization code ID to mark as used
      * @param tx - Optional transaction client
      * @returns Updated authorization code
-     * @throws NotFoundError if authorization code is not found
+     * @throws NotFoundError if authorization code is not found or already used
      */
     async markUsed(id: string, tx?: DbClient): Promise<AuthorizationCode> {
       const invoker = tx ?? defaultDb;
@@ -78,7 +79,7 @@ export function createAuthorizationCodesRepository(
           used: true,
           usedAt: now,
         })
-        .where(eq(authorizationCodes.id, id))
+        .where(and(eq(authorizationCodes.id, id), eq(authorizationCodes.used, false)))
         .returning();
 
       if (!authCode) {

--- a/libs/server/config/src/lib/schemas/auth.ts
+++ b/libs/server/config/src/lib/schemas/auth.ts
@@ -108,6 +108,16 @@ export const authEnvSchema = z.object({
    * Authorize rate limit window in seconds (default: 60 = 1 minute)
    */
   AUTHORIZE_RATE_WINDOW: z.coerce.number().int().min(1).default(60),
+
+  /**
+   * Maximum token exchange attempts per window
+   */
+  TOKEN_RATE_LIMIT: z.coerce.number().int().min(1).default(30),
+
+  /**
+   * Token rate limit window in seconds (default: 60 = 1 minute)
+   */
+  TOKEN_RATE_WINDOW: z.coerce.number().int().min(1).default(60),
 });
 
 /**

--- a/nx.json
+++ b/nx.json
@@ -36,7 +36,8 @@
         "libs/shared/validation/*",
         "libs/shared/testing/*",
         "libs/server/jwt/*",
-        "libs/server/pkce/*"
+        "libs/server/pkce/*",
+        "libs/fastify/plugins/pkce/*"
       ]
     },
     {
@@ -56,7 +57,8 @@
         "libs/shared/validation/*",
         "libs/shared/testing/*",
         "libs/server/jwt/*",
-        "libs/server/pkce/*"
+        "libs/server/pkce/*",
+        "libs/fastify/plugins/pkce/*"
       ],
       "options": {
         "typecheck": {

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -23,7 +23,8 @@
       "@qauth/server-email": ["libs/server/email/src/index.ts"],
       "@qauth/server-config": ["libs/server/config/src/index.ts"],
       "@qauth/server-jwt": ["libs/server/jwt/src/index.ts"],
-      "@qauth/server-pkce": ["libs/server/pkce/src/index.ts"]
+      "@qauth/server-pkce": ["libs/server/pkce/src/index.ts"],
+      "@qauth/fastify-plugin-pkce": ["libs/fastify/plugins/pkce/src/index.ts"]
     },
     "esModuleInterop": true,
     "strict": true,


### PR DESCRIPTION
- Add TOKEN_RATE_LIMIT and TOKEN_RATE_WINDOW to auth config (30/min, 60s)
- Add MIN_RESPONSE_TIME_MS.TOKEN (300ms) for timing-attack mitigation
- Add tokenExchangeBodySchema and tokenExchangeResponseSchema in oauth schemas
- Implement POST /oauth/token: client_secret_post, PKCE, code validation
- Rate limit by IP; audit oauth.token.exchange.success/failure
- Optional session; ensureMinimumResponseTime on invalid_grant/invalid_client
- Add collection variables: oauthCodeVerifier, oauthClientSecret, authorizationCode
- Add POST /oauth/token request (JSON body, test script saves access/refresh tokens)
- Document flow: authorize → copy code → set variables → token exchange