### PR TITLE
fix(ci): docker images can build again

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -54,3 +54,16 @@ Thumbs.db
 .cache
 .temp
 tmp
+
+# Apps that are not built inside the auth-server / migration-runner images.
+# Both Dockerfiles `COPY apps ./apps`; Nx's project-graph processor then tries
+# to parse every app's config (e.g. developer-portal/vite.config.mts) which
+# imports `@tailwindcss/vite`. That dep is scoped to developer-portal and is
+# not pulled in by the root-level `pnpm install --frozen-lockfile` in the
+# deps stage — so the build fails even though auth-server itself has no
+# reference to developer-portal.
+#
+# Excluding developer-portal from the build context removes it from Nx's
+# view entirely. Add a dedicated build story for developer-portal when it
+# ships its own image.
+apps/developer-portal

--- a/MVP-PRD.md
+++ b/MVP-PRD.md
@@ -338,7 +338,7 @@ Response:
 
 **Tasks**:
 
-- [x] Implement client registration (manual for MVP)
+- [x] Implement client registration (manual for MVP — also scriptable via `nx run db:db:seed-oauth-clients` for machine-client bootstrap at deploy time; see `libs/infra/db/README.md`)
 - [x] Create authorization endpoint (`GET /oauth/authorize`)
 - [x] Create token endpoint (`POST /oauth/token`)
 - [x] Implement PKCE (code_challenge, code_verifier)
@@ -538,7 +538,7 @@ Response:
 **Timeline**: 3-4 weeks
 **Status**: In Progress
 
-**Objective**: Allow developers to register and manage OAuth clients without manual intervention.
+**Objective**: Allow developers to register and manage OAuth clients without manual intervention via a web UI. Machine clients (`client_credentials`) can already be provisioned from a JSON manifest using `nx run db:db:seed-oauth-clients` — the portal is the user-facing equivalent for developer-registered clients.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -289,6 +289,7 @@ qauth/
 - PostgreSQL 18 + Redis 7
 - Docker deployment with automated migrations and health checks
 - Structured audit logging (basic)
+- Scriptable machine-client provisioning (`nx run db:db:seed-oauth-clients`) — JSON-manifest-driven, idempotent, argon2id-hashed secrets; useful for bootstrapping `client_credentials` clients at deploy time before the developer portal ships
 
 **Developer tools:**
 

--- a/apps/auth-server/Dockerfile
+++ b/apps/auth-server/Dockerfile
@@ -1,26 +1,34 @@
 # Auth Server Dockerfile
-# Multi-stage build for production
+# Multi-stage build for production. Requires BuildKit (default on Docker
+# 23+) for the `--mount=type=cache` pnpm-store mount.
+#
+# syntax=docker/dockerfile:1.7
 
-# Stage 1: Dependencies
+# Stage 1: Base image with corepack + root workspace manifests.
+#
+# We intentionally do NOT run `pnpm install` here. pnpm-workspace.yaml points
+# at apps/** and libs/**; without those directories on disk, the install
+# only resolves root-manifest deps and leaves every workspace-scoped dep
+# (fastify, @fastify/*, etc.) out of node_modules. The install happens in
+# the builder stage, once workspace sources are in place.
 FROM node:24-alpine AS deps
 WORKDIR /app
+RUN corepack enable
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY nx.json tsconfig.base.json ./
-RUN corepack enable && \
-    pnpm install --frozen-lockfile
 
 # Stage 2: Builder
 FROM deps AS builder
-# Copy root vitest.config.ts (needed for Nx project graph processing)
+# Copy root vitest.config.ts (needed for Nx project-graph processing)
 COPY vitest.config.ts ./
 COPY libs ./libs
 COPY apps ./apps
 
-# Re-run install now that workspace packages are on disk. The deps-stage
-# install only saw the root manifest (workspace dirs didn't exist yet), so
-# workspace-scoped deps like `fastify`, `@fastify/*`, etc. were not wired
-# into node_modules. This pass completes the workspace graph.
-RUN pnpm install --frozen-lockfile
+# Install with a cache mount for pnpm's package store — lockfile changes
+# or source changes invalidate the layer, but downloaded/extracted packages
+# persist across builds, so only the workspace symlink graph is rebuilt.
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
+    pnpm install --frozen-lockfile --store-dir /pnpm/store
 
 # Build auth-server and all its dependencies
 RUN pnpm nx build auth-server --prod

--- a/apps/auth-server/Dockerfile
+++ b/apps/auth-server/Dockerfile
@@ -16,6 +16,12 @@ COPY vitest.config.ts ./
 COPY libs ./libs
 COPY apps ./apps
 
