### PR TITLE
test(auth): Phase 1.7 tests for JWT middleware, introspect, and userinfo

### DIFF
--- a/apps/auth-server/src/app/routes/oauth/introspect.test.ts
+++ b/apps/auth-server/src/app/routes/oauth/introspect.test.ts
@@ -1,5 +1,7 @@
 import { InvalidCredentialsError, JWTExpiredError, JWTInvalidError } from '@qauth/shared-errors';
 import type { FastifyInstance } from 'fastify';
+import Fastify from 'fastify';
+import { serializerCompiler, validatorCompiler, ZodTypeProvider } from 'fastify-type-provider-zod';
 import { describe, expect, it, type Mock, vi } from 'vitest';
 
 vi.mock('../../helpers/timing', () => ({
@@ -11,9 +13,12 @@ vi.mock('../../../config/env', () => ({
     DATABASE_URL: 'postgresql://test:test@localhost:5432/test',
     EMAIL_FROM_ADDRESS: 'noreply@example.com',
     EMAIL_BASE_URL: 'http://localhost:3000',
+    INTROSPECT_RATE_LIMIT: 60,
+    INTROSPECT_RATE_WINDOW: 60,
   },
 }));
 
+import errorHandler from '../../plugins/error-handler';
 import introspectRoute from './introspect';
 
 interface TestContext {
@@ -444,5 +449,45 @@ describe('POST /oauth/introspect route', () => {
         error: 'Invalid JWT token: signature verification failed',
       },
     });
+  });
+
+  it('returns 400 for missing or empty token', async () => {
+    const app = Fastify({ logger: false }).withTypeProvider<ZodTypeProvider>();
+    app.setValidatorCompiler(validatorCompiler);
+    app.setSerializerCompiler(serializerCompiler);
+
+    app.decorate('repositories', {
+      realms: { findByName: vi.fn(), create: vi.fn() },
+      oauthClients: { findByClientId: vi.fn() },
+      auditLogs: { create: vi.fn() },
+    } as any);
+    app.decorate('passwordHasher', { verifyPassword: vi.fn() } as any);
+    app.decorate('jwtUtils', { verifyAccessToken: vi.fn() } as any);
+
+    await app.register(introspectRoute);
+    await app.register(errorHandler);
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/introspect',
+      headers: {
+        'content-type': 'application/json',
+      },
+      payload: {
+        token: '',
+        client_id: 'client-123',
+        client_secret: 'secret',
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+
+    const json = response.json();
+    expect(json).toMatchObject({
+      statusCode: 400,
+    });
+    expect(json.error).toBeDefined();
+
+    await app.close();
   });
 });

--- a/apps/auth-server/src/app/routes/oauth/introspect.test.ts
+++ b/apps/auth-server/src/app/routes/oauth/introspect.test.ts
@@ -467,27 +467,29 @@ describe('POST /oauth/introspect route', () => {
     await app.register(introspectRoute);
     await app.register(errorHandler);
 
-    const response = await app.inject({
-      method: 'POST',
-      url: '/introspect',
-      headers: {
-        'content-type': 'application/json',
-      },
-      payload: {
-        token: '',
-        client_id: 'client-123',
-        client_secret: 'secret',
-      },
-    });
+    try {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/introspect',
+        headers: {
+          'content-type': 'application/json',
+        },
+        payload: {
+          token: '',
+          client_id: 'client-123',
+          client_secret: 'secret',
+        },
+      });
 
-    expect(response.statusCode).toBe(400);
+      expect(response.statusCode).toBe(400);
 
-    const json = response.json();
-    expect(json).toMatchObject({
-      statusCode: 400,
-    });
-    expect(json.error).toBeDefined();
-
-    await app.close();
+      const json = response.json();
+      expect(json).toMatchObject({
+        statusCode: 400,
+      });
+      expect(json.error).toBeDefined();
+    } finally {
+      await app.close();
+    }
   });
 });

