### PR TITLE
feat(docs): add OpenAPI/Swagger UI and document all endpoints

### DIFF
--- a/MVP-PRD.md
+++ b/MVP-PRD.md
@@ -399,13 +399,15 @@ Response:
 
 **Tasks**:
 
-- [ ] Create JWT validation middleware
-- [ ] Implement token introspection endpoint (`POST /oauth/introspect`)
-- [ ] Create userinfo endpoint (`GET /userinfo`)
-- [ ] Handle expired tokens
-- [ ] Handle invalid signatures
+- [x] Create JWT validation middleware
+- [x] Implement token introspection endpoint (`POST /oauth/introspect`)
+- [x] Create userinfo endpoint (`GET /userinfo`)
+- [x] Handle expired tokens
+- [x] Handle invalid signatures
 
 **API Endpoints**:
+
+**GET /userinfo** (OIDC userinfo):
 
 ```typescript
 GET /userinfo
@@ -417,10 +419,17 @@ Response:
   "email": "user@example.com",
   "email_verified": true
 }
+```
 
----
+- **Auth**: `Authorization: Bearer <access_token>` (required). JWT middleware verifies the token and attaches the payload.
+- **Response**: `sub` (required), `email` (optional), `email_verified` (optional). Claims reflect the authenticated user.
 
+**POST /oauth/introspect** (RFC 7662 token introspection):
+
+```typescript
 POST /oauth/introspect
+Content-Type: application/x-www-form-urlencoded
+
 token=access_token_here&client_id=client_123&client_secret=client_secret_here
 
 Response (active token):
@@ -434,11 +443,14 @@ Response (active token):
   "token_type": "Bearer"
 }
 
-Response (invalid or expired token, or token issued to different client):
+Response (invalid, expired, or cross-client token):
 {
   "active": false
 }
 ```
+
+- **Body**: `token` (required), `client_id` (required), `client_secret` (required), `token_type_hint` (optional). Confidential client authentication (client_secret_post).
+- **Response**: RFC 7662 2.2 — `active` (required); when active, optional claims `sub`, `client_id`, `exp`, `iat`, `iss`, `token_type` may be returned.
 
 **Acceptance Criteria**:
 

--- a/apps/auth-server/Dockerfile.dev
+++ b/apps/auth-server/Dockerfile.dev
@@ -7,15 +7,13 @@ WORKDIR /app
 
 RUN corepack enable
 
-# Dependencies only (layer cache)
+# Workspace and config (needed before install for pnpm workspace)
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY libs ./libs
+COPY apps ./apps
 COPY nx.json tsconfig.base.json ./
 COPY vitest.config.ts ./
 RUN pnpm install --frozen-lockfile
-
-# Workspace (Compose Watch will sync over these; writable for sync targets)
-COPY libs ./libs
-COPY apps ./apps
 
 RUN addgroup -g 1001 -S nodejs && adduser -S nodejs -u 1001 && \
     chown -R nodejs:nodejs /app

--- a/apps/auth-server/Dockerfile.dev
+++ b/apps/auth-server/Dockerfile.dev
@@ -7,13 +7,15 @@ WORKDIR /app
 
 RUN corepack enable
 
-# Workspace and config (needed before install for pnpm workspace)
+# Dependencies only (layer cache)
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
-COPY libs ./libs
-COPY apps ./apps
 COPY nx.json tsconfig.base.json ./
 COPY vitest.config.ts ./
 RUN pnpm install --frozen-lockfile
+
+# Workspace (Compose Watch will sync over these; writable for sync targets)
+COPY libs ./libs
+COPY apps ./apps
 
 RUN addgroup -g 1001 -S nodejs && adduser -S nodejs -u 1001 && \
     chown -R nodejs:nodejs /app

