### PR TITLE
feat(db): add idempotent OAuth-client seeder

### DIFF
--- a/libs/infra/db/package.json
+++ b/libs/infra/db/package.json
@@ -11,7 +11,8 @@
     "drizzle-kit": "catalog:",
     "drizzle-orm": "catalog:",
     "drizzle-seed": "catalog:",
-    "pg": "catalog:"
+    "pg": "catalog:",
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@types/pg": "catalog:",

--- a/libs/infra/db/project.json
+++ b/libs/infra/db/project.json
@@ -52,6 +52,15 @@
         "cwd": "libs/infra/db"
       },
       "description": "Seed database with initial data (dev client)"
+    },
+    "db:seed-oauth-clients": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "tsx src/scripts/seed-oauth-clients.ts",
+        "cwd": "libs/infra/db",
+        "forwardAllArgs": true
+      },
+      "description": "Idempotent OAuth-client provisioner — pass `-- --manifest=<path> [--rotate]`"
     }
   }
 }

--- a/libs/infra/db/src/scripts/seed-oauth-clients.ts
+++ b/libs/infra/db/src/scripts/seed-oauth-clients.ts
@@ -28,26 +28,6 @@
  *   client_ids. Uses plain `drizzle-orm` inserts because `drizzle-seed`'s
  *   faker-style API is awkward for "insert these exact rows."
  *
- * Manifest shape:
- *
- *   {
- *     "realm": "default",
- *     "clients": [
- *       {
- *         "client_id": "example-service",
- *         "name": "Example Service",
- *         "description": "A machine client that does things.",
- *         "grant_types": ["client_credentials"],
- *         "scopes": ["read:things"],
- *         "audience": ["https://api.example.com"],
- *         "redirect_uris": [],
- *         "response_types": [],
- *         "require_pkce": false,
- *         "token_endpoint_auth_method": "client_secret_basic"
- *       }
- *     ]
- *   }
- *
  * The target realm must already exist. Create it via migrations or the
  * default-realm helper before running this.
  */
@@ -56,96 +36,56 @@ import { readFileSync } from 'node:fs';
 
 import { hash } from '@node-rs/argon2';
 import * as dotenv from 'dotenv';
-import { and, eq } from 'drizzle-orm';
+import { and, eq, sql } from 'drizzle-orm';
 import { drizzle } from 'drizzle-orm/node-postgres';
+import { z } from 'zod';
 
 import { oauthClients, realms } from '../lib/schema';
-import type { GrantType, ResponseType } from '../lib/schema/enums';
+import { grantTypeEnum, responseTypeEnum, tokenEndpointAuthMethodEnum } from '../lib/schema/enums';
 
 dotenv.config({ path: '../../../.env' });
 
 /* ------------------------------------------------------------------------ */
-/*                             Manifest shape                               */
+/*                       Manifest schema (zod)                              */
 /* ------------------------------------------------------------------------ */
 
-const VALID_GRANT_TYPES = [
-  'authorization_code',
-  'refresh_token',
-  'client_credentials',
-] as const satisfies readonly GrantType[];
+// Reuse pgEnum values to stay in lock-step with the database schema. If
+// someone adds a grant type or auth method to the enum, the manifest
+// validator picks it up automatically.
+const grantTypeZ = z.enum(grantTypeEnum.enumValues);
+const responseTypeZ = z.enum(responseTypeEnum.enumValues);
+const tokenEndpointAuthMethodZ = z.enum(tokenEndpointAuthMethodEnum.enumValues);
 
-const VALID_AUTH_METHODS = [
-  'client_secret_post',
-  'client_secret_basic',
-  'private_key_jwt',
-  'none',
-] as const;
-type TokenEndpointAuthMethod = (typeof VALID_AUTH_METHODS)[number];
+const clientSpecSchema = z
+  .object({
+    client_id: z.string().min(1).max(255),
+    name: z.string().min(1).max(255),
+    description: z.string().max(2000).optional(),
+    grant_types: z.array(grantTypeZ).min(1),
+    response_types: z.array(responseTypeZ).optional(),
+    scopes: z.array(z.string().min(1)).optional(),
+    audience: z.array(z.string().min(1)).nullable().optional(),
+    redirect_uris: z.array(z.string().url()).optional(),
+    require_pkce: z.boolean().optional(),
+    token_endpoint_auth_method: tokenEndpointAuthMethodZ.optional(),
+  })
+  .strict();
 
-type ClientSpec = {
-  client_id: string;
-  name: string;
-  description?: string;
-  grant_types: GrantType[];
-  response_types?: ResponseType[];
-  scopes?: string[];
-  audience?: string[] | null;
-  redirect_uris?: string[];
-  require_pkce?: boolean;
-  token_endpoint_auth_method?: TokenEndpointAuthMethod;
-};
+const manifestSchema = z
+  .object({
+    realm: z.string().min(1),
+    clients: z.array(clientSpecSchema).min(1),
+  })
+  .strict();
 