--- a/apps/auth-server/src/app/routes/oauth/userinfo.test.ts
+++ b/apps/auth-server/src/app/routes/oauth/userinfo.test.ts
@@ -306,25 +306,27 @@ describe('GET /userinfo route', () => {
       async () => ({ sub: 'user-1' })
     );
 
-    const response = await app.inject({
-      method: 'GET',
-      url: '/oauth/userinfo',
-      headers: {
-        authorization: 'Bearer invalid-or-malformed-token',
-        'user-agent': 'vitest',
-      },
-    });
+    try {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/oauth/userinfo',
+        headers: {
+          authorization: 'Bearer invalid-or-malformed-token',
+          'user-agent': 'vitest',
+        },
+      });
 
-    expect(response.statusCode).toBe(401);
+      expect(response.statusCode).toBe(401);
 
-    const json = response.json();
-    expect(json).toMatchObject({
-      statusCode: 401,
-      error: expect.any(String),
-      code: 'JWT_INVALID',
-    });
-
-    await app.close();
+      const json = response.json();
+      expect(json).toMatchObject({
+        statusCode: 401,
+        error: expect.any(String),
+        code: 'JWT_INVALID',
+      });
+    } finally {
+      await app.close();
+    }
   });
 
   it('returns 401 for expired token', async () => {
@@ -344,25 +346,27 @@ describe('GET /userinfo route', () => {
       async () => ({ sub: 'user-1' })
     );
 
-    const response = await app.inject({
-      method: 'GET',
-      url: '/oauth/userinfo',
-      headers: {
-        authorization: 'Bearer expired-token',
-        'user-agent': 'vitest',
-      },
-    });
+    try {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/oauth/userinfo',
+        headers: {
+          authorization: 'Bearer expired-token',
+          'user-agent': 'vitest',
+        },
+      });
 
-    expect(response.statusCode).toBe(401);
+      expect(response.statusCode).toBe(401);
 
-    const json = response.json();
-    expect(json).toMatchObject({
-      statusCode: 401,
-      error: 'JWT token has expired',
-      code: 'JWT_EXPIRED',
-    });
-
-    await app.close();
+      const json = response.json();
+      expect(json).toMatchObject({
+        statusCode: 401,
+        error: 'JWT token has expired',
+        code: 'JWT_EXPIRED',
+      });
+    } finally {
+      await app.close();
+    }
   });
 
   it('returns 401 for missing token', async () => {
@@ -382,23 +386,25 @@ describe('GET /userinfo route', () => {
       async () => ({ sub: 'user-1' })
     );
 
-    const response = await app.inject({
-      method: 'GET',
-      url: '/oauth/userinfo',
-      headers: {
-        'user-agent': 'vitest',
-      },
-    });
+    try {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/oauth/userinfo',
+        headers: {
+          'user-agent': 'vitest',
+        },
+      });
 
-    expect(response.statusCode).toBe(401);
+      expect(response.statusCode).toBe(401);
 
-    const json = response.json();
-    expect(json).toMatchObject({
-      statusCode: 401,
-      error: 'Missing or malformed Authorization header',
-      code: 'JWT_INVALID',
-    });
-
-    await app.close();
+      const json = response.json();
+      expect(json).toMatchObject({
+        statusCode: 401,
+        error: 'Missing or malformed Authorization header',
+        code: 'JWT_INVALID',
+      });
+    } finally {
+      await app.close();
+    }
   });
 });

--- a/apps/auth-server/src/app/routes/oauth/userinfo.test.ts
+++ b/apps/auth-server/src/app/routes/oauth/userinfo.test.ts
@@ -1,4 +1,4 @@
-import { JWTInvalidError, NotFoundError } from '@qauth/shared-errors';
+import { JWTExpiredError, JWTInvalidError, NotFoundError } from '@qauth/shared-errors';
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import Fastify from 'fastify';
 import { serializerCompiler, validatorCompiler, ZodTypeProvider } from 'fastify-type-provider-zod';
