### PR TITLE
fix(ci): auth-server image uses pnpm deploy + tsx

### DIFF
--- a/apps/auth-server/Dockerfile
+++ b/apps/auth-server/Dockerfile
@@ -49,19 +49,27 @@ WORKDIR /app
 # node_modules stays tight to the app's own runtime deps.
 RUN npm install --global tsx@4
 
+# Create the non-root user up-front so the subsequent COPY --chown can
+# reference it. Chowning at COPY time avoids a trailing `chown -R /app`
+# pass, which would otherwise rewrite the entire ~450MB deploy layer.
+RUN addgroup -g 1001 -S nodejs && \
+    adduser -S nodejs -u 1001
+
 # Copy the self-contained deploy.
-COPY --from=builder /deploy ./
+COPY --from=builder --chown=nodejs:nodejs /deploy ./
 
 # Entrypoint: tsx on auth-server's TS entry. Since this is a deploy bundle,
 # workspace packages live as real copies under ./node_modules/@qauth-labs/
 # and external deps under ./node_modules/ — Node's normal resolution finds
 # both without any custom resolver or generated manifest.
-COPY apps/auth-server/docker-entrypoint.sh ./docker-entrypoint.sh
-RUN sed -i 's/\r$//' ./docker-entrypoint.sh && chmod +x ./docker-entrypoint.sh
+COPY --chown=nodejs:nodejs apps/auth-server/docker-entrypoint.sh ./docker-entrypoint.sh
+# BusyBox `sed -i` writes a temp file and renames it, which resets the
+# file's ownership to root; re-chown the single file back to nodejs so
+# USER nodejs can exec it cleanly. (Per-file chown, not -R — cheap.)
+RUN sed -i 's/\r$//' ./docker-entrypoint.sh && \
+    chmod +x ./docker-entrypoint.sh && \
+    chown nodejs:nodejs ./docker-entrypoint.sh
 
-RUN addgroup -g 1001 -S nodejs && \
-    adduser -S nodejs -u 1001 && \
-    chown -R nodejs:nodejs /app
 USER nodejs
 
 EXPOSE 3000

--- a/apps/auth-server/Dockerfile
+++ b/apps/auth-server/Dockerfile
@@ -1,77 +1,71 @@
-# Auth Server Dockerfile
-# Multi-stage build for production. Requires BuildKit (default on Docker
-# 23+) for the `--mount=type=cache` pnpm-store mount.
+# Auth Server Dockerfile — production image.
+#
+# Strategy: `pnpm deploy` for a self-contained tree, then run TypeScript
+# sources under tsx at startup.
+#
+# An earlier iteration of this Dockerfile tried to ship the Nx esbuild
+# prod bundle. That path hit a chain of mismatches — pnpm's no-hoist
+# layout scattered deps, Nx emitted `package.js` where Node expected
+# `package.json`, the custom main.js resolver's manifest was empty, and
+# transitive workspace deps couldn't be resolved via file-system lookups.
+# pnpm-deploy-plus-tsx is substantially simpler and idiomatic for pnpm
+# workspaces. If we later want a bundled image, the right fix is in
+# qauth's Nx config (populating the main.js manifest), not here.
+#
+# Requires BuildKit (default on Docker 23+) for the `--mount=type=cache`
+# pnpm-store mount.
 #
 # syntax=docker/dockerfile:1.7
 
-# Stage 1: Base image with corepack + root workspace manifests.
-#
-# We intentionally do NOT run `pnpm install` here. pnpm-workspace.yaml points
-# at apps/** and libs/**; without those directories on disk, the install
-# only resolves root-manifest deps and leaves every workspace-scoped dep
-# (fastify, @fastify/*, etc.) out of node_modules. The install happens in
-# the builder stage, once workspace sources are in place.
-FROM node:24-alpine AS deps
+# Stage 1: Workspace + install.
+FROM node:24-alpine AS builder
 WORKDIR /app
 RUN corepack enable
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY nx.json tsconfig.base.json ./
-
-# Stage 2: Builder
-FROM deps AS builder
-# Copy root vitest.config.ts (needed for Nx project-graph processing)
 COPY vitest.config.ts ./
 COPY libs ./libs
 COPY apps ./apps
 
-# Install with a cache mount for pnpm's package store — lockfile changes
-# or source changes invalidate the layer, but downloaded/extracted packages
-# persist across builds, so only the workspace symlink graph is rebuilt.
+# Install with a cache mount for pnpm's package store.
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
     pnpm install --frozen-lockfile --store-dir /pnpm/store
 
-# Build auth-server and all its dependencies
-RUN pnpm nx build auth-server --prod
+# Produce a self-contained deploy bundle at /deploy containing:
+#   - apps/auth-server's full source
+#   - all workspace deps (real copies, not symlinks) under node_modules/@qauth-labs/
+#   - all external prod deps under node_modules/
+# We keep devDeps out via --prod.
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
+    pnpm --filter @qauth-labs/auth-server deploy --prod --legacy \
+    --store-dir /pnpm/store /deploy
 
-# Stage 3: Runner (minimal production image)
+# Stage 2: Runner.
 FROM node:24-alpine AS runner
 WORKDIR /app
 
-# Enable corepack to use correct pnpm version
-RUN corepack enable
+# tsx is a lightweight TypeScript runner (zero config) that we use as
+# the production entrypoint. Kept global so the deployed bundle's
+# node_modules stays tight to the app's own runtime deps.
+RUN npm install --global tsx@4
 