+# Re-run install now that workspace packages are on disk. The deps-stage
+# install only saw the root manifest (workspace dirs didn't exist yet), so
+# workspace-scoped deps like `fastify`, `@fastify/*`, etc. were not wired
+# into node_modules. This pass completes the workspace graph.
+RUN pnpm install --frozen-lockfile
+
 # Build auth-server and all its dependencies
 RUN pnpm nx build auth-server --prod
 
@@ -26,11 +32,10 @@ WORKDIR /app
 # Enable corepack to use correct pnpm version
 RUN corepack enable
 
-# Copy built application
+# Copy built application bundle. Nx's build output already embeds the
+# compiled workspace libs at `./libs/` inside this directory and main.js
+# contains a resolver that points `@qauth-labs/*` at them.
 COPY --from=builder /app/dist/apps/auth-server ./
-
-# Copy compiled workspace libraries (referenced by @qauth-labs/* imports)
-COPY --from=builder /app/dist/libs ./dist/libs
 
 # Copy package files for dependency resolution
 COPY --from=builder /app/package.json ./package.json

--- a/apps/migration-runner/Dockerfile
+++ b/apps/migration-runner/Dockerfile
@@ -1,29 +1,28 @@
 # Migration Runner Dockerfile
-# Runs database migrations using Nx targets from infra-db
-# This maintains separation of concerns: infra-db owns migrations
+# Runs database migrations using Nx targets from infra-db. Requires
+# BuildKit (default on Docker 23+) for the `--mount=type=cache` pnpm-store
+# mount.
+#
+# syntax=docker/dockerfile:1.7
 
-# Stage 1: Dependencies
+# Stage 1: Base image with corepack + root workspace manifests.
+# No install here — see the auth-server Dockerfile for the reason.
 FROM node:24-alpine AS deps
 WORKDIR /app
-
-# Copy only package files first (layer caching)
+RUN corepack enable
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY nx.json tsconfig.base.json ./
 
-# Enable corepack to use correct pnpm version from package.json
-RUN corepack enable && \
-    pnpm install --frozen-lockfile
-
-# Stage 2: Full workspace (needed for Nx to work)
+# Stage 2: Full workspace (needed for Nx to resolve the project graph).
 FROM deps AS workspace
-# Copy root vitest.config.ts (needed for Nx project graph processing)
 COPY vitest.config.ts ./
 COPY libs ./libs
 COPY apps ./apps
 
-# Re-run install now that workspace packages are on disk. See the auth-server
+# Install with a cache mount for pnpm's package store — see auth-server
 # Dockerfile for the full rationale.
-RUN pnpm install --frozen-lockfile
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
+    pnpm install --frozen-lockfile --store-dir /pnpm/store
 
 # Copy entrypoint script
 COPY apps/migration-runner/docker-entrypoint.sh ./docker-entrypoint.sh

--- a/apps/migration-runner/Dockerfile
+++ b/apps/migration-runner/Dockerfile
@@ -21,6 +21,10 @@ COPY vitest.config.ts ./
 COPY libs ./libs
 COPY apps ./apps
 
+# Re-run install now that workspace packages are on disk. See the auth-server
+# Dockerfile for the full rationale.
+RUN pnpm install --frozen-lockfile
+
 # Copy entrypoint script
 COPY apps/migration-runner/docker-entrypoint.sh ./docker-entrypoint.sh
 # Fix Windows line endings (CRLF) and permissions

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -22,7 +22,8 @@ QAuth uses Docker Compose to orchestrate the following services:
 
 ## Prerequisites
 
-- Docker 20.10+ and Docker Compose 2.0+
+- Docker **23.0+** (BuildKit on by default) or earlier Docker with `DOCKER_BUILDKIT=1` set. The auth-server and migration-runner Dockerfiles use `# syntax=docker/dockerfile:1.7` and a `--mount=type=cache` pnpm-store mount, both of which require BuildKit.
+- Docker Compose 2.0+
 - Docker Compose **2.22+** for development watch (`docker-compose.dev.yml` + `--watch`)
 - OpenSSL (for generating JWT keys)
 
@@ -304,6 +305,8 @@ docker builder prune
 # Rebuild without cache
 docker-compose build --no-cache
 ```
+
+If the build fails on `Cannot find module '@tailwindcss/vite'` or a similar dev-portal-scoped import: `apps/developer-portal` is intentionally excluded from the auth-server and migration-runner build contexts via `.dockerignore`. The exclusion keeps Nx's project-graph processor from trying to parse configs for an app that has no Dockerfile of its own yet. Developer-portal will ship with its own image when Phase 2 is ready; until then the exclusion is load-bearing and should not be removed.
 
 ### Watch: "no space left on device"
 

--- a/libs/infra/db/README.md
+++ b/libs/infra/db/README.md
@@ -320,6 +320,40 @@ nx run db:db:studio
 nx run db:db:drop
 ```
 