@@ -294,6 +294,8 @@ describe('GET /userinfo route', () => {
     app.setValidatorCompiler(validatorCompiler);
     app.setSerializerCompiler(serializerCompiler);
 
+    await app.register(errorHandler);
+
     app.get(
       '/oauth/userinfo',
       {
@@ -303,8 +305,6 @@ describe('GET /userinfo route', () => {
       },
       async () => ({ sub: 'user-1' })
     );
-
-    await app.register(errorHandler);
 
     const response = await app.inject({
       method: 'GET',
@@ -321,6 +321,81 @@ describe('GET /userinfo route', () => {
     expect(json).toMatchObject({
       statusCode: 401,
       error: expect.any(String),
+      code: 'JWT_INVALID',
+    });
+
+    await app.close();
+  });
+
+  it('returns 401 for expired token', async () => {
+    const app = Fastify({ logger: false }).withTypeProvider<ZodTypeProvider>();
+    app.setValidatorCompiler(validatorCompiler);
+    app.setSerializerCompiler(serializerCompiler);
+
+    await app.register(errorHandler);
+
+    app.get(
+      '/oauth/userinfo',
+      {
+        preHandler: async () => {
+          throw new JWTExpiredError('JWT token has expired');
+        },
+      },
+      async () => ({ sub: 'user-1' })
+    );
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/oauth/userinfo',
+      headers: {
+        authorization: 'Bearer expired-token',
+        'user-agent': 'vitest',
+      },
+    });
+
+    expect(response.statusCode).toBe(401);
+
+    const json = response.json();
+    expect(json).toMatchObject({
+      statusCode: 401,
+      error: 'JWT token has expired',
+      code: 'JWT_EXPIRED',
+    });
+
+    await app.close();
+  });
+
+  it('returns 401 for missing token', async () => {
+    const app = Fastify({ logger: false }).withTypeProvider<ZodTypeProvider>();
+    app.setValidatorCompiler(validatorCompiler);
+    app.setSerializerCompiler(serializerCompiler);
+
+    await app.register(errorHandler);
+
+    app.get(
+      '/oauth/userinfo',
+      {
+        preHandler: async () => {
+          throw new JWTInvalidError('Missing or malformed Authorization header');
+        },
+      },
+      async () => ({ sub: 'user-1' })
+    );
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/oauth/userinfo',
+      headers: {
+        'user-agent': 'vitest',
+      },
+    });
+
+    expect(response.statusCode).toBe(401);
+
+    const json = response.json();
+    expect(json).toMatchObject({
+      statusCode: 401,
+      error: 'Missing or malformed Authorization header',
       code: 'JWT_INVALID',
     });
 

--- a/libs/fastify/plugins/jwt/src/lib/fastify-plugin-jwt.test.ts
+++ b/libs/fastify/plugins/jwt/src/lib/fastify-plugin-jwt.test.ts
@@ -1,0 +1,203 @@
+import { generateEdDSAKeyPair, importPrivateKey, signAccessToken } from '@qauth/server-jwt';
+import { JWTExpiredError, JWTInvalidError } from '@qauth/shared-errors';
+import type { FastifyInstance } from 'fastify';
+import Fastify from 'fastify';
+import { exportPKCS8, exportSPKI } from 'jose';
+import { describe, expect, it } from 'vitest';
+
+import { jwtPlugin } from './fastify-plugin-jwt';
+
+/**
+ * Minimal error handler for tests - maps JWT errors to 401
+ */
+async function registerTestErrorHandler(app: FastifyInstance) {
+  app.setErrorHandler((error, _request, reply) => {
+    if (error instanceof JWTExpiredError) {
+      return reply.code(401).send({
+        error: error.message,
+        code: 'JWT_EXPIRED',
+        statusCode: 401,
+      });
+    }
+    if (error instanceof JWTInvalidError) {
+      return reply.code(401).send({
+        error: error.message,
+        code: 'JWT_INVALID',
+        statusCode: 401,
+      });
+    }
+    throw error;
+  });
+}
+
+async function buildTestApp() {
+  const { privateKey, publicKey } = await generateEdDSAKeyPair(true);
+  const privateKeyPem = await exportPKCS8(privateKey);
+  const publicKeyPem = await exportSPKI(publicKey);
+
+  const app = Fastify({ logger: false });
+
+  await app.register(jwtPlugin, {
+    privateKey: privateKeyPem,
+    publicKey: publicKeyPem,
+    issuer: 'https://auth.test.example.com',
+    accessTokenLifespan: 900,
+    refreshTokenLifespan: 86400,
+  });
+
+  await registerTestErrorHandler(app);
+
+  app.get('/protected', { preHandler: app.requireJwt }, async (request) => ({
+    sub: request.jwtPayload?.sub,
+    email: request.jwtPayload?.email,
+  }));
+
+  return { app, privateKeyPem, publicKeyPem };
+}
+
+describe('requireJwt middleware', () => {
+  it('allows valid token and sets jwtPayload', async () => {
+    const { app, privateKeyPem } = await buildTestApp();
+
+    const token = await signAccessToken(
+      {
+        sub: 'user-1',
+        email: 'user@example.com',
+        email_verified: true,
+        clientId: 'client-1',
+      },
+      await importPrivateKey(privateKeyPem),
+      'https://auth.test.example.com',
+      900
+    );
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/protected',
+      headers: {
+        authorization: `Bearer ${token}`,
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const json = response.json();
+    expect(json).toEqual({
+      sub: 'user-1',
+      email: 'user@example.com',
+    });
+
+    await app.close();
+  });
+
+  it('returns 401 for expired token', async () => {
+    const { app, privateKeyPem } = await buildTestApp();
+
+    const token = await signAccessToken(
+      {
+        sub: 'user-1',
+        email: 'user@example.com',
+        email_verified: true,
+        clientId: 'client-1',
+      },
+      await importPrivateKey(privateKeyPem),
+      'https://auth.test.example.com',
+      1
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 1100));
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/protected',
+      headers: {
+        authorization: `Bearer ${token}`,
+      },
+    });
+
+    expect(response.statusCode).toBe(401);
+    const json = response.json();
+    expect(json).toMatchObject({
+      statusCode: 401,
+      code: 'JWT_EXPIRED',
+      error: expect.any(String),
+    });
+
+    await app.close();
+  }, 10000);
+
+  it('returns 401 for invalid signature', async () => {
+    const { app } = await buildTestApp();
+    const { privateKey: otherPrivateKey } = await generateEdDSAKeyPair();
+
+    const token = await signAccessToken(
+      {
+        sub: 'user-1',
+        email: 'user@example.com',
+        email_verified: true,
+        clientId: 'client-1',
+      },
+      otherPrivateKey,
+      'https://auth.test.example.com',
+      900
+    );
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/protected',
+      headers: {
+        authorization: `Bearer ${token}`,
+      },
+    });
+
+    expect(response.statusCode).toBe(401);
+    const json = response.json();
+    expect(json).toMatchObject({
+      statusCode: 401,
+      code: 'JWT_INVALID',
+      error: expect.any(String),
+    });
+
+    await app.close();
+  });
+
+  it('returns 401 for missing token', async () => {
+    const { app } = await buildTestApp();
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/protected',
+    });
+
+    expect(response.statusCode).toBe(401);
+    const json = response.json();
+    expect(json).toMatchObject({
+      statusCode: 401,
+      code: 'JWT_INVALID',
+      error: 'Missing or malformed Authorization header',
+    });
+
+    await app.close();
+  });
+
+  it('returns 401 for malformed Authorization header', async () => {
+    const { app } = await buildTestApp();
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/protected',
+      headers: {
+        authorization: 'InvalidFormat',
+      },
+    });
+
+    expect(response.statusCode).toBe(401);
+    const json = response.json();
+    expect(json).toMatchObject({
+      statusCode: 401,
+      code: 'JWT_INVALID',
+      error: 'Missing or malformed Authorization header',
+    });
+
+    await app.close();
+  });
+});