-type Manifest = {
-  realm: string;
-  clients: ClientSpec[];
-};
-
-function assertManifest(raw: unknown): asserts raw is Manifest {
-  if (!raw || typeof raw !== 'object') {
-    throw new Error('Manifest must be a JSON object.');
-  }
-  const obj = raw as Record<string, unknown>;
-  if (typeof obj['realm'] !== 'string' || obj['realm'].length === 0) {
-    throw new Error('Manifest.realm must be a non-empty string.');
-  }
-  if (!Array.isArray(obj['clients']) || obj['clients'].length === 0) {
-    throw new Error('Manifest.clients must be a non-empty array.');
-  }
-  for (const [i, c] of obj['clients'].entries()) {
-    if (!c || typeof c !== 'object') {
-      throw new Error(`clients[${i}] is not an object.`);
-    }
-    const spec = c as Record<string, unknown>;
-    if (typeof spec['client_id'] !== 'string' || !spec['client_id']) {
-      throw new Error(`clients[${i}].client_id must be a non-empty string.`);
-    }
-    if (typeof spec['name'] !== 'string' || !spec['name']) {
-      throw new Error(`clients[${i}].name must be a non-empty string.`);
-    }
-    if (
-      !Array.isArray(spec['grant_types']) ||
-      spec['grant_types'].length === 0 ||
-      !spec['grant_types'].every((g) => VALID_GRANT_TYPES.includes(g as GrantType))
-    ) {
-      throw new Error(
-        `clients[${i}].grant_types must be a non-empty subset of ${VALID_GRANT_TYPES.join(', ')}.`
-      );
-    }
-    if (
-      spec['token_endpoint_auth_method'] !== undefined &&
-      !VALID_AUTH_METHODS.includes(spec['token_endpoint_auth_method'] as TokenEndpointAuthMethod)
-    ) {
-      throw new Error(
-        `clients[${i}].token_endpoint_auth_method must be one of ${VALID_AUTH_METHODS.join(', ')}.`
-      );
-    }
-  }
-}
+type ClientSpec = z.infer<typeof clientSpecSchema>;
 
 /* ------------------------------------------------------------------------ */
 /*                                 Helpers                                  */
 /* ------------------------------------------------------------------------ */
 