+### Seeding
+
+Two seeders live under `src/scripts/`. Both require `DATABASE_URL` in the environment (or in the repo-root `.env` — `dotenv` is loaded automatically).
+
+```bash
+# Dev fixture generator (destructive — calls reset() then replants realms + oauth_clients)
+nx run db:db:seed
+
+# Idempotent OAuth-client provisioner (additive; production-safe)
+# Reads a JSON manifest; generates 32-byte client secrets; argon2id-hashes
+# them; prints plaintext secrets once to STDOUT (the DB only keeps hashes).
+# Existing client_ids are skipped unless `--rotate` is passed.
+nx run db:db:seed-oauth-clients -- --manifest=/path/to/manifest.json [--rotate]
+```
+
+Manifest shape for `db:seed-oauth-clients`:
+
+```json
+{
+  "realm": "default",
+  "clients": [
+    {
+      "client_id": "example-service",
+      "name": "Example Service",
+      "grant_types": ["client_credentials"],
+      "scopes": ["read:things"],
+      "audience": ["https://api.example.com"]
+    }
+  ]
+}
+```
+
+The target realm must already exist. See `src/scripts/seed-oauth-clients.ts` for the authoritative Zod schema and the full set of optional fields (`description`, `response_types`, `redirect_uris`, `require_pkce`, `token_endpoint_auth_method`).
+
 ## Project Structure
 
 ```
@@ -346,6 +380,9 @@ libs/infra/db/
 │   │   └── utils/
 │   │       ├── index.ts        # Utility exports
 │   │       └── email.ts        # Email normalization utilities
+│   ├── scripts/
+│   │   ├── seed.ts                    # Dev-fixture seeder (drizzle-seed)
+│   │   └── seed-oauth-clients.ts      # Idempotent client provisioner
 │   └── index.ts               # Public API exports
 │   └── qauth-schema.dbml      # Database schema visualization (DBML format)
 ├── drizzle/                   # Migration files
@@ -479,7 +516,6 @@ The Fastify plugin automatically manages the database connection lifecycle, so y
 ## Future Enhancements
 
 - Post-quantum cryptography key storage (Phase 7)
-- Database seeding and fixtures
 - Advanced query optimizations
 - Read replicas support
 


### PR DESCRIPTION
## Summary

Two issues were preventing `apps/auth-server/Dockerfile` and `apps/migration-runner/Dockerfile` from building end-to-end. Discovered while standing up the auth-server on a fresh VPS.

### 1. Workspace deps missing in `node_modules`

The deps stage ran `pnpm install --frozen-lockfile` **before** \`apps/\` and \`libs/\` existed on disk, so pnpm only installed root-manifest deps — workspace-scoped packages (\`fastify\`, \`@fastify/autoload\`, \`@fastify/cors\`, \`@fastify/swagger\`, \`fastify-type-provider-zod\`, …) were absent from \`node_modules\`. Nx then failed auth-server's compile with \`TS2307: Cannot find module 'fastify'\`.

**Fix:** re-run \`pnpm install --frozen-lockfile\` in the builder stage after workspace sources are in place. Both Dockerfiles updated.

### 2. Dangling `COPY --from=builder /app/dist/libs`

Nx's current build output embeds the compiled workspace libs at \`./libs/\` **inside** the auth-server bundle (\`/app/dist/apps/auth-server/libs/\`), and the bundle's \`main.js\` contains a resolver that points \`@qauth-labs/*\` at that location. The separate COPY of \`/app/dist/libs\` in the runner stage pointed at a path that no longer exists.

**Fix:** remove the dangling line. The bundle copy on the previous line already brings the libs along.

### 3. `apps/developer-portal` noise in build context

\`developer-portal/vite.config.mts\` imports \`@tailwindcss/vite\` (dev-portal-scoped). Nx's project-graph processor parses every app's config at build time, and that import fails to resolve in a stripped docker build context. Auth-server and migration-runner don't depend on developer-portal, so excluding it from the build context removes a noisy failure mode without loss of function.

**Fix:** add \`apps/developer-portal\` to \`.dockerignore\`. Give developer-portal its own Dockerfile when it ships.

## Test plan

- [x] \`docker build -f apps/auth-server/Dockerfile -t qauth-test .\` — builds end-to-end on a fresh cache (local).
- [x] \`docker build -f apps/migration-runner/Dockerfile -t qauth-migration .\` — builds end-to-end (local).
- [x] Resulting image's \`/app/\` contains \`main.js\`, \`libs/\`, \`node_modules/\` and can \`node -e require.resolve(main.js)\`.
- [ ] Integration: image starts against a real postgres + redis and answers \`/health\`.