--- a/libs/fastify/plugins/jwt/src/lib/fastify-plugin-jwt.test.ts
+++ b/libs/fastify/plugins/jwt/src/lib/fastify-plugin-jwt.test.ts
@@ -2,13 +2,38 @@ import { generateEdDSAKeyPair, importPrivateKey, signAccessToken } from '@qauth/
 import { JWTExpiredError, JWTInvalidError } from '@qauth/shared-errors';
 import type { FastifyInstance } from 'fastify';
 import Fastify from 'fastify';
-import { exportPKCS8, exportSPKI } from 'jose';
+import { exportPKCS8, exportSPKI, SignJWT } from 'jose';
 import { describe, expect, it } from 'vitest';
 
 import { jwtPlugin } from './fastify-plugin-jwt';
 
 /**
- * Minimal error handler for tests - maps JWT errors to 401
+ * Sign an already-expired token (avoids flaky setTimeout-based tests).
+ * Uses past exp timestamp so verification fails immediately with JWTExpiredError.
+ */
+async function signExpiredToken(
+  privateKeyPem: string,
+  payload: { sub: string; email: string; email_verified: boolean; clientId: string }
+): Promise<string> {
+  const key = await importPrivateKey(privateKeyPem);
+  const now = Math.floor(Date.now() / 1000);
+  return new SignJWT({
+    sub: payload.sub,
+    email: payload.email,
+    email_verified: payload.email_verified,
+    client_id: payload.clientId,
+  })
+    .setProtectedHeader({ alg: 'EdDSA' })
+    .setIssuedAt(now - 3600)
+    .setExpirationTime(now - 60)
+    .setIssuer('https://auth.test.example.com')
+    .sign(key);
+}
+
+/**
+ * Minimal error handler for tests - maps JWT errors to 401.
+ * Kept local (not imported from auth-server) to avoid pulling in auth-server
+ * dependencies into the fastify-plugin-jwt library.
  */
 async function registerTestErrorHandler(app: FastifyInstance) {
   app.setErrorHandler((error, _request, reply) => {
@@ -58,146 +83,144 @@ async function buildTestApp() {
 describe('requireJwt middleware', () => {
   it('allows valid token and sets jwtPayload', async () => {
     const { app, privateKeyPem } = await buildTestApp();
+    try {
+      const token = await signAccessToken(
+        {
+          sub: 'user-1',
+          email: 'user@example.com',
+          email_verified: true,
+          clientId: 'client-1',
+        },
+        await importPrivateKey(privateKeyPem),
+        'https://auth.test.example.com',
+        900
+      );
 
-    const token = await signAccessToken(
-      {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/protected',
+        headers: {
+          authorization: `Bearer ${token}`,
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const json = response.json();
+      expect(json).toEqual({
         sub: 'user-1',
         email: 'user@example.com',
-        email_verified: true,
-        clientId: 'client-1',
-      },
-      await importPrivateKey(privateKeyPem),
-      'https://auth.test.example.com',
-      900
-    );
-
-    const response = await app.inject({
-      method: 'GET',
-      url: '/protected',
-      headers: {
-        authorization: `Bearer ${token}`,
-      },
-    });
-
-    expect(response.statusCode).toBe(200);
-    const json = response.json();
-    expect(json).toEqual({
-      sub: 'user-1',
-      email: 'user@example.com',
-    });
-
-    await app.close();
+      });
+    } finally {
+      await app.close();
+    }
   });
 
   it('returns 401 for expired token', async () => {
     const { app, privateKeyPem } = await buildTestApp();
-
-    const token = await signAccessToken(
-      {
+    try {
+      const token = await signExpiredToken(privateKeyPem, {
         sub: 'user-1',
         email: 'user@example.com',
         email_verified: true,
         clientId: 'client-1',
-      },
-      await importPrivateKey(privateKeyPem),
-      'https://auth.test.example.com',
-      1
-    );
+      });
 
-    await new Promise((resolve) => setTimeout(resolve, 1100));
+      const response = await app.inject({
+        method: 'GET',
+        url: '/protected',
+        headers: {
+          authorization: `Bearer ${token}`,
+        },
+      });
 
-    const response = await app.inject({
-      method: 'GET',
-      url: '/protected',
-      headers: {
-        authorization: `Bearer ${token}`,
-      },
-    });
-
-    expect(response.statusCode).toBe(401);
-    const json = response.json();
-    expect(json).toMatchObject({
-      statusCode: 401,
-      code: 'JWT_EXPIRED',
-      error: expect.any(String),
-    });
-
-    await app.close();
-  }, 10000);
+      expect(response.statusCode).toBe(401);
+      const json = response.json();
+      expect(json).toMatchObject({
+        statusCode: 401,
+        code: 'JWT_EXPIRED',
+        error: expect.any(String),
+      });
+    } finally {
+      await app.close();
+    }
+  });
 
   it('returns 401 for invalid signature', async () => {
     const { app } = await buildTestApp();
-    const { privateKey: otherPrivateKey } = await generateEdDSAKeyPair();
+    try {
+      const { privateKey: otherPrivateKey } = await generateEdDSAKeyPair();
+      const token = await signAccessToken(
+        {
+          sub: 'user-1',
+          email: 'user@example.com',
+          email_verified: true,
+          clientId: 'client-1',
+        },
+        otherPrivateKey,
+        'https://auth.test.example.com',
+        900
+      );
 
-    const token = await signAccessToken(
-      {
-        sub: 'user-1',
-        email: 'user@example.com',
-        email_verified: true,
-        clientId: 'client-1',
-      },
-      otherPrivateKey,
-      'https://auth.test.example.com',
-      900
-    );
+      const response = await app.inject({
+        method: 'GET',
+        url: '/protected',
+        headers: {
+          authorization: `Bearer ${token}`,
+        },
+      });
 
-    const response = await app.inject({
-      method: 'GET',
-      url: '/protected',
-      headers: {
-        authorization: `Bearer ${token}`,
-      },
-    });
-
-    expect(response.statusCode).toBe(401);
-    const json = response.json();
-    expect(json).toMatchObject({
-      statusCode: 401,
-      code: 'JWT_INVALID',
-      error: expect.any(String),
-    });
-
-    await app.close();
+      expect(response.statusCode).toBe(401);
+      const json = response.json();
+      expect(json).toMatchObject({
+        statusCode: 401,
+        code: 'JWT_INVALID',
+        error: expect.any(String),
+      });
+    } finally {
+      await app.close();
+    }
   });
 
   it('returns 401 for missing token', async () => {
     const { app } = await buildTestApp();
+    try {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/protected',
+      });
 
-    const response = await app.inject({
-      method: 'GET',
-      url: '/protected',
-    });
-
-    expect(response.statusCode).toBe(401);
-    const json = response.json();
-    expect(json).toMatchObject({
-      statusCode: 401,
-      code: 'JWT_INVALID',
-      error: 'Missing or malformed Authorization header',
-    });
-
-    await app.close();
+      expect(response.statusCode).toBe(401);
+      const json = response.json();
+      expect(json).toMatchObject({
+        statusCode: 401,
+        code: 'JWT_INVALID',
+        error: 'Missing or malformed Authorization header',
+      });
+    } finally {
+      await app.close();
+    }
   });
 
   it('returns 401 for malformed Authorization header', async () => {
     const { app } = await buildTestApp();
+    try {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/protected',
+        headers: {
+          authorization: 'InvalidFormat',
+        },
+      });
 
-    const response = await app.inject({
-      method: 'GET',
-      url: '/protected',
-      headers: {
-        authorization: 'InvalidFormat',
-      },
-    });
-
-    expect(response.statusCode).toBe(401);
-    const json = response.json();
-    expect(json).toMatchObject({
-      statusCode: 401,
-      code: 'JWT_INVALID',
-      error: 'Missing or malformed Authorization header',
-    });
-
-    await app.close();
+      expect(response.statusCode).toBe(401);
+      const json = response.json();
+      expect(json).toMatchObject({
+        statusCode: 401,
+        code: 'JWT_INVALID',
+        error: 'Missing or malformed Authorization header',
+      });
+    } finally {
+      await app.close();
+    }
   });
 });