--- a/apps/auth-server/src/app/app.ts
+++ b/apps/auth-server/src/app/app.ts
@@ -113,12 +113,13 @@ export async function app(fastify: FastifyInstance, opts: object) {
   fastify.register(AutoLoad, {
     dir: path.join(__dirname, 'plugins'),
     options: { ...opts },
-    ignorePattern: /(error-handler|rate-limit)\.(ts|js)$/,
+    ignorePattern: /(error-handler|rate-limit)\.(ts|js)$|\.(test|spec)\.(ts|js)$/,
   });
 
   fastify.register(AutoLoad, {
     dir: path.join(__dirname, 'routes'),
     options: { ...opts },
+    ignorePattern: /\.(test|spec)\.(ts|js)$/,
   });
 
   // Register error handler last to catch all unhandled errors

--- a/apps/auth-server/src/app/openapi.test.ts
+++ b/apps/auth-server/src/app/openapi.test.ts
@@ -1,0 +1,111 @@
+/// <reference types="vitest/globals" />
+import swagger from '@fastify/swagger';
+import swaggerUi from '@fastify/swagger-ui';
+import Fastify from 'fastify';
+import {
+  createJsonSchemaTransform,
+  serializerCompiler,
+  validatorCompiler,
+  ZodTypeProvider,
+} from 'fastify-type-provider-zod';
+
+import {
+  introspectRequestSchema,
+  introspectResponseSchema,
+  userinfoResponseSchema,
+} from './schemas/oauth';
+
+/**
+ * Verifies that OpenAPI spec and Swagger UI are configured and that Phase 1.7
+ * endpoints (GET /oauth/userinfo, POST /oauth/introspect) appear in the spec.
+ * Does not start the full app (no DB/Redis); only swagger + minimal route schemas.
+ */
+describe('OpenAPI / Swagger', () => {
+  it('exposes Phase 1.7 endpoints in the OpenAPI spec', async () => {
+    const app = Fastify({ logger: false }).withTypeProvider<ZodTypeProvider>();
+    app.setValidatorCompiler(validatorCompiler);
+    app.setSerializerCompiler(serializerCompiler);
+
+    await app.register(swagger, {
+      openapi: {
+        openapi: '3.1.0',
+        info: {
+          title: 'QAuth Auth Server API',
+          description:
+            'OAuth 2.1 / OIDC authentication server API. Phase 1.7: userinfo and token introspection.',
+          version: '1.0.0',
+        },
+        servers: [{ url: '/', description: 'Default' }],
+        components: {
+          securitySchemes: {
+            bearerAuth: {
+              type: 'http',
+              scheme: 'bearer',
+              bearerFormat: 'JWT',
+              description: 'Access token obtained from login, refresh, or OAuth token endpoint.',
+            },
+          },
+        },
+      },
+      transform: createJsonSchemaTransform({
+        zodToJsonConfig: { target: 'draft-2020-12' },
+      }),
+    });
+
+    await app.register(swaggerUi, {
+      routePrefix: '/docs',
+      uiConfig: { docExpansion: 'list', filter: true },
+    });
+
+    // Register routes with same schema as real Phase 1.7 routes so spec is generated
+    app.withTypeProvider<ZodTypeProvider>().get(
+      '/oauth/userinfo',
+      {
+        schema: {
+          description:
+            'OIDC userinfo endpoint. Returns claims for the authenticated user. Requires Bearer access token.',
+          tags: ['OAuth', 'Userinfo'],
+          security: [{ bearerAuth: [] }],
+          response: { 200: userinfoResponseSchema },
+        },
+      },
+      async () => ({ sub: 'test', email: 'test@example.com', email_verified: true })
+    );
+
+    app.withTypeProvider<ZodTypeProvider>().post(
+      '/oauth/introspect',
+      {
+        schema: {
+          description:
+            'RFC 7662 token introspection. Send access token and client credentials in application/x-www-form-urlencoded body.',
+          tags: ['OAuth', 'Introspection'],
+          body: introspectRequestSchema,
+          response: { 200: introspectResponseSchema },
+        },
+      },
+      async () => ({ active: false })
+    );
+
+    await app.ready();
+
+    const spec = app.swagger() as {
+      openapi?: string;
+      info?: { title?: string };
+      components?: unknown;
+      paths?: Record<string, unknown>;
+    };
+    expect(spec.openapi).toBe('3.1.0');
+    expect(spec.info?.title).toBe('QAuth Auth Server API');
+    expect(spec.components).toBeDefined();
+    expect(spec.paths?.['/oauth/userinfo']).toBeDefined();
+    expect((spec.paths?.['/oauth/userinfo'] as { get?: unknown })?.get).toBeDefined();
+    expect(spec.paths?.['/oauth/introspect']).toBeDefined();
+    expect((spec.paths?.['/oauth/introspect'] as { post?: unknown })?.post).toBeDefined();
+
+    const docsResponse = await app.inject({ method: 'GET', url: '/docs' });
+    expect(docsResponse.statusCode).toBe(200);
+    expect(docsResponse.headers['content-type']).toMatch(/text\/html/);
+
+    await app.close();
+  });
+});

--- a/apps/auth-server/src/app/routes/auth/login.ts
+++ b/apps/auth-server/src/app/routes/auth/login.ts
@@ -9,7 +9,7 @@ import { MIN_RESPONSE_TIME_MS } from '../../constants';
 import { getOrCreateSystemClient } from '../../helpers/oauth-client';
 import { getOrCreateDefaultRealm } from '../../helpers/realm';
 import { ensureMinimumResponseTime } from '../../helpers/timing';
-import { loginResponseSchema, loginSchema } from '../../schemas/auth';
+import { type LoginRequest, loginResponseSchema, loginSchema } from '../../schemas/auth';
 
 /**
  * Login route
@@ -21,6 +21,9 @@ export default async function (fastify: FastifyInstance) {
     '/login',
     {
       schema: {
+        description:
+          'Authenticate with email and password. Returns access token, refresh token, and expiration. Requires valid credentials.',
+        tags: ['Auth'],
         body: loginSchema,
         response: {
           200: loginResponseSchema,
@@ -36,7 +39,7 @@ export default async function (fastify: FastifyInstance) {
     },
     async (request, reply) => {
       const startTime = Date.now();
-      const { email, password } = request.body;
+      const { email, password } = request.body as LoginRequest;
 
       try {
         // Normalize email

--- a/apps/auth-server/src/app/routes/auth/logout.ts
+++ b/apps/auth-server/src/app/routes/auth/logout.ts
@@ -15,6 +15,9 @@ export default async function (fastify: FastifyInstance) {
     '/logout',
     {
       schema: {
+        description:
+          'Log out the current user. Revokes all refresh tokens for the user. Accepts expired access tokens.',
+        tags: ['Auth'],
         headers: logoutHeadersSchema,
         response: {
           200: logoutResponseSchema,

--- a/apps/auth-server/src/app/routes/auth/refresh.ts
+++ b/apps/auth-server/src/app/routes/auth/refresh.ts
@@ -6,7 +6,7 @@ import { ZodTypeProvider } from 'fastify-type-provider-zod';
 import { env } from '../../../config/env';
 import { MIN_RESPONSE_TIME_MS } from '../../constants';
 import { ensureMinimumResponseTime } from '../../helpers/timing';
-import { refreshResponseSchema, refreshSchema } from '../../schemas/auth';
+import { type RefreshRequest, refreshResponseSchema, refreshSchema } from '../../schemas/auth';
 
 /**
  * Refresh token route
@@ -18,6 +18,9 @@ export default async function (fastify: FastifyInstance) {
     '/refresh',
     {
       schema: {
+        description:
+          'Exchange a refresh token for new access and refresh tokens. Implements token rotation for security.',
+        tags: ['Auth'],
         body: refreshSchema,
         response: {
           200: refreshResponseSchema,
@@ -33,7 +36,7 @@ export default async function (fastify: FastifyInstance) {
     },
     async (request, reply) => {
       const startTime = Date.now();
-      const { refresh_token } = request.body;
+      const { refresh_token } = request.body as RefreshRequest;
 
       try {
         // Hash refresh token

--- a/apps/auth-server/src/app/routes/auth/register.ts
+++ b/apps/auth-server/src/app/routes/auth/register.ts
@@ -5,7 +5,7 @@ import { ZodTypeProvider } from 'fastify-type-provider-zod';
 
 import { env } from '../../../config/env';
 import { getOrCreateDefaultRealm } from '../../helpers/realm';
-import { registerResponseSchema, registerSchema } from '../../schemas/auth';
+import { type RegisterRequest, registerResponseSchema, registerSchema } from '../../schemas/auth';
 
 /**
  * Registration route
@@ -16,6 +16,9 @@ export default async function (fastify: FastifyInstance) {
     '/register',
     {
       schema: {
+        description:
+          'Register a new user account. Creates user, sends verification email, and returns user data. Password must meet strength requirements.',
+        tags: ['Auth'],
         body: registerSchema,
         response: {
           201: registerResponseSchema,
@@ -30,7 +33,7 @@ export default async function (fastify: FastifyInstance) {
       },
     },
     async (request, reply) => {
-      const { email, password, realmId } = request.body;
+      const { email, password, realmId } = request.body as RegisterRequest;
 
       // Email is already validated by Zod schema, just normalize it
       const normalizedEmail = normalizeEmail(email);

--- a/apps/auth-server/src/app/routes/auth/resend-verification.ts
+++ b/apps/auth-server/src/app/routes/auth/resend-verification.ts
@@ -11,7 +11,11 @@ import {
   SUCCESS_MESSAGES,
 } from '../../constants';
 import { getOrCreateDefaultRealm } from '../../helpers/realm';
-import { resendVerificationResponseSchema, resendVerificationSchema } from '../../schemas/auth';
+import {
+  type ResendVerificationRequest,
+  resendVerificationResponseSchema,
+  resendVerificationSchema,
+} from '../../schemas/auth';
 import { errorResponseSchema } from '../../schemas/common';
 
 /**
@@ -36,6 +40,9 @@ export default async function (fastify: FastifyInstance) {
     '/resend-verification',
     {
       schema: {
+        description:
+          'Request a new verification email. Rate limited per IP and per email. Always returns success to prevent email enumeration.',
+        tags: ['Auth'],
         body: resendVerificationSchema,
         response: {
           200: resendVerificationResponseSchema,
@@ -52,7 +59,7 @@ export default async function (fastify: FastifyInstance) {
     },
     async (request) => {
       const startTime = Date.now();
-      const { email } = request.body;
+      const { email } = request.body as ResendVerificationRequest;
 
       // Email is already validated by Zod schema, just normalize it
       const normalizedEmail = normalizeEmail(email);

--- a/apps/auth-server/src/app/routes/auth/verify.ts
+++ b/apps/auth-server/src/app/routes/auth/verify.ts
@@ -3,7 +3,7 @@ import type { FastifyInstance } from 'fastify';
 import { ZodTypeProvider } from 'fastify-type-provider-zod';
 
 import { env } from '../../../config/env';
-import { verifyQuerySchema, verifyResponseSchema } from '../../schemas/auth';
+import { type VerifyQuery, verifyQuerySchema, verifyResponseSchema } from '../../schemas/auth';
 
 /**
  * Email verification route
@@ -25,6 +25,9 @@ export default async function (fastify: FastifyInstance) {
     '/verify',
     {
       schema: {
+        description:
+          'Verify email address using token sent via email. Single-use; marks token as used. Returns success message.',
+        tags: ['Auth'],
         querystring: verifyQuerySchema,
         response: {
           200: verifyResponseSchema,
@@ -39,7 +42,7 @@ export default async function (fastify: FastifyInstance) {
       },
     },
     async (request) => {
-      const { token } = request.query;
+      const { token } = request.query as VerifyQuery;
 
       // Token format already validated by Zod schema (64-char hex string)
       // This prevents CVE-2025-12374 style attacks at schema level

--- a/apps/auth-server/src/app/routes/health.ts
+++ b/apps/auth-server/src/app/routes/health.ts
@@ -15,6 +15,11 @@ export default async function (fastify: FastifyInstance) {
   fastify.get<{ Reply: HealthResponse }>(
     '/health',
     {
+      schema: {
+        description:
+          'Health check endpoint. Returns database and Redis connectivity status. Used for liveness and readiness probes.',
+        tags: ['System'],
+      },
       config: {
         rateLimit: {
           max: env.HEALTH_RATE_LIMIT_MAX,

--- a/apps/auth-server/src/app/routes/oauth/authorize.ts
+++ b/apps/auth-server/src/app/routes/oauth/authorize.ts
@@ -7,7 +7,7 @@ import { env } from '../../../config/env';
 import { AUTHORIZATION_CODE_TTL_MS } from '../../constants';
 import { buildRedirectUrl } from '../../helpers/oauth-redirect';
 import { getOrCreateDefaultRealm } from '../../helpers/realm';
-import { authorizeQuerySchema } from '../../schemas/oauth';
+import { type AuthorizeQuery, authorizeQuerySchema } from '../../schemas/oauth';
 
 /**
  * GET /oauth/authorize
@@ -19,6 +19,9 @@ export default async function (fastify: FastifyInstance) {
     '/authorize',
     {
       schema: {
+        description:
+          'OAuth 2.1 authorization endpoint. Issues authorization code with PKCE. Requires Bearer access token for user context. Redirects to client redirect_uri.',
+        tags: ['OAuth', 'Authorization'],
         querystring: authorizeQuerySchema,
       },
       config: {
@@ -30,7 +33,7 @@ export default async function (fastify: FastifyInstance) {
       },
     },
     async (request, reply) => {
-      const query = request.query;
+      const query = request.query as AuthorizeQuery;
       const redirectUri = query.redirect_uri;
       const state = query.state;
 

--- a/apps/auth-server/src/app/routes/oauth/introspect.ts
+++ b/apps/auth-server/src/app/routes/oauth/introspect.ts
@@ -6,7 +6,11 @@ import { env } from '../../../config/env';
 import { MIN_RESPONSE_TIME_MS } from '../../constants';
 import { getOrCreateDefaultRealm } from '../../helpers/realm';
 import { ensureMinimumResponseTime } from '../../helpers/timing';
-import { introspectRequestSchema, introspectResponseSchema } from '../../schemas/oauth';
+import {
+  type IntrospectRequest,
+  introspectRequestSchema,
+  introspectResponseSchema,
+} from '../../schemas/oauth';
 
 /**
  * POST /oauth/introspect
@@ -22,6 +26,9 @@ export default async function (fastify: FastifyInstance) {
     '/introspect',
     {
       schema: {
+        description:
+          'RFC 7662 token introspection. Send access token and client credentials in application/x-www-form-urlencoded body. Returns active and claims when token is valid for the client.',
+        tags: ['OAuth', 'Introspection'],
         body: introspectRequestSchema,
         response: {
           200: introspectResponseSchema,
@@ -37,7 +44,8 @@ export default async function (fastify: FastifyInstance) {
     },
     async (request, reply) => {
       const startTime = Date.now();
-      const { token, client_id, client_secret } = request.body;
+      const body = request.body as IntrospectRequest;
+      const { token, client_id, client_secret } = body;
 
       try {
         const realm = await getOrCreateDefaultRealm(fastify);
@@ -163,8 +171,7 @@ export default async function (fastify: FastifyInstance) {
           throw error;
         }
 
-        const fallbackOauthClientId =
-          typeof request.body.client_id === 'string' ? request.body.client_id : null;
+        const fallbackOauthClientId = body.client_id ?? null;
 
         await fastify.repositories.auditLogs.create({
           userId: null,

--- a/apps/auth-server/src/app/routes/oauth/token.ts
+++ b/apps/auth-server/src/app/routes/oauth/token.ts
@@ -7,7 +7,11 @@ import { env } from '../../../config/env';
 import { MIN_RESPONSE_TIME_MS } from '../../constants';
 import { getOrCreateDefaultRealm } from '../../helpers/realm';
 import { ensureMinimumResponseTime } from '../../helpers/timing';
-import { tokenExchangeBodySchema, tokenExchangeResponseSchema } from '../../schemas/oauth';
+import {
+  type TokenExchangeBody,
+  tokenExchangeBodySchema,
+  tokenExchangeResponseSchema,
+} from '../../schemas/oauth';
 
 /**
  * POST /oauth/token
@@ -19,6 +23,9 @@ export default async function (fastify: FastifyInstance) {
     '/token',
     {
       schema: {
+        description:
+          'OAuth 2.1 token endpoint. Exchanges authorization code for access and refresh tokens. Requires client credentials and PKCE code_verifier.',
+        tags: ['OAuth', 'Token'],
         body: tokenExchangeBodySchema,
         response: {
           200: tokenExchangeResponseSchema,
@@ -34,7 +41,7 @@ export default async function (fastify: FastifyInstance) {
     },
     async (request, reply) => {
       const startTime = Date.now();
-      const body = request.body;
+      const body = request.body as TokenExchangeBody;
 
       try {
         // Realm

--- a/apps/auth-server/src/app/routes/oauth/userinfo.ts
+++ b/apps/auth-server/src/app/routes/oauth/userinfo.ts
@@ -21,6 +21,10 @@ export default async function (fastify: FastifyInstance) {
     {
       preHandler: fastify.requireJwt,
       schema: {
+        description:
+          'OIDC userinfo endpoint. Returns claims for the authenticated user. Requires Bearer access token.',
+        tags: ['OAuth', 'Userinfo'],
+        security: [{ bearerAuth: [] }],
         response: {
           200: userinfoResponseSchema,
         },

--- a/apps/auth-server/src/app/routes/root.ts
+++ b/apps/auth-server/src/app/routes/root.ts
@@ -1,7 +1,17 @@
 import type { FastifyInstance } from 'fastify';
 
 export default async function (fastify: FastifyInstance) {
-  fastify.get('/', async function () {
-    return { message: 'Hello API' };
-  });
+  fastify.get(
+    '/',
+    {
+      schema: {
+        description:
+          'Root API endpoint. Returns a simple greeting to verify the auth server is running.',
+        tags: ['System'],
+      },
+    },
+    async function () {
+      return { message: 'Hello API' };
+    }
+  );
 }

--- a/apps/auth-server/src/main.ts
+++ b/apps/auth-server/src/main.ts
@@ -1,5 +1,12 @@
+import swagger from '@fastify/swagger';
+import swaggerUi from '@fastify/swagger-ui';
 import Fastify from 'fastify';
-import { serializerCompiler, validatorCompiler, ZodTypeProvider } from 'fastify-type-provider-zod';
+import {
+  createJsonSchemaTransform,
+  serializerCompiler,
+  validatorCompiler,
+  ZodTypeProvider,
+} from 'fastify-type-provider-zod';
 
 import { app } from './app/app';
 import { env } from './config/env';
@@ -34,7 +41,38 @@ process.on('SIGINT', () => shutdown('SIGINT'));
 // Start server
 async function start() {
   try {
-    // Register your application as a normal plugin.
+    // Swagger must be registered BEFORE routes for route discovery (see @fastify/swagger README)
+    await server.register(swagger, {
+      openapi: {
+        openapi: '3.1.0',
+        info: {
+          title: 'QAuth Auth Server API',
+          description:
+            'OAuth 2.1 / OIDC authentication server API. Phase 1.7: userinfo and token introspection.',
+          version: '1.0.0',
+        },
+        servers: [{ url: '/', description: 'Default' }],
+        components: {
+          securitySchemes: {
+            bearerAuth: {
+              type: 'http',
+              scheme: 'bearer',
+              bearerFormat: 'JWT',
+              description: 'Access token obtained from login, refresh, or OAuth token endpoint.',
+            },
+          },
+        },
+      },
+      transform: createJsonSchemaTransform({
+        zodToJsonConfig: { target: 'draft-2020-12' },
+      }),
+    });
+    await server.register(swaggerUi, {
+      routePrefix: '/docs',
+      uiConfig: { docExpansion: 'list', filter: true },
+    });
+
+    // Register app (routes) after swagger so they appear in OpenAPI spec
     await server.register(app);
 
     // Start listening.

--- a/apps/auth-server/src/main.ts
+++ b/apps/auth-server/src/main.ts
@@ -16,7 +16,9 @@ const server = Fastify({
   logger: {
     level: env.LOG_LEVEL,
   },
-  ignoreTrailingSlash: true,
+  routerOptions: {
+    ignoreTrailingSlash: true,
+  },
 }).withTypeProvider<ZodTypeProvider>();
 
 // Set up Zod validator and serializer

--- a/package.json
+++ b/package.json
@@ -94,6 +94,8 @@
     "@fastify/autoload": "^6.3.1",
     "@fastify/cors": "^11.2.0",
     "@fastify/rate-limit": "^10.3.0",
+    "@fastify/swagger": "^9.7.0",
+    "@fastify/swagger-ui": "^5.2.5",
     "@node-rs/argon2": "^2.0.2",
     "@react-email/components": "^1.0.3",
     "dotenv": "^17.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,12 @@ importers:
       '@fastify/rate-limit':
         specifier: ^10.3.0
         version: 10.3.0
+      '@fastify/swagger':
+        specifier: ^9.7.0
+        version: 9.7.0
+      '@fastify/swagger-ui':
+        specifier: ^5.2.5
+        version: 5.2.5
       '@node-rs/argon2':
         specifier: ^2.0.2
         version: 2.0.2
@@ -40,7 +46,7 @@ importers:
         version: 5.1.0
       fastify-type-provider-zod:
         specifier: ^6.1.0
-        version: 6.1.0(@fastify/swagger@9.6.1)(fastify@5.6.2)(openapi-types@12.1.3)(zod@4.2.1)
+        version: 6.1.0(@fastify/swagger@9.7.0)(fastify@5.6.2)(openapi-types@12.1.3)(zod@4.2.1)
       ioredis:
         specifier: ^5.8.2
         version: 5.8.2
@@ -1665,6 +1671,9 @@ packages:
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@fastify/accept-negotiator@2.0.1':
+    resolution: {integrity: sha512-/c/TW2bO/v9JeEgoD/g1G5GxGeCF1Hafdf79WPmUlgYiBXummY0oX3VVq4yFkKKVBKDNlaDUYoab7g38RpPqCQ==}
+
   '@fastify/ajv-compiler@4.0.5':
     resolution: {integrity: sha512-KoWKW+MhvfTRWL4qrhUwAAZoaChluo0m0vbiJlGMt2GXvL4LVPQEjt8kSpHI3IBq5Rez8fg+XeH3cneztq+C7A==}
 
@@ -1692,8 +1701,17 @@ packages:
   '@fastify/rate-limit@10.3.0':
     resolution: {integrity: sha512-eIGkG9XKQs0nyynatApA3EVrojHOuq4l6fhB4eeCk4PIOeadvOJz9/4w3vGI44Go17uaXOWEcPkaD8kuKm7g6Q==}
 
-  '@fastify/swagger@9.6.1':
-    resolution: {integrity: sha512-fKlpJqFMWoi4H3EdUkDaMteEYRCfQMEkK0HJJ0eaf4aRlKd8cbq0pVkOfXDXmtvMTXYcnx3E+l023eFDBsA1HA==}
+  '@fastify/send@4.1.0':
+    resolution: {integrity: sha512-TMYeQLCBSy2TOFmV95hQWkiTYgC/SEx7vMdV+wnZVX4tt8VBLKzmH8vV9OzJehV0+XBfg+WxPMt5wp+JBUKsVw==}
+
+  '@fastify/static@9.0.0':
+    resolution: {integrity: sha512-r64H8Woe/vfilg5RTy7lwWlE8ZZcTrc3kebYFMEUBrMqlydhQyoiExQXdYAy2REVpST/G35+stAM8WYp1WGmMA==}
+
+  '@fastify/swagger-ui@5.2.5':
+    resolution: {integrity: sha512-ky3I0LAkXKX/prwSDpoQ3kscBKsj2Ha6Gp1/JfgQSqyx0bm9F2bE//XmGVGj2cR9l5hUjZYn60/hqn7e+OLgWQ==}
+
+  '@fastify/swagger@9.7.0':
+    resolution: {integrity: sha512-Vp1SC1GC2Hrkd3faFILv86BzUNyFz5N4/xdExqtCgkGASOzn/x+eMe4qXIGq7cdT6wif/P/oa6r1Ruqx19paZA==}
 
   '@grpc/grpc-js@1.14.3':
     resolution: {integrity: sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==}
@@ -3331,6 +3349,10 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
   bare-events@2.8.2:
     resolution: {integrity: sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==}
     peerDependencies:
@@ -3390,6 +3412,10 @@ packages:
 
   brace-expansion@2.0.2:
     resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
+
+  brace-expansion@5.0.4:
+    resolution: {integrity: sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==}
+    engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -3550,6 +3576,10 @@ packages:
   confusing-browser-globals@1.0.11:
     resolution: {integrity: sha512-JsPKdmh8ZkmnHxDk55FZ1TqVLvEQTvoByJZRN9jzI0UjxK/QgAmsphz7PGtqgPieQZ/CQcHWXCR7ATDNhGe+YA==}
 
+  content-disposition@1.0.1:
+    resolution: {integrity: sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==}
+    engines: {node: '>=18'}
+
   conventional-changelog-angular@7.0.0:
     resolution: {integrity: sha512-ROjNchA9LgfNMTTFSIWPzebCwOGFdgkEq45EnvvrmSLvCtAw0HSmrCs7/ty+wAeYUZyNay0YMUNYFTRL72PkBQ==}
     engines: {node: '>=16'}
@@ -3702,6 +3732,10 @@ packages:
   denque@2.1.0:
     resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
     engines: {node: '>=0.10'}
+
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
 
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
@@ -3984,6 +4018,9 @@ packages:
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
+
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
   escape-string-regexp@1.0.5:
     resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
@@ -4369,6 +4406,10 @@ packages:
     resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
     hasBin: true
 
+  glob@13.0.6:
+    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
+    engines: {node: 18 || 20 || >=22}
+
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
     deprecated: Glob versions prior to v9 are no longer supported
@@ -4444,6 +4485,10 @@ packages:
 
   htmlparser2@8.0.2:
     resolution: {integrity: sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==}
+
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
 
   husky@9.1.7:
     resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
@@ -4984,6 +5029,10 @@ packages:
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
+  lru-cache@11.2.6:
+    resolution: {integrity: sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==}
+    engines: {node: 20 || >=22}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
@@ -5037,6 +5086,11 @@ packages:
     engines: {node: '>=4.0.0'}
     hasBin: true
 
+  mime@3.0.0:
+    resolution: {integrity: sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==}
+    engines: {node: '>=10.0.0'}
+    hasBin: true
+
   mimic-fn@2.1.0:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
@@ -5044,6 +5098,10 @@ packages:
   mimic-function@5.0.1:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
     engines: {node: '>=18'}
+
+  minimatch@10.2.4:
+    resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
+    engines: {node: 18 || 20 || >=22}
 
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
@@ -5065,6 +5123,10 @@ packages:
 
   minipass@7.1.2:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
 
   mkdirp-classic@0.5.3:
@@ -5274,6 +5336,10 @@ packages:
   path-scurry@1.11.1:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
+
+  path-scurry@2.0.2:
+    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
+    engines: {node: 18 || 20 || >=22}
 
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -5706,6 +5772,9 @@ packages:
     resolution: {integrity: sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==}
     engines: {node: '>= 0.4'}
 
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
     engines: {node: '>=8'}
@@ -5801,6 +5870,10 @@ packages:
 
   standard-as-callback@2.1.0:
     resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
 
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
@@ -5983,6 +6056,10 @@ packages:
   toad-cache@3.7.0:
     resolution: {integrity: sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw==}
     engines: {node: '>=12'}
+
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
 
   totalist@3.0.1:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
@@ -7978,6 +8055,8 @@ snapshots:
       '@eslint/core': 0.17.0
       levn: 0.4.1
 
+  '@fastify/accept-negotiator@2.0.1': {}
+
   '@fastify/ajv-compiler@4.0.5':
     dependencies:
       ajv: 8.17.1
@@ -8014,7 +8093,32 @@ snapshots:
       fastify-plugin: 5.1.0
       toad-cache: 3.7.0
 
-  '@fastify/swagger@9.6.1':
+  '@fastify/send@4.1.0':
+    dependencies:
+      '@lukeed/ms': 2.0.2
+      escape-html: 1.0.3
+      fast-decode-uri-component: 1.0.1
+      http-errors: 2.0.1
+      mime: 3.0.0
+
+  '@fastify/static@9.0.0':
+    dependencies:
+      '@fastify/accept-negotiator': 2.0.1
+      '@fastify/send': 4.1.0
+      content-disposition: 1.0.1
+      fastify-plugin: 5.1.0
+      fastq: 1.20.1
+      glob: 13.0.6
+
+  '@fastify/swagger-ui@5.2.5':
+    dependencies:
+      '@fastify/static': 9.0.0
+      fastify-plugin: 5.1.0
+      openapi-types: 12.1.3
+      rfdc: 1.4.1
+      yaml: 2.8.2
+
+  '@fastify/swagger@9.7.0':
     dependencies:
       fastify-plugin: 5.1.0
       json-schema-resolver: 3.0.0
@@ -9942,6 +10046,8 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  balanced-match@4.0.4: {}
+
   bare-events@2.8.2: {}
 
   bare-fs@4.5.2:
@@ -10003,6 +10109,10 @@ snapshots:
   brace-expansion@2.0.2:
     dependencies:
       balanced-match: 1.0.2
+
+  brace-expansion@5.0.4:
+    dependencies:
+      balanced-match: 4.0.4
 
   braces@3.0.3:
     dependencies:
@@ -10148,6 +10258,8 @@ snapshots:
 
   confusing-browser-globals@1.0.11: {}
 
+  content-disposition@1.0.1: {}
+
   conventional-changelog-angular@7.0.0:
     dependencies:
       compare-func: 2.0.0
@@ -10283,6 +10395,8 @@ snapshots:
   delayed-stream@1.0.0: {}
 
   denque@2.1.0: {}
+
+  depd@2.0.0: {}
 
   dequal@2.0.3: {}
 
@@ -10650,6 +10764,8 @@ snapshots:
 
   escalade@3.2.0: {}
 
+  escape-html@1.0.3: {}
+
   escape-string-regexp@1.0.5: {}
 
   escape-string-regexp@2.0.0: {}
@@ -10914,10 +11030,10 @@ snapshots:
 
   fastify-plugin@5.1.0: {}
 
-  fastify-type-provider-zod@6.1.0(@fastify/swagger@9.6.1)(fastify@5.6.2)(openapi-types@12.1.3)(zod@4.2.1):
+  fastify-type-provider-zod@6.1.0(@fastify/swagger@9.7.0)(fastify@5.6.2)(openapi-types@12.1.3)(zod@4.2.1):
     dependencies:
       '@fastify/error': 4.2.0
-      '@fastify/swagger': 9.6.1
+      '@fastify/swagger': 9.7.0
       fastify: 5.6.2
       openapi-types: 12.1.3
       zod: 4.2.1
@@ -11111,6 +11227,12 @@ snapshots:
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
 
+  glob@13.0.6:
+    dependencies:
+      minimatch: 10.2.4
+      minipass: 7.1.3
+      path-scurry: 2.0.2
+
   glob@7.2.3:
     dependencies:
       fs.realpath: 1.0.0
@@ -11185,6 +11307,14 @@ snapshots:
       domhandler: 5.0.3
       domutils: 3.2.2
       entities: 4.5.0
+
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
 
   husky@9.1.7: {}
 
@@ -11890,6 +12020,8 @@ snapshots:
 
   lru-cache@10.4.3: {}
 
+  lru-cache@11.2.6: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -11935,9 +12067,15 @@ snapshots:
 
   mime@2.6.0: {}
 
+  mime@3.0.0: {}
+
   mimic-fn@2.1.0: {}
 
   mimic-function@5.0.1: {}
+
+  minimatch@10.2.4:
+    dependencies:
+      brace-expansion: 5.0.4
 
   minimatch@3.1.2:
     dependencies:
@@ -11958,6 +12096,8 @@ snapshots:
   minimist@1.2.8: {}
 
   minipass@7.1.2: {}
+
+  minipass@7.1.3: {}
 
   mkdirp-classic@0.5.3: {}
 
@@ -12220,6 +12360,11 @@ snapshots:
     dependencies:
       lru-cache: 10.4.3
       minipass: 7.1.2
+
+  path-scurry@2.0.2:
+    dependencies:
+      lru-cache: 11.2.6
+      minipass: 7.1.3
 
   path-type@4.0.0: {}
 
@@ -12625,6 +12770,8 @@ snapshots:
       es-errors: 1.3.0
       es-object-atoms: 1.1.1
 
+  setprototypeof@1.2.0: {}
+
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
@@ -12729,6 +12876,8 @@ snapshots:
   stackback@0.0.2: {}
 
   standard-as-callback@2.1.0: {}
+
+  statuses@2.0.2: {}
 
   std-env@3.10.0: {}
 
@@ -13002,6 +13151,8 @@ snapshots:
       is-number: 7.0.0
 
   toad-cache@3.7.0: {}
+
+  toidentifier@1.0.1: {}
 
   totalist@3.0.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,7 +4,6 @@ packages:
 
 onlyBuiltDependencies:
   - '@swc/core'
-  # - cpu-features - optional for ssh2, not used in this project
   - esbuild
   - nx
   - protobufjs


### PR DESCRIPTION
Closes #77

- Add @fastify/swagger and @fastify/swagger-ui, serve docs at /docs
- Register swagger before routes for proper endpoint discovery
- Add description and tags to all endpoints (root, health, auth, oauth)
- Update MVP-PRD Phase 1.7 with userinfo and introspect API docs
- Add openapi.test.ts for spec validation
- Remove fastify-type-provider-zod patch (use OpenAPI 3.1.0)