### PR TITLE
feat(oauth): add OIDC userinfo endpoint (#73)

### DIFF
--- a/apps/auth-server/src/app/constants/security.ts
+++ b/apps/auth-server/src/app/constants/security.ts
@@ -20,4 +20,6 @@ export const MIN_RESPONSE_TIME_MS = {
   TOKEN: 300,
   /** Introspect endpoint minimum response time (300ms) */
   INTROSPECT: 300,
+  /** Userinfo endpoint minimum response time (300ms) */
+  USERINFO: 300,
 } as const;

--- a/apps/auth-server/src/app/routes/oauth/userinfo.test.ts
+++ b/apps/auth-server/src/app/routes/oauth/userinfo.test.ts
@@ -4,6 +4,16 @@ import { describe, expect, it, type Mock, vi } from 'vitest';
 
 import userinfoRoute from './userinfo';
 
+vi.mock('../../../config/env', () => ({
+  env: {
+    DATABASE_URL: 'postgresql://test:test@localhost:5432/test',
+    EMAIL_FROM_ADDRESS: 'noreply@example.com',
+    EMAIL_BASE_URL: 'http://localhost:3000',
+    USERINFO_RATE_LIMIT: 60,
+    USERINFO_RATE_WINDOW: 60,
+  },
+}));
+
 interface TestContext {
   handler?: (request: FastifyRequest, reply: FastifyReply) => Promise<unknown>;
   options?: {
@@ -126,6 +136,18 @@ describe('GET /userinfo route', () => {
       email: 'user@example.com',
       email_verified: true,
     });
+
+    const auditLogMock = fastify.repositories.auditLogs.create as unknown as Mock;
+    expect(auditLogMock).toHaveBeenCalledWith({
+      userId: 'user-1',
+      oauthClientId: null,
+      event: 'oauth.userinfo.success',
+      eventType: 'token',
+      success: true,
+      ipAddress: '127.0.0.1',
+      userAgent: 'vitest',
+      metadata: {},
+    });
   });
 
   it('throws NotFoundError when user is not found', async () => {
@@ -160,6 +182,61 @@ describe('GET /userinfo route', () => {
     }
 
     await expect(handler(request, reply)).rejects.toThrow(NotFoundError);
+
+    const auditLogMock = fastify.repositories.auditLogs.create as unknown as Mock;
+    expect(auditLogMock).toHaveBeenCalledWith({
+      userId: 'missing-user',
+      oauthClientId: null,
+      event: 'oauth.userinfo.failure',
+      eventType: 'token',
+      success: false,
+      ipAddress: '127.0.0.1',
+      userAgent: 'vitest',
+      metadata: {
+        error: expect.stringContaining('missing-user'),
+      },
+    });
+  });
+
+  it('handles user without email gracefully', async () => {
+    const { fastify, ctx } = createFastifyStub();
+    await userinfoRoute(fastify);
+
+    const handler = ctx.handler;
+    expect(handler).toBeDefined();
+
+    const findByIdMock = fastify.repositories.users.findById as unknown as Mock;
+    findByIdMock.mockResolvedValue({
+      id: 'user-2',
+      email: null,
+      emailVerified: false,
+    });
+
+    const request = {
+      jwtPayload: {
+        sub: 'user-2',
+      },
+      ip: '127.0.0.1',
+      headers: {
+        authorization: 'Bearer token',
+        'user-agent': 'vitest',
+      },
+    } as unknown as FastifyRequest;
+
+    const reply = {
+      send: (body: unknown) => body,
+    } as unknown as FastifyReply;
+
+    if (!handler) {
+      throw new Error('Userinfo handler was not registered');
+    }
+
+    const result = await handler(request, reply);
+
+    expect(result).toEqual({
+      sub: 'user-2',
+      email_verified: false,
+    });
   });
 
   it('throws JWTInvalidError when jwt payload is missing', async () => {
@@ -189,5 +266,19 @@ describe('GET /userinfo route', () => {
     }
 
     await expect(handler(request, reply)).rejects.toThrow(JWTInvalidError);
+
+    const auditLogMock = fastify.repositories.auditLogs.create as unknown as Mock;
+    expect(auditLogMock).toHaveBeenCalledWith({
+      userId: null,
+      oauthClientId: null,
+      event: 'oauth.userinfo.failure',
+      eventType: 'token',
+      success: false,
+      ipAddress: '127.0.0.1',
+      userAgent: 'vitest',
+      metadata: {
+        error: 'Missing JWT payload',
+      },
+    });
   });
 });

--- a/apps/auth-server/src/app/routes/oauth/userinfo.test.ts
+++ b/apps/auth-server/src/app/routes/oauth/userinfo.test.ts
@@ -1,0 +1,193 @@
+import { JWTInvalidError, NotFoundError } from '@qauth/shared-errors';
+import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import { describe, expect, it, type Mock, vi } from 'vitest';
+
+import userinfoRoute from './userinfo';
+
+interface TestContext {
+  handler?: (request: FastifyRequest, reply: FastifyReply) => Promise<unknown>;
+  options?: {
+    preHandler?: (request: FastifyRequest, reply: FastifyReply) => Promise<void>;
+  };
+}
+
+function createFastifyStub() {
+  const ctx: TestContext = {};
+
+  const fastify: FastifyInstance & {
+    withTypeProvider: () => {
+      get: (
+        url: string,
+        opts: TestContext['options'],
+        handler: (request: FastifyRequest, reply: FastifyReply) => Promise<unknown>
+      ) => FastifyInstance;
+    };
+    requireJwt: (request: FastifyRequest, reply: FastifyReply) => Promise<void>;
+    repositories: {
+      users: {
+        findById: Mock;
+      };
+      auditLogs: {
+        create: Mock;
+      };
+    };
+  } = {
+    withTypeProvider: () => ({
+      get: (
+        _url: string,
+        opts: TestContext['options'],
+        handler: (request: FastifyRequest, reply: FastifyReply) => Promise<unknown>
+      ) => {
+        ctx.handler = handler;
+        ctx.options = opts;
+        return fastify;
+      },
+    }),
+    requireJwt: vi.fn(),
+    repositories: {
+      users: {
+        findById: vi.fn() as unknown as Mock,
+      },
+      auditLogs: {
+        create: vi.fn() as unknown as Mock,
+      },
+    },
+  } as unknown as FastifyInstance & {
+    withTypeProvider: () => {
+      get: (
+        url: string,
+        opts: TestContext['options'],
+        handler: (request: FastifyRequest, reply: FastifyReply) => Promise<unknown>
+      ) => FastifyInstance;
+    };
+    requireJwt: (request: FastifyRequest, reply: FastifyReply) => Promise<void>;
+    repositories: {
+      users: {
+        findById: Mock;
+      };
+      auditLogs: {
+        create: Mock;
+      };
+    };
+  };
+
+  return { fastify, ctx };
+}
+
+describe('GET /userinfo route', () => {
+  it('registers route with requireJwt as preHandler', async () => {
+    const { fastify, ctx } = createFastifyStub();
+
+    await userinfoRoute(fastify);
+
+    expect(ctx.handler).toBeDefined();
+    expect(ctx.options?.preHandler).toBe(fastify.requireJwt);
+  });
+
+  it('returns userinfo for existing user and jwt payload', async () => {
+    const { fastify, ctx } = createFastifyStub();
+    await userinfoRoute(fastify);
+
+    const handler = ctx.handler;
+    expect(handler).toBeDefined();
+
+    const findByIdMock = fastify.repositories.users.findById as unknown as Mock;
+    findByIdMock.mockResolvedValue({
+      id: 'user-1',
+      email: 'user@example.com',
+      emailVerified: true,
+    });
+
+    const request = {
+      jwtPayload: {
+        sub: 'user-1',
+        email: 'user@example.com',
+        email_verified: true,
+      },
+      ip: '127.0.0.1',
+      headers: {
+        authorization: 'Bearer token',
+        'user-agent': 'vitest',
+      },
+    } as unknown as FastifyRequest;
+
+    const reply = {
+      send: (body: unknown) => body,
+    } as unknown as FastifyReply;
+
+    if (!handler) {
+      throw new Error('Userinfo handler was not registered');
+    }
+
+    const result = await handler(request, reply);
+
+    expect(result).toEqual({
+      sub: 'user-1',
+      email: 'user@example.com',
+      email_verified: true,
+    });
+  });
+
+  it('throws NotFoundError when user is not found', async () => {
+    const { fastify, ctx } = createFastifyStub();
+    await userinfoRoute(fastify);
+
+    const handler = ctx.handler;
+    expect(handler).toBeDefined();
+
+    const findByIdMock = fastify.repositories.users.findById as unknown as Mock;
+    findByIdMock.mockResolvedValue(null);
+
+    const request = {
+      jwtPayload: {
+        sub: 'missing-user',
+      },
+      ip: '127.0.0.1',
+      headers: {
+        authorization: 'Bearer token',
+        'user-agent': 'vitest',
+      },
+    } as unknown as FastifyRequest;
+
+    const reply = {
+      send: () => {
+        throw new Error('send should not be called when user is missing');
+      },
+    } as unknown as FastifyReply;
+
+    if (!handler) {
+      throw new Error('Userinfo handler was not registered');
+    }
+
+    await expect(handler(request, reply)).rejects.toThrow(NotFoundError);
+  });
+
+  it('throws JWTInvalidError when jwt payload is missing', async () => {
+    const { fastify, ctx } = createFastifyStub();
+    await userinfoRoute(fastify);
+
+    const handler = ctx.handler;
+    expect(handler).toBeDefined();
+
+    const request = {
+      // No jwtPayload
+      ip: '127.0.0.1',
+      headers: {
+        authorization: 'Bearer token',
+        'user-agent': 'vitest',
+      },
+    } as unknown as FastifyRequest;
+
+    const reply = {
+      send: () => {
+        throw new Error('send should not be called when jwt payload is missing');
+      },
+    } as unknown as FastifyReply;
+
+    if (!handler) {
+      throw new Error('Userinfo handler was not registered');
+    }
+
+    await expect(handler(request, reply)).rejects.toThrow(JWTInvalidError);
+  });
+});

--- a/apps/auth-server/src/app/routes/oauth/userinfo.ts
+++ b/apps/auth-server/src/app/routes/oauth/userinfo.ts
@@ -2,6 +2,7 @@ import { JWTInvalidError, NotFoundError } from '@qauth/shared-errors';
 import type { FastifyInstance } from 'fastify';
 import { ZodTypeProvider } from 'fastify-type-provider-zod';
 
+import { env } from '../../../config/env';
 import { userinfoResponseSchema } from '../../schemas/oauth';
 
 /**
@@ -22,25 +23,76 @@ export default async function (fastify: FastifyInstance) {
           200: userinfoResponseSchema,
         },
       },
+      config: {
+        rateLimit: {
+          max: env.USERINFO_RATE_LIMIT,
+          timeWindow: env.USERINFO_RATE_WINDOW * 1000,
+          keyGenerator: (request) => request.ip || 'unknown',
+        },
+      },
     },
     async (request, reply) => {
-      const payload = request.jwtPayload;
+      let userId: string | null = null;
 
-      if (!payload || !payload.sub) {
-        throw new JWTInvalidError('Missing JWT payload');
+      try {
+        const payload = request.jwtPayload;
+
+        if (!payload || !payload.sub) {
+          throw new JWTInvalidError('Missing JWT payload');
+        }
+
+        userId = payload.sub;
+
+        const user = await fastify.repositories.users.findById(userId);
+
+        if (!user) {
+          throw new NotFoundError('User', userId);
+        }
+
+        const responseBody: {
+          sub: string;
+          email?: string;
+          email_verified?: boolean;
+        } = {
+          sub: user.id,
+        };
+
+        if (typeof user.email === 'string' && user.email.length > 0) {
+          responseBody.email = user.email;
+        }
+
+        if (typeof user.emailVerified === 'boolean') {
+          responseBody.email_verified = user.emailVerified;
+        }
+
+        await fastify.repositories.auditLogs.create({
+          userId: user.id,
+          oauthClientId: null,
+          event: 'oauth.userinfo.success',
+          eventType: 'token',
+          success: true,
+          ipAddress: request.ip,
+          userAgent: request.headers['user-agent'] || null,
+          metadata: {},
+        });
+
+        return reply.send(responseBody);
+      } catch (error) {
+        await fastify.repositories.auditLogs.create({
+          userId: userId,
+          oauthClientId: null,
+          event: 'oauth.userinfo.failure',
+          eventType: 'token',
+          success: false,
+          ipAddress: request.ip,
+          userAgent: request.headers['user-agent'] || null,
+          metadata: {
+            error: error instanceof Error ? error.message : 'Unknown error',
+          },
+        });
+
+        throw error;
       }
-
-      const user = await fastify.repositories.users.findById(payload.sub);
-
-      if (!user) {
-        throw new NotFoundError('User', payload.sub);
-      }
-
-      return reply.send({
-        sub: user.id,
-        email: user.email,
-        email_verified: user.emailVerified,
-      });
     }
   );
 }

--- a/apps/auth-server/src/app/routes/oauth/userinfo.ts
+++ b/apps/auth-server/src/app/routes/oauth/userinfo.ts
@@ -1,0 +1,46 @@
+import { JWTInvalidError, NotFoundError } from '@qauth/shared-errors';
+import type { FastifyInstance } from 'fastify';
+import { ZodTypeProvider } from 'fastify-type-provider-zod';
+
+import { userinfoResponseSchema } from '../../schemas/oauth';
+
+/**
+ * GET /userinfo
+ * OIDC userinfo endpoint (MVP).
+ *
+ * - Requires Authorization: Bearer <access_token>.
+ * - Uses JWT middleware to verify token and attach payload.
+ * - Returns sub, email, email_verified for the authenticated user.
+ */
+export default async function (fastify: FastifyInstance) {
+  fastify.withTypeProvider<ZodTypeProvider>().get(
+    '/userinfo',
+    {
+      preHandler: fastify.requireJwt,
+      schema: {
+        response: {
+          200: userinfoResponseSchema,
+        },
+      },
+    },
+    async (request, reply) => {
+      const payload = request.jwtPayload;
+
+      if (!payload || !payload.sub) {
+        throw new JWTInvalidError('Missing JWT payload');
+      }
+
+      const user = await fastify.repositories.users.findById(payload.sub);
+
+      if (!user) {
+        throw new NotFoundError('User', payload.sub);
+      }
+
+      return reply.send({
+        sub: user.id,
+        email: user.email,
+        email_verified: user.emailVerified,
+      });
+    }
+  );
+}

--- a/apps/auth-server/src/app/routes/oauth/userinfo.ts
+++ b/apps/auth-server/src/app/routes/oauth/userinfo.ts
@@ -3,6 +3,8 @@ import type { FastifyInstance } from 'fastify';
 import { ZodTypeProvider } from 'fastify-type-provider-zod';
 
 import { env } from '../../../config/env';
+import { MIN_RESPONSE_TIME_MS } from '../../constants';
+import { ensureMinimumResponseTime } from '../../helpers/timing';
 import { userinfoResponseSchema } from '../../schemas/oauth';
 
 /**
@@ -32,6 +34,7 @@ export default async function (fastify: FastifyInstance) {
       },
     },
     async (request, reply) => {
+      const startTime = Date.now();
       let userId: string | null = null;
 
       try {
@@ -76,6 +79,8 @@ export default async function (fastify: FastifyInstance) {
           metadata: {},
         });
 
+        await ensureMinimumResponseTime(startTime, MIN_RESPONSE_TIME_MS.USERINFO);
+
         return reply.send(responseBody);
       } catch (error) {
         await fastify.repositories.auditLogs.create({
@@ -90,6 +95,8 @@ export default async function (fastify: FastifyInstance) {
             error: error instanceof Error ? error.message : 'Unknown error',
           },
         });
+
+        await ensureMinimumResponseTime(startTime, MIN_RESPONSE_TIME_MS.USERINFO);
 
         throw error;
       }

--- a/apps/auth-server/src/app/schemas/oauth.ts
+++ b/apps/auth-server/src/app/schemas/oauth.ts
@@ -88,8 +88,8 @@ export type IntrospectResponse = z.infer<typeof introspectResponseSchema>;
  */
 export const userinfoResponseSchema = z.object({
   sub: z.string().min(1),
-  email: z.email(),
-  email_verified: z.boolean(),
+  email: z.email().optional(),
+  email_verified: z.boolean().optional(),
 });
 
 export type UserinfoResponse = z.infer<typeof userinfoResponseSchema>;

--- a/apps/auth-server/src/app/schemas/oauth.ts
+++ b/apps/auth-server/src/app/schemas/oauth.ts
@@ -81,3 +81,15 @@ export const introspectResponseSchema = z.object({
 });
 
 export type IntrospectResponse = z.infer<typeof introspectResponseSchema>;
+
+/**
+ * OIDC userinfo response schema (GET /userinfo).
+ * Returns selected claims for the authenticated end-user.
+ */
+export const userinfoResponseSchema = z.object({
+  sub: z.string().min(1),
+  email: z.email(),
+  email_verified: z.boolean(),
+});
+
+export type UserinfoResponse = z.infer<typeof userinfoResponseSchema>;

--- a/libs/server/config/src/lib/schemas/auth.ts
+++ b/libs/server/config/src/lib/schemas/auth.ts
@@ -128,6 +128,14 @@ export const authEnvSchema = z.object({
    * Introspect rate limit window in seconds (default: 60 = 1 minute)
    */
   INTROSPECT_RATE_WINDOW: z.coerce.number().int().min(1).default(60),
+  /**
+   * Maximum userinfo requests per window
+   */
+  USERINFO_RATE_LIMIT: z.coerce.number().int().min(1).default(60),
+  /**
+   * Userinfo rate limit window in seconds (default: 60 = 1 minute)
+   */
+  USERINFO_RATE_WINDOW: z.coerce.number().int().min(1).default(60),
 });
 
 /**


### PR DESCRIPTION
Closes #73

Summary:
- Add GET /userinfo endpoint for OIDC
- Define userinfo response schema and validation
- Add tests for userinfo route covering success and error cases

Key behaviours:
- Requires a valid Bearer access token
- Returns sub, email, and email_verified claims
- Returns 401 for invalid, expired, or missing access tokens
- Returns 404 when the user referenced by the token no longer exists

Testing:
- Added tests for the new /userinfo route
- pnpm nx test auth-server --testFile=apps/auth-server/src/app/routes/oauth/userinfo.test.ts passes