--- a/libs/fastify/plugins/jwt/vitest.config.ts
+++ b/libs/fastify/plugins/jwt/vitest.config.ts
@@ -1,0 +1,12 @@
+import path from 'node:path';
+import baseConfig from '../../../../vitest.config';
+import { mergeConfig } from 'vite';
+
+export default mergeConfig(baseConfig, {
+  resolve: {
+    alias: {
+      '@qauth/shared-errors': path.resolve(__dirname, '../../../shared/errors/src/index.ts'),
+      '@qauth/server-jwt': path.resolve(__dirname, '../../../server/jwt/src/index.ts'),
+    },
+  },
+});

--- a/libs/fastify/plugins/jwt/vitest.config.ts
+++ b/libs/fastify/plugins/jwt/vitest.config.ts
@@ -1,12 +1,3 @@
-import path from 'node:path';
 import baseConfig from '../../../../vitest.config';
-import { mergeConfig } from 'vite';
 
-export default mergeConfig(baseConfig, {
-  resolve: {
-    alias: {
-      '@qauth/shared-errors': path.resolve(__dirname, '../../../shared/errors/src/index.ts'),
-      '@qauth/server-jwt': path.resolve(__dirname, '../../../server/jwt/src/index.ts'),
-    },
-  },
-});
+export default baseConfig;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,8 +1,35 @@
+import path from 'node:path';
 import { defineConfig } from 'vitest/config';
 import tsconfigPaths from 'vite-tsconfig-paths';
 