-# Copy built application bundle. Nx's build output already embeds the
-# compiled workspace libs at `./libs/` inside this directory and main.js
-# contains a resolver that points `@qauth-labs/*` at them.
-COPY --from=builder /app/dist/apps/auth-server ./
+# Copy the self-contained deploy.
+COPY --from=builder /deploy ./
 
-# Copy package files for dependency resolution
-COPY --from=builder /app/package.json ./package.json
-COPY --from=builder /app/pnpm-lock.yaml ./pnpm-lock.yaml
-COPY --from=builder /app/pnpm-workspace.yaml ./pnpm-workspace.yaml
-
-# Copy node_modules (includes workspace dependencies)
-# This is the simplest approach for monorepo - can be optimized later
-COPY --from=builder /app/node_modules ./node_modules
-
-# Copy entrypoint script
+# Entrypoint: tsx on auth-server's TS entry. Since this is a deploy bundle,
+# workspace packages live as real copies under ./node_modules/@qauth-labs/
+# and external deps under ./node_modules/ — Node's normal resolution finds
+# both without any custom resolver or generated manifest.
 COPY apps/auth-server/docker-entrypoint.sh ./docker-entrypoint.sh
-# Fix Windows line endings (CRLF) and permissions
-RUN sed -i 's/\r$//' ./docker-entrypoint.sh && \
-    chmod +x ./docker-entrypoint.sh
+RUN sed -i 's/\r$//' ./docker-entrypoint.sh && chmod +x ./docker-entrypoint.sh
 
-# Create non-root user
 RUN addgroup -g 1001 -S nodejs && \
-    adduser -S nodejs -u 1001
-
-# Change ownership
-RUN chown -R nodejs:nodejs /app
-
+    adduser -S nodejs -u 1001 && \
+    chown -R nodejs:nodejs /app
 USER nodejs
 
 EXPOSE 3000
 
-# Health check
 HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
   CMD node -e "require('http').get('http://localhost:3000/health', (r) => {process.exit(r.statusCode === 200 ? 0 : 1)})"
 

--- a/apps/auth-server/docker-entrypoint.sh
+++ b/apps/auth-server/docker-entrypoint.sh
@@ -2,4 +2,4 @@
 set -e
 
 echo "Starting auth server..."
-exec node main.js
+exec tsx src/main.ts


### PR DESCRIPTION
## Summary

Ship a working production auth-server image. The previous Dockerfile produced an image that built successfully but crashed on boot — discovered during the first actual VPS deploy.

### What was broken

The Dockerfile shipped Nx's \`dist/apps/auth-server/\` esbuild prod bundle to the runner stage. In practice that path hit a chain of resolution mismatches:

1. **Scattered workspace deps.** pnpm's no-hoist default places workspace-scoped deps (\`fastify\`, \`@fastify/*\`, \`ioredis\`, …) under each workspace package's own \`node_modules/\`. The runner only copied root \`node_modules\` so all of them were absent.
2. **\`package.js\` vs \`package.json\`.** Nx emits a CommonJS \`package.js\` helper next to some compiled libs and nothing at all next to the transitively-imported ones (infra-cache, shared-errors, …). Node's CJS resolver can't read \`package.js\`, so \`require('@qauth-labs/*')\` failed despite the compiled \`src/index.js\` sitting right there.
3. **Empty custom-resolver manifest.** The Nx-generated \`main.js\` installs a custom \`Module._resolveFilename\` that's supposed to map workspace names to bundled paths via a \`manifest\` array. The array was empty, so every workspace require fell through to the filesystem lookup that (1) and (2) couldn't satisfy.

Fixing those end-to-end inside the Dockerfile would have meant rewriting Nx's build output in shell and populating a manifest that doesn't belong there.

### What this PR does

Skips the prod bundle entirely; uses the tool pnpm already ships for exactly this:

- **Builder** runs \`pnpm --filter @qauth-labs/auth-server deploy --prod --legacy /deploy\`. pnpm produces a self-contained tree: auth-server's source, workspace deps as real copies under \`node_modules/@qauth-labs/\`, external deps at the standard location.
- **Runner** installs \`tsx\` globally and exec's the TypeScript entry directly (\`tsx src/main.ts\`). No bundler, no custom resolver, no generated runtime manifest.

\`docker-entrypoint.sh\` is updated from \`node main.js\` to \`exec tsx src/main.ts\` to match the new layout.

### Trade-offs

- **Boot cost:** tsx parses TS on first load (~0.5 s cold). Negligible for a server that runs for weeks.
- **Image size:** ~1.6 GB → ~450 MB. The old approach carried the full workspace \`node_modules\`; the deploy bundle has only prod deps for auth-server.
- **Future path:** if we later want a truly bundled image, the correct fix is in qauth's Nx config (populate the \`main.js\` manifest), not in the Dockerfile.

## Test plan

- [x] Local build from clean cache: \`docker build -f apps/auth-server/Dockerfile .\` — succeeds.
- [x] Local boot smoke test — starts, reads \`.env\` via dotenv, validates schema, fails cleanly on missing \`DATABASE_URL\` (expected without env).
- [ ] End-to-end on VPS: postgres 18 → migration-runner → auth-server healthy on \`GET /health\`.
- [ ] Confirm pnpm deploy bundle has every workspace lib at \`node_modules/@qauth-labs/*\`.