+// Matches `DEFAULT_PASSWORD_CONFIG` in libs/server/password so hashes verify
+// against the same settings the auth-server uses at runtime.
 const ARGON2_OPTS = { memoryCost: 65536, timeCost: 3, parallelism: 4 } as const;
 
 function generateClientSecret(): string {
@@ -178,6 +118,9 @@ function parseArgs(argv: string[]): { manifestPath: string; rotate: boolean } {
 /*                                   Main                                   */
 /* ------------------------------------------------------------------------ */
 
+type Action = 'created' | 'rotated' | 'skipped';
+type Issued = { clientId: string; secret: string; action: Action };
+
 async function main(): Promise<void> {
   const { manifestPath, rotate } = parseArgs(process.argv);
 
@@ -188,8 +131,7 @@ async function main(): Promise<void> {
   }
 
   const raw: unknown = JSON.parse(readFileSync(manifestPath, 'utf8'));
-  assertManifest(raw);
-  const manifest = raw;
+  const manifest = manifestSchema.parse(raw);
 
   const db = drizzle(databaseUrl);
 
@@ -203,83 +145,141 @@ async function main(): Promise<void> {
       process.exit(1);
     }
 
-    type Issued = { clientId: string; secret: string; action: 'created' | 'rotated' | 'skipped' };
     const issued: Issued[] = [];
-
     for (const spec of manifest.clients) {
-      const [existing] = await db
-        .select({ id: oauthClients.id })
-        .from(oauthClients)
-        .where(and(eq(oauthClients.realmId, realm.id), eq(oauthClients.clientId, spec.client_id)))
-        .limit(1);
-
-      if (existing && !rotate) {
-        issued.push({ clientId: spec.client_id, secret: '', action: 'skipped' });
-        continue;
-      }
-
-      const plaintextSecret = generateClientSecret();
-      const clientSecretHash = await hash(plaintextSecret, ARGON2_OPTS);
-
-      const row = {
-        realmId: realm.id,
-        clientId: spec.client_id,
-        clientSecretHash,
-        name: spec.name,
-        description: spec.description ?? null,
-        redirectUris: spec.redirect_uris ?? [],
-        scopes: spec.scopes ?? [],
-        audience: spec.audience ?? null,
-        requirePkce: spec.require_pkce ?? false,
-        tokenEndpointAuthMethod: spec.token_endpoint_auth_method ?? 'client_secret_basic',
-        grantTypes: spec.grant_types,
-        responseTypes: spec.response_types ?? [],
-        enabled: true,
-      } as const;
-
-      if (existing) {
-        await db.update(oauthClients).set(row).where(eq(oauthClients.id, existing.id));
-        issued.push({ clientId: spec.client_id, secret: plaintextSecret, action: 'rotated' });
-      } else {
-        await db.insert(oauthClients).values(row);
-        issued.push({ clientId: spec.client_id, secret: plaintextSecret, action: 'created' });
-      }
+      issued.push(await provisionClient(db, realm.id, spec, rotate));
     }
 
-    /* ------------------------------ Report ------------------------------ */
-
-    const created = issued.filter((i) => i.action === 'created');
-    const rotated = issued.filter((i) => i.action === 'rotated');
-    const skipped = issued.filter((i) => i.action === 'skipped');
-
-    console.log(
-      `\nSeeded realm "${manifest.realm}": ` +
-        `${created.length} created, ${rotated.length} rotated, ${skipped.length} skipped.\n`
-    );
-
-    if (created.length + rotated.length > 0) {
-      console.log(
-        'Store these plaintext secrets securely — the DB only keeps argon2id hashes.\n' +
-          '  (fingerprint = first 8 chars of sha256(secret), for cross-checking)\n'
-      );
-      for (const i of [...created, ...rotated]) {
-        console.log(`  ${i.clientId}`);
-        console.log(`    secret:      ${i.secret}`);
-        console.log(`    fingerprint: ${fingerprint(i.secret)}`);
-        console.log(`    action:      ${i.action}`);
-      }
-      console.log('');
-    }
-
-    if (skipped.length > 0) {
-      console.log(
-        `Skipped (already exist; pass --rotate to re-issue secrets):\n  ` +
-          skipped.map((s) => s.clientId).join(', ') +
-          '\n'
-      );
-    }
+    report(manifest.realm, issued);
   } finally {
     await db.$client.end();
+  }
+}
+
+/**
+ * Provision a single client. The check-then-act is wrapped in a transaction
+ * so that if two seeder instances ever raced, one would block on the
+ * row-level lock acquired by the other's read (FOR UPDATE semantics are
+ * implicit in an UPDATE under READ COMMITTED on the same row).
+ *
+ * argon2 hashing is deliberately done *inside* the transaction only after
+ * we've decided we need a new hash — so the skip path incurs no CPU cost.
+ */
+async function provisionClient(
+  db: ReturnType<typeof drizzle>,
+  realmId: string,
+  spec: ClientSpec,
+  rotate: boolean
+): Promise<Issued> {
+  return db.transaction(async (tx) => {
+    const [existing] = await tx
+      .select({ id: oauthClients.id })
+      .from(oauthClients)
+      .where(and(eq(oauthClients.realmId, realmId), eq(oauthClients.clientId, spec.client_id)))
+      .limit(1);
+
+    if (existing && !rotate) {
+      return { clientId: spec.client_id, secret: '', action: 'skipped' as const };
+    }
+
+    const plaintextSecret = generateClientSecret();
+    const clientSecretHash = await hash(plaintextSecret, ARGON2_OPTS);
+
+    if (existing) {
+      await tx
+        .update(oauthClients)
+        .set(buildUpdate(spec, clientSecretHash))
+        .where(eq(oauthClients.id, existing.id));
+      return { clientId: spec.client_id, secret: plaintextSecret, action: 'rotated' as const };
+    }
+
+    await tx.insert(oauthClients).values(buildInsert(realmId, spec, clientSecretHash));
+    return { clientId: spec.client_id, secret: plaintextSecret, action: 'created' as const };
+  });
+}
+
+/* ------------------------------------------------------------------------ */
+/*                              Row builders                                */
+/* ------------------------------------------------------------------------ */
+
+/**
+ * Row for a freshly-inserted client. Defaults here mirror the schema column
+ * defaults (require_pkce = true, response_types = ['code']) so a client
+ * created via seed behaves identically to one created via the dev portal.
+ */
+function buildInsert(realmId: string, spec: ClientSpec, clientSecretHash: string) {
+  return {
+    realmId,
+    clientId: spec.client_id,
+    clientSecretHash,
+    name: spec.name,
+    description: spec.description ?? null,
+    redirectUris: spec.redirect_uris ?? [],
+    scopes: spec.scopes ?? [],
+    audience: spec.audience ?? null,
+    requirePkce: spec.require_pkce ?? true,
+    tokenEndpointAuthMethod: spec.token_endpoint_auth_method ?? 'client_secret_basic',
+    grantTypes: spec.grant_types,
+    responseTypes: spec.response_types ?? ['code'],
+    enabled: true,
+  } as const;
+}
+
+/**
+ * Row for a rotation. Deliberately omits `enabled` so Drizzle doesn't emit
+ * it in the SET clause — a client that was manually disabled in the DB
+ * stays disabled after a secret rotation.
+ */
+function buildUpdate(spec: ClientSpec, clientSecretHash: string) {
+  return {
+    clientSecretHash,
+    name: spec.name,
+    description: spec.description ?? null,
+    redirectUris: spec.redirect_uris ?? [],
+    scopes: spec.scopes ?? [],
+    audience: spec.audience ?? null,
+    requirePkce: spec.require_pkce ?? true,
+    tokenEndpointAuthMethod: spec.token_endpoint_auth_method ?? 'client_secret_basic',
+    grantTypes: spec.grant_types,
+    responseTypes: spec.response_types ?? ['code'],
+    updatedAt: sql`(EXTRACT(EPOCH FROM now()) * 1000)::bigint`,
+  } as const;
+}
+
+/* ------------------------------------------------------------------------ */
+/*                                 Report                                   */
+/* ------------------------------------------------------------------------ */
+
+function report(realm: string, issued: Issued[]): void {
+  const created = issued.filter((i) => i.action === 'created');
+  const rotated = issued.filter((i) => i.action === 'rotated');
+  const skipped = issued.filter((i) => i.action === 'skipped');
+
+  console.log(
+    `\nSeeded realm "${realm}": ` +
+      `${created.length} created, ${rotated.length} rotated, ${skipped.length} skipped.\n`
+  );
+
+  if (created.length + rotated.length > 0) {
+    console.log(
+      'Store these plaintext secrets securely — the DB only keeps argon2id hashes.\n' +
+        '  (fingerprint = first 8 chars of sha256(secret), for cross-checking)\n'
+    );
+    for (const i of [...created, ...rotated]) {
+      console.log(`  ${i.clientId}`);
+      console.log(`    secret:      ${i.secret}`);
+      console.log(`    fingerprint: ${fingerprint(i.secret)}`);
+      console.log(`    action:      ${i.action}`);
+    }
+    console.log('');
+  }
+
+  if (skipped.length > 0) {
+    console.log(
+      `Skipped (already exist; pass --rotate to re-issue secrets):\n  ` +
+        skipped.map((s) => s.clientId).join(', ') +
+        '\n'
+    );
   }
 }
 

--- a/libs/infra/db/src/scripts/seed-oauth-clients.ts
+++ b/libs/infra/db/src/scripts/seed-oauth-clients.ts
@@ -65,7 +65,7 @@ const clientSpecSchema = z
     response_types: z.array(responseTypeZ).optional(),
     scopes: z.array(z.string().min(1)).optional(),
     audience: z.array(z.string().min(1)).nullable().optional(),
-    redirect_uris: z.array(z.string().url()).optional(),
+    redirect_uris: z.array(z.url()).optional(),
     require_pkce: z.boolean().optional(),
     token_endpoint_auth_method: tokenEndpointAuthMethodZ.optional(),
   })