+const root = path.join(__dirname);
+
 export default defineConfig({
   plugins: [tsconfigPaths()],
+  resolve: {
+    alias: {
+      '@qauth/shared-errors': path.join(root, 'libs/shared/errors/src/index.ts'),
+      '@qauth/shared-testing': path.join(root, 'libs/shared/testing/src/index.ts'),
+      '@qauth/shared-validation': path.join(root, 'libs/shared/validation/src/index.ts'),
+      '@qauth/server-jwt': path.join(root, 'libs/server/jwt/src/index.ts'),
+      '@qauth/server-password': path.join(root, 'libs/server/password/src/index.ts'),
+      '@qauth/server-email': path.join(root, 'libs/server/email/src/index.ts'),
+      '@qauth/server-config': path.join(root, 'libs/server/config/src/index.ts'),
+      '@qauth/server-pkce': path.join(root, 'libs/server/pkce/src/index.ts'),
+      '@qauth/infra-db': path.join(root, 'libs/infra/db/src/index.ts'),
+      '@qauth/infra-cache': path.join(root, 'libs/infra/cache/src/index.ts'),
+      '@qauth/fastify-plugin-jwt': path.join(root, 'libs/fastify/plugins/jwt/src/index.ts'),
+      '@qauth/fastify-plugin-db': path.join(root, 'libs/fastify/plugins/db/src/index.ts'),
+      '@qauth/fastify-plugin-cache': path.join(root, 'libs/fastify/plugins/cache/src/index.ts'),
+      '@qauth/fastify-plugin-password': path.join(
+        root,
+        'libs/fastify/plugins/password/src/index.ts'
+      ),
+      '@qauth/fastify-plugin-email': path.join(root, 'libs/fastify/plugins/email/src/index.ts'),
+      '@qauth/fastify-plugin-pkce': path.join(root, 'libs/fastify/plugins/pkce/src/index.ts'),
+    },
+    conditions: ['source', 'default'],
+  },
   test: {
     globals: true,
     environment: 'node',
@@ -27,8 +54,5 @@ export default defineConfig({
         '**/test/**',
       ],
     },
-  },
-  resolve: {
-    conditions: ['source', 'default'],
   },
 });


### PR DESCRIPTION
Closes #76

## Summary

Adds comprehensive tests for Phase 1.7 per GitHub issue #76: JWT middleware (`requireJwt`), POST `/oauth/introspect`, and GET `/userinfo`, covering valid, expired, invalid signature, and missing token scenarios.

## Changes

- **JWT middleware tests** (`fastify-plugin-jwt.test.ts`): valid token, expired token, invalid signature, missing token
- **Introspect tests**: added missing-token case (400 validation error)
- **Userinfo tests**: added expired token (401) and missing token (401) cases
- **Vitest config**: path aliases for root-level test runs; dedicated `vitest.config.ts` for `fastify-plugin-jwt`

## Acceptance Criteria Met

- [x] All middleware cases covered (valid, expired, invalid signature, missing)
- [x] Introspect response validated for each case (including missing token → 400)
- [x] Userinfo response validated for each case (including expired and missing → 401)

## Verification

```bash
pnpm nx test fastify-plugin-jwt
pnpm nx test auth-server
```