--- a/libs/infra/db/src/scripts/seed-oauth-clients.ts
+++ b/libs/infra/db/src/scripts/seed-oauth-clients.ts
@@ -1,0 +1,289 @@
+/**
+ * Idempotent OAuth-client provisioner.
+ *
+ * Reads a JSON manifest and inserts (or, with `--rotate`, updates) OAuth
+ * clients in an existing realm. Plaintext `client_secret` values are
+ * generated per client, printed once to STDOUT, and argon2id-hashed in the
+ * database. Designed for bootstrapping machine (`client_credentials`)
+ * clients outside the developer portal.
+ *
+ * Usage (from the repo root):
+ *
+ *   DATABASE_URL=postgresql://qauth:pw@host:5432/qauth \
+ *     pnpm nx run infra-db:db:seed-oauth-clients -- \
+ *     --manifest=/absolute/path/to/manifest.json [--rotate]
+ *
+ * Or directly:
+ *
+ *   cd libs/infra/db && \
+ *     tsx src/scripts/seed-oauth-clients.ts \
+ *     --manifest=/path/to/manifest.json [--rotate]
+ *
+ * Differences from `seed.ts`:
+ * - `seed.ts` is a dev-fixture generator (uses `drizzle-seed`, calls
+ *   `reset()`, wipes + replants the `realms` + `oauth_clients` tables).
+ *   It's destructive and not safe for production.
+ * - `seed-oauth-clients.ts` is additive and idempotent — existing clients
+ *   are left alone by default, and `--rotate` only touches the listed
+ *   client_ids. Uses plain `drizzle-orm` inserts because `drizzle-seed`'s
+ *   faker-style API is awkward for "insert these exact rows."
+ *
+ * Manifest shape:
+ *
+ *   {
+ *     "realm": "default",
+ *     "clients": [
+ *       {
+ *         "client_id": "example-service",
+ *         "name": "Example Service",
+ *         "description": "A machine client that does things.",
+ *         "grant_types": ["client_credentials"],
+ *         "scopes": ["read:things"],
+ *         "audience": ["https://api.example.com"],
+ *         "redirect_uris": [],
+ *         "response_types": [],
+ *         "require_pkce": false,
+ *         "token_endpoint_auth_method": "client_secret_basic"
+ *       }
+ *     ]
+ *   }
+ *
+ * The target realm must already exist. Create it via migrations or the
+ * default-realm helper before running this.
+ */
+import { createHash, randomBytes } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+
+import { hash } from '@node-rs/argon2';
+import * as dotenv from 'dotenv';
+import { and, eq } from 'drizzle-orm';
+import { drizzle } from 'drizzle-orm/node-postgres';
+
+import { oauthClients, realms } from '../lib/schema';
+import type { GrantType, ResponseType } from '../lib/schema/enums';
+
+dotenv.config({ path: '../../../.env' });
+
+/* ------------------------------------------------------------------------ */
+/*                             Manifest shape                               */
+/* ------------------------------------------------------------------------ */
+
+const VALID_GRANT_TYPES = [
+  'authorization_code',
+  'refresh_token',
+  'client_credentials',
+] as const satisfies readonly GrantType[];
+
+const VALID_AUTH_METHODS = [
+  'client_secret_post',
+  'client_secret_basic',
+  'private_key_jwt',
+  'none',
+] as const;
+type TokenEndpointAuthMethod = (typeof VALID_AUTH_METHODS)[number];
+
+type ClientSpec = {
+  client_id: string;
+  name: string;
+  description?: string;
+  grant_types: GrantType[];
+  response_types?: ResponseType[];
+  scopes?: string[];
+  audience?: string[] | null;
+  redirect_uris?: string[];
+  require_pkce?: boolean;
+  token_endpoint_auth_method?: TokenEndpointAuthMethod;
+};
+
+type Manifest = {
+  realm: string;
+  clients: ClientSpec[];
+};
+
+function assertManifest(raw: unknown): asserts raw is Manifest {
+  if (!raw || typeof raw !== 'object') {
+    throw new Error('Manifest must be a JSON object.');
+  }
+  const obj = raw as Record<string, unknown>;
+  if (typeof obj['realm'] !== 'string' || obj['realm'].length === 0) {
+    throw new Error('Manifest.realm must be a non-empty string.');
+  }
+  if (!Array.isArray(obj['clients']) || obj['clients'].length === 0) {
+    throw new Error('Manifest.clients must be a non-empty array.');
+  }
+  for (const [i, c] of obj['clients'].entries()) {
+    if (!c || typeof c !== 'object') {
+      throw new Error(`clients[${i}] is not an object.`);
+    }
+    const spec = c as Record<string, unknown>;
+    if (typeof spec['client_id'] !== 'string' || !spec['client_id']) {
+      throw new Error(`clients[${i}].client_id must be a non-empty string.`);
+    }
+    if (typeof spec['name'] !== 'string' || !spec['name']) {
+      throw new Error(`clients[${i}].name must be a non-empty string.`);
+    }
+    if (
+      !Array.isArray(spec['grant_types']) ||
+      spec['grant_types'].length === 0 ||
+      !spec['grant_types'].every((g) => VALID_GRANT_TYPES.includes(g as GrantType))
+    ) {
+      throw new Error(
+        `clients[${i}].grant_types must be a non-empty subset of ${VALID_GRANT_TYPES.join(', ')}.`
+      );
+    }
+    if (
+      spec['token_endpoint_auth_method'] !== undefined &&
+      !VALID_AUTH_METHODS.includes(spec['token_endpoint_auth_method'] as TokenEndpointAuthMethod)
+    ) {
+      throw new Error(
+        `clients[${i}].token_endpoint_auth_method must be one of ${VALID_AUTH_METHODS.join(', ')}.`
+      );
+    }
+  }
+}
+
+/* ------------------------------------------------------------------------ */
+/*                                 Helpers                                  */
+/* ------------------------------------------------------------------------ */
+
+const ARGON2_OPTS = { memoryCost: 65536, timeCost: 3, parallelism: 4 } as const;
+
+function generateClientSecret(): string {
+  return randomBytes(32).toString('hex');
+}
+
+function fingerprint(secret: string): string {
+  return createHash('sha256').update(secret).digest('hex').slice(0, 8);
+}
+
+function parseArgs(argv: string[]): { manifestPath: string; rotate: boolean } {
+  const rest = argv.slice(2);
+  const rotate = rest.includes('--rotate');
+  let manifestPath: string | undefined;
+  for (const a of rest) {
+    if (a.startsWith('--manifest=')) manifestPath = a.slice('--manifest='.length);
+    else if (!a.startsWith('--')) manifestPath = a;
+  }
+  if (!manifestPath) {
+    console.error(
+      'Usage: seed-oauth-clients.ts --manifest=<path> [--rotate]\n' +
+        '       Set DATABASE_URL in the environment.'
+    );
+    process.exit(2);
+  }
+  return { manifestPath, rotate };
+}
+
+/* ------------------------------------------------------------------------ */
+/*                                   Main                                   */
+/* ------------------------------------------------------------------------ */
+
+async function main(): Promise<void> {
+  const { manifestPath, rotate } = parseArgs(process.argv);
+
+  const databaseUrl = process.env['DATABASE_URL'];
+  if (!databaseUrl) {
+    console.error('DATABASE_URL must be set in the environment.');
+    process.exit(2);
+  }
+
+  const raw: unknown = JSON.parse(readFileSync(manifestPath, 'utf8'));
+  assertManifest(raw);
+  const manifest = raw;
+
+  const db = drizzle(databaseUrl);
+
+  try {
+    const [realm] = await db.select().from(realms).where(eq(realms.name, manifest.realm)).limit(1);
+    if (!realm) {
+      console.error(
+        `Realm "${manifest.realm}" not found. Create it first (via migrations or the ` +
+          `default-realm helper) before seeding clients.`
+      );
+      process.exit(1);
+    }
+
+    type Issued = { clientId: string; secret: string; action: 'created' | 'rotated' | 'skipped' };
+    const issued: Issued[] = [];
+
+    for (const spec of manifest.clients) {
+      const [existing] = await db
+        .select({ id: oauthClients.id })
+        .from(oauthClients)
+        .where(and(eq(oauthClients.realmId, realm.id), eq(oauthClients.clientId, spec.client_id)))
+        .limit(1);
+
+      if (existing && !rotate) {
+        issued.push({ clientId: spec.client_id, secret: '', action: 'skipped' });
+        continue;
+      }
+
+      const plaintextSecret = generateClientSecret();
+      const clientSecretHash = await hash(plaintextSecret, ARGON2_OPTS);
+
+      const row = {
+        realmId: realm.id,
+        clientId: spec.client_id,
+        clientSecretHash,
+        name: spec.name,
+        description: spec.description ?? null,
+        redirectUris: spec.redirect_uris ?? [],
+        scopes: spec.scopes ?? [],
+        audience: spec.audience ?? null,
+        requirePkce: spec.require_pkce ?? false,
+        tokenEndpointAuthMethod: spec.token_endpoint_auth_method ?? 'client_secret_basic',
+        grantTypes: spec.grant_types,
+        responseTypes: spec.response_types ?? [],
+        enabled: true,
+      } as const;
+
+      if (existing) {
+        await db.update(oauthClients).set(row).where(eq(oauthClients.id, existing.id));
+        issued.push({ clientId: spec.client_id, secret: plaintextSecret, action: 'rotated' });
+      } else {
+        await db.insert(oauthClients).values(row);
+        issued.push({ clientId: spec.client_id, secret: plaintextSecret, action: 'created' });
+      }
+    }
+
+    /* ------------------------------ Report ------------------------------ */
+
+    const created = issued.filter((i) => i.action === 'created');
+    const rotated = issued.filter((i) => i.action === 'rotated');
+    const skipped = issued.filter((i) => i.action === 'skipped');
+
+    console.log(
+      `\nSeeded realm "${manifest.realm}": ` +
+        `${created.length} created, ${rotated.length} rotated, ${skipped.length} skipped.\n`
+    );
+
+    if (created.length + rotated.length > 0) {
+      console.log(
+        'Store these plaintext secrets securely — the DB only keeps argon2id hashes.\n' +
+          '  (fingerprint = first 8 chars of sha256(secret), for cross-checking)\n'
+      );
+      for (const i of [...created, ...rotated]) {
+        console.log(`  ${i.clientId}`);
+        console.log(`    secret:      ${i.secret}`);
+        console.log(`    fingerprint: ${fingerprint(i.secret)}`);
+        console.log(`    action:      ${i.action}`);
+      }
+      console.log('');
+    }
+
+    if (skipped.length > 0) {
+      console.log(
+        `Skipped (already exist; pass --rotate to re-issue secrets):\n  ` +
+          skipped.map((s) => s.clientId).join(', ') +
+          '\n'
+      );
+    }
+  } finally {
+    await db.$client.end();
+  }
+}
+
+main().catch((err) => {
+  console.error(err instanceof Error ? (err.stack ?? err.message) : err);
+  process.exit(1);
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -626,6 +626,9 @@ importers:
       pg:
         specifier: 'catalog:'
         version: 8.16.3
+      zod:
+        specifier: 'catalog:'
+        version: 4.2.1
     devDependencies:
       '@types/pg':
         specifier: 'catalog:'
@@ -2564,24 +2567,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@node-rs/argon2-linux-arm64-musl@2.0.2':
     resolution: {integrity: sha512-p3YqVMNT/4DNR67tIHTYGbedYmXxW9QlFmF39SkXyEbGQwpgSf6pH457/fyXBIYznTU/smnG9EH+C1uzT5j4hA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@node-rs/argon2-linux-x64-gnu@2.0.2':
     resolution: {integrity: sha512-ZM3jrHuJ0dKOhvA80gKJqBpBRmTJTFSo2+xVZR+phQcbAKRlDMSZMFDiKbSTnctkfwNFtjgDdh5g1vaEV04AvA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@node-rs/argon2-linux-x64-musl@2.0.2':
     resolution: {integrity: sha512-of5uPqk7oCRF/44a89YlWTEfjsftPywyTULwuFDKyD8QtVZoonrJR6ZWvfFE/6jBT68S0okAkAzzMEdBVWdxWw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@node-rs/argon2-wasm32-wasi@2.0.2':
     resolution: {integrity: sha512-U3PzLYKSQYzTERstgtHLd4ZTkOF9co57zTXT77r0cVUsleGZOrd6ut7rHzeWwoJSiHOVxxa0OhG1JVQeB7lLoQ==}
@@ -2727,41 +2734,49 @@ packages:
     resolution: {integrity: sha512-NmPeCexWIZHW9RM3lDdFENN9C3WtlQ5L4RSNFESIjreS921rgePhulsszYdGnHdcnKPYlBBJnX/NxVsfioBbnQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@nx/nx-linux-arm64-gnu@22.5.4':
     resolution: {integrity: sha512-mPji9PzleWPvXpmFDKaXpTymRgZkk/hW8JHGhvEZpKHHXMYgTGWC+BqOEM2A4dYC4bu4fi9RrteL7aouRRWJoQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@nx/nx-linux-arm64-musl@22.3.3':
     resolution: {integrity: sha512-K02U88Q0dpvCfmSXXvY7KbYQSa1m+mkYeqDBRHp11yHk1GoIqaHp8oEWda7FV4gsriNExPSS5tX1/QGVoLZrCw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@nx/nx-linux-arm64-musl@22.5.4':
     resolution: {integrity: sha512-hF/HvEhbCjcFpTgY7RbP1tUTbp0M1adZq4ckyW8mwhDWQ/MDsc8FnOHwCO3Bzy9ZeJM0zQUES6/m0Onz8geaEA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@nx/nx-linux-x64-gnu@22.3.3':
     resolution: {integrity: sha512-04TEbvgwRaB9ifr39YwJmWh3RuXb4Ry4m84SOJyjNXAfPrepcWgfIQn1VL2ul1Ybq+P023dLO9ME8uqFh6j1YQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@nx/nx-linux-x64-gnu@22.5.4':
     resolution: {integrity: sha512-1+vicSYEOtc7CNMoRCjo59no4gFe8w2nGIT127wk1yeW3EJzRVNlOA7Deu10NUUbzLeOvHc8EFOaU7clT+F7XQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@nx/nx-linux-x64-musl@22.3.3':
     resolution: {integrity: sha512-uxBXx5q+S5OGatbYDxnamsKXRKlYn+Eq1nrCAHaf8rIfRoHlDiRV2PqtWuF+O2pxR5FWKpvr+/sZtt9rAf7KMw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@nx/nx-linux-x64-musl@22.5.4':
     resolution: {integrity: sha512-/KjndxVB14yU0SJOhqADHOWoTy4Y45h5RjW3cxcXlPSJZz7ar1FnlLne1rWMMMUttepc8ku+3T//SGKi2eu+Nw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@nx/nx-win32-arm64-msvc@22.3.3':
     resolution: {integrity: sha512-aOwlfD6ZA1K6hjZtbhBSp7s1yi3sHbMpLCa4stXzfhCCpKUv46HU/EdiWdE1N8AsyNFemPZFq81k1VTowcACdg==}
@@ -2870,41 +2885,49 @@ packages:
     resolution: {integrity: sha512-xlMh4gNtplNQEwuF5icm69udC7un0WyzT5ywOeHrPMEsghKnLjXok2wZgAA7ocTm9+JsI+nVXIQa5XO1x+HPQg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-arm64-musl@11.16.2':
     resolution: {integrity: sha512-OZs33QTMi0xmHv/4P0+RAKXJTBk7UcMH5tpTaCytWRXls/DGaJ48jOHmriQGK2YwUqXl+oneuNyPOUO0obJ+Hg==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-linux-ppc64-gnu@11.16.2':
     resolution: {integrity: sha512-UVyuhaV32dJGtF6fDofOcBstg9JwB2Jfnjfb8jGlu3xcG+TsubHRhuTwQ6JZ1sColNT1nMxBiu7zdKUEZi1kwg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-gnu@11.16.2':
     resolution: {integrity: sha512-YZZS0yv2q5nE1uL/Fk4Y7m9018DSEmDNSG8oJzy1TJjA1jx5HL52hEPxi98XhU6OYhSO/vC1jdkJeE8TIHugug==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-musl@11.16.2':
     resolution: {integrity: sha512-9VYuypwtx4kt1lUcwJAH4dPmgJySh4/KxtAPdRoX2BTaZxVm/yEXHq0mnl/8SEarjzMvXKbf7Cm6UBgptm3DZw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-linux-s390x-gnu@11.16.2':
     resolution: {integrity: sha512-3gbwQ+xlL5gpyzgSDdC8B4qIM4mZaPDLaFOi3c/GV7CqIdVJc5EZXW4V3T6xwtPBOpXPXfqQLbhTnUD4SqwJtA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-gnu@11.16.2':
     resolution: {integrity: sha512-m0WcK0j54tSwWa+hQaJMScZdWneqE7xixp/vpFqlkbhuKW9dRHykPAFvSYg1YJ3MJgu9ZzVNpYHhPKJiEQq57Q==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-musl@11.16.2':
     resolution: {integrity: sha512-ZjUm3w96P2t47nWywGwj1A2mAVBI/8IoS7XHhcogWCfXnEI3M6NPIRQPYAZW4s5/u3u6w1uPtgOwffj2XIOb/g==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-openharmony-arm64@11.16.2':
     resolution: {integrity: sha512-OFVQ2x3VenTp13nIl6HcQ/7dmhFmM9dg2EjKfHcOtYfrVLQdNR6THFU7GkMdmc8DdY1zLUeilHwBIsyxv5hkwQ==}
@@ -3232,66 +3255,79 @@ packages:
     resolution: {integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.59.0':
     resolution: {integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.59.0':
     resolution: {integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.59.0':
     resolution: {integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.59.0':
     resolution: {integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.59.0':
     resolution: {integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.59.0':
     resolution: {integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.59.0':
     resolution: {integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.59.0':
     resolution: {integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.59.0':
     resolution: {integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.59.0':
     resolution: {integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.59.0':
     resolution: {integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.59.0':
     resolution: {integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.59.0':
     resolution: {integrity: sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==}
@@ -3337,21 +3373,25 @@ packages:
     resolution: {integrity: sha512-fvZX6xZPvBT8qipSpvkKMX5M7yd2BSpZNCZXcefw6gA3uC7LI3gu+er0LrDXY1PtPzVuHTyDx+abwWpagV3PiQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rspack/binding-linux-arm64-musl@1.6.8':
     resolution: {integrity: sha512-++XMKcMNrt59HcFBLnRaJcn70k3X0GwkAegZBVpel8xYIAgvoXT5+L8P1ExId/yTFxqedaz8DbcxQnNmMozviw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rspack/binding-linux-x64-gnu@1.6.8':
     resolution: {integrity: sha512-tv3BWkTE1TndfX+DsE1rSTg8fBevCxujNZ3MlfZ22Wfy9x1FMXTJlWG8VIOXmaaJ1wUHzv8S7cE2YUUJ2LuiCg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rspack/binding-linux-x64-musl@1.6.8':
     resolution: {integrity: sha512-DCGgZ5/in1O3FjHWqXnDsncRy+48cMhfuUAAUyl0yDj1NpsZu9pP+xfGLvGcQTiYrVl7IH9Aojf1eShP/77WGA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rspack/binding-wasm32-wasi@1.6.8':
     resolution: {integrity: sha512-VUwdhl/lI4m6o1OGCZ9JwtMjTV/yLY5VZTQdEPKb40JMTlmZ5MBlr5xk7ByaXXYHr6I+qnqEm73iMKQvg6iknw==}
@@ -3525,24 +3565,28 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.15.18':
     resolution: {integrity: sha512-0a+Lix+FSSHBSBOA0XznCcHo5/1nA6oLLjcnocvzXeqtdjnPb+SvchItHI+lfeiuj1sClYPDvPMLSLyXFaiIKw==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-linux-x64-gnu@1.15.18':
     resolution: {integrity: sha512-wG9J8vReUlpaHz4KOD/5UE1AUgirimU4UFT9oZmupUDEofxJKYb1mTA/DrMj0s78bkBiNI+7Fo2EgPuvOJfuAA==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.15.18':
     resolution: {integrity: sha512-4nwbVvCphKzicwNWRmvD5iBaZj8JYsRGa4xOxJmOyHlMDpsvvJ2OR2cODlvWyGFH6BYL1MfIAK3qph3hp0Az6g==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.15.18':
     resolution: {integrity: sha512-zk0RYO+LjiBCat2RTMHzAWaMky0cra9loH4oRrLKLLNuL+jarxKLFDA8xTZWEkCPLjUTwlRN7d28eDLLMgtUcQ==}
@@ -3618,24 +3662,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.1':
     resolution: {integrity: sha512-WZA0CHRL/SP1TRbA5mp9htsppSEkWuQ4KsSUumYQnyl8ZdT39ntwqmz4IUHGN6p4XdSlYfJwM4rRzZLShHsGAQ==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.1':
     resolution: {integrity: sha512-qMFzxI2YlBOLW5PhblzuSWlWfwLHaneBE0xHzLrBgNtqN6mWfs+qYbhryGSXQjFYB1Dzf5w+LN5qbUTPhW7Y5g==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.1':
     resolution: {integrity: sha512-5r1X2FKnCMUPlXTWRYpHdPYUY6a1Ar/t7P24OuiEdEOmms5lyqjDRvVY1yy9Rmioh+AunQ0rWiOTPE8F9A3v5g==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.1':
     resolution: {integrity: sha512-MGFB5cVPvshR85MTJkEvqDUnuNoysrsRxd6vnk1Lf2tbiqNlXpHYZqkqOQalydienEWOHHFyyuTSYRsLfxFJ2Q==}
@@ -3985,41 +4033,49 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -6386,24 +6442,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.31.1:
     resolution: {integrity: sha512-mVZ7Pg2zIbe3XlNbZJdjs86YViQFoJSpc41CbVmKBPiGmC4YrfeOyz65ms2qpAobVd7WQsbW4PdsSJEMymyIMg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.31.1:
     resolution: {integrity: sha512-xGlFWRMl+0KvUhgySdIaReQdB4FNudfUTARn7q0hh/V67PVGCs3ADFjw+6++kG1RNd0zdGRlEKa+T13/tQjPMA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.31.1:
     resolution: {integrity: sha512-eowF8PrKHw9LpoZii5tdZwnBcYDxRw2rRCyvAXLi34iyeYfqCQNA9rmUM0ce62NlPhCvof1+9ivRaTY6pSKDaA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.31.1:
     resolution: {integrity: sha512-aJReEbSEQzx1uBlQizAOBSjcmr9dCdL3XuC/6HLXAxmtErsj2ICo5yYggg1qOODQMtnjNQv2UHb9NpOuFtYe4w==}


### PR DESCRIPTION
## Summary

Adds a production-safe OAuth-client seed script for bootstrapping machine (\`client_credentials\`) clients into an existing realm without going through the developer portal.

- \`libs/infra/db/src/scripts/seed-oauth-clients.ts\` — reads a JSON manifest, generates 32-byte client secrets, argon2id-hashes them (matching \`DEFAULT_PASSWORD_CONFIG\` from \`@qauth-labs/server-password\` so runtime verifies cleanly), and inserts via plain drizzle-orm.
- Idempotent: existing \`client_id\`s are skipped unless \`--rotate\` is passed. \`--rotate\` re-issues the secret and overwrites metadata for the listed clients only.
- Plaintext secrets printed once to STDOUT alongside an 8-char sha256 fingerprint. The DB only keeps argon2id hashes.
- New Nx target \`infra-db:db:seed-oauth-clients\` follows the same pattern as the existing \`db:seed\` dev-fixture target.

Differences from the existing \`libs/infra/db/src/scripts/seed.ts\`:
- \`seed.ts\` is destructive (calls \`reset()\`, wipes + replants \`realms\` + \`oauth_clients\`). Fine for dev; not safe for prod.
- \`seed-oauth-clients.ts\` is additive. Deliberately uses plain drizzle-orm rather than \`drizzle-seed\` — drizzle-seed's faker-style refine API is optimised for \"insert N rows with realistic-looking data,\" not \"insert these exact rows with these exact scopes and audiences.\"

## Usage

\`\`\`bash
DATABASE_URL=postgresql://qauth:pw@host:5432/qauth \\
  pnpm nx run infra-db:db:seed-oauth-clients -- \\
  --manifest=/path/to/manifest.json [--rotate]
\`\`\`

Manifest shape is documented in the file header.

## Test plan

- [x] \`pnpm nx run-many -t typecheck test build lint --skip-nx-cache\` — all 20 projects pass
- [x] Usage error when no \`--manifest\` given
- [x] Zod-style manifest validation surfaces field-specific errors (bad \`grant_types\` rejected)
- [ ] Live smoke: seed 1 client, run again (skip), \`--rotate\` (update), introspect an issued JWT

Depends on #141 (merged): the new \`audience\` column on \`oauth_clients\`.