### PR TITLE
feat(oauth): audience-bound introspection for resource servers

### DIFF
--- a/apps/auth-server/src/app/routes/oauth/introspect.test.ts
+++ b/apps/auth-server/src/app/routes/oauth/introspect.test.ts
@@ -268,6 +268,200 @@ describe('POST /oauth/introspect route', () => {
     expect(result).toEqual({ active: false });
   });
 
+  it('returns active: true when the introspecting client is authoritative for the token audience (string aud)', async () => {
+    const { fastify, ctx } = createFastifyStub();
+    await introspectRoute(fastify);
+
+    const handler = ctx.handler;
+    expect(handler).toBeDefined();
+
+    // Resource-server-style client: no minted scopes, but listed as
+    // authoritative for "api.example.com".
+    const client = {
+      id: 'client-rs',
+      clientId: 'resource-server',
+      clientSecretHash: 'hashed-secret',
+      enabled: true,
+      audience: ['api.example.com'],
+    };
+
+    const findByClientIdMock = fastify.repositories.oauthClients.findByClientId as unknown as Mock;
+    const verifyPasswordMock = fastify.passwordHasher.verifyPassword as unknown as Mock;
+    const verifyAccessTokenMock = fastify.jwtUtils.verifyAccessToken as unknown as Mock;
+
+    findByClientIdMock.mockResolvedValue(client);
+    verifyPasswordMock.mockResolvedValue(true);
+    verifyAccessTokenMock.mockResolvedValue({
+      sub: 'user-1',
+      clientId: 'caller-app',
+      scope: 'api:read',
+      aud: 'api.example.com',
+      exp: 1234567890,
+      iat: 1234567800,
+      iss: 'https://auth.example.com',
+    });
+
+    const request = {
+      body: { token: 'caller-token', client_id: client.clientId, client_secret: 'secret' },
+      ip: '127.0.0.1',
+      headers: { 'user-agent': 'vitest' },
+    };
+
+    const reply = { send: (body: unknown) => body };
+
+    if (!handler) throw new Error('Introspect handler was not registered');
+
+    const result = await handler(request, reply);
+
+    expect(result).toEqual({
+      active: true,
+      sub: 'user-1',
+      client_id: 'caller-app',
+      exp: 1234567890,
+      iat: 1234567800,
+      iss: 'https://auth.example.com',
+      aud: 'api.example.com',
+      scope: 'api:read',
+      token_type: 'Bearer',
+    });
+  });
+
+  it('returns active: true when every member of an array aud is in the client audience list', async () => {
+    const { fastify, ctx } = createFastifyStub();
+    await introspectRoute(fastify);
+
+    const handler = ctx.handler;
+    expect(handler).toBeDefined();
+
+    const client = {
+      id: 'client-rs',
+      clientId: 'resource-server',
+      clientSecretHash: 'hashed-secret',
+      enabled: true,
+      audience: ['api.example.com', 'admin.example.com'],
+    };
+
+    const findByClientIdMock = fastify.repositories.oauthClients.findByClientId as unknown as Mock;
+    const verifyPasswordMock = fastify.passwordHasher.verifyPassword as unknown as Mock;
+    const verifyAccessTokenMock = fastify.jwtUtils.verifyAccessToken as unknown as Mock;
+
+    findByClientIdMock.mockResolvedValue(client);
+    verifyPasswordMock.mockResolvedValue(true);
+    verifyAccessTokenMock.mockResolvedValue({
+      sub: 'user-1',
+      clientId: 'caller-app',
+      aud: ['api.example.com', 'admin.example.com'],
+      exp: 1234567890,
+      iat: 1234567800,
+      iss: 'https://auth.example.com',
+    });
+
+    const request = {
+      body: { token: 'caller-token', client_id: client.clientId, client_secret: 'secret' },
+      ip: '127.0.0.1',
+      headers: { 'user-agent': 'vitest' },
+    };
+
+    const reply = { send: (body: unknown) => body };
+
+    if (!handler) throw new Error('Introspect handler was not registered');
+
+    const result = (await handler(request, reply)) as { active: boolean };
+    expect(result.active).toBe(true);
+  });
+
+  it('returns active: false when token aud is not in the introspecting client audience list', async () => {
+    const { fastify, ctx } = createFastifyStub();
+    await introspectRoute(fastify);
+
+    const handler = ctx.handler;
+    expect(handler).toBeDefined();
+
+    // Client is authoritative only for "other.example.com" — cross-audience
+    // introspection must be rejected even though the client authenticates.
+    const client = {
+      id: 'client-rs',
+      clientId: 'resource-server',
+      clientSecretHash: 'hashed-secret',
+      enabled: true,
+      audience: ['other.example.com'],
+    };
+
+    const findByClientIdMock = fastify.repositories.oauthClients.findByClientId as unknown as Mock;
+    const verifyPasswordMock = fastify.passwordHasher.verifyPassword as unknown as Mock;
+    const verifyAccessTokenMock = fastify.jwtUtils.verifyAccessToken as unknown as Mock;
+
+    findByClientIdMock.mockResolvedValue(client);
+    verifyPasswordMock.mockResolvedValue(true);
+    verifyAccessTokenMock.mockResolvedValue({
+      sub: 'user-1',
+      clientId: 'caller-app',
+      aud: 'api.example.com',
+      exp: 1234567890,
+      iat: 1234567800,
+      iss: 'https://auth.example.com',
+    });
+
+    const request = {
+      body: { token: 'caller-token', client_id: client.clientId, client_secret: 'secret' },
+      ip: '127.0.0.1',
+      headers: { 'user-agent': 'vitest' },
+    };
+
+    const reply = { send: (body: unknown) => body };
+
+    if (!handler) throw new Error('Introspect handler was not registered');
+
+    const result = await handler(request, reply);
+    expect(result).toEqual({ active: false });
+  });
+
+  it('returns active: false for cross-client introspection when the client has no audience configured', async () => {
+    const { fastify, ctx } = createFastifyStub();
+    await introspectRoute(fastify);
+
+    const handler = ctx.handler;
+    expect(handler).toBeDefined();
+
+    // Regression guard: pre-audience-bound behaviour is preserved when a
+    // client has no `audience` configured — cross-client is rejected.
+    const client = {
+      id: 'client-1',
+      clientId: 'client-123',
+      clientSecretHash: 'hashed-secret',
+      enabled: true,
+      audience: null,
+    };
+
+    const findByClientIdMock = fastify.repositories.oauthClients.findByClientId as unknown as Mock;
+    const verifyPasswordMock = fastify.passwordHasher.verifyPassword as unknown as Mock;
+    const verifyAccessTokenMock = fastify.jwtUtils.verifyAccessToken as unknown as Mock;
+
+    findByClientIdMock.mockResolvedValue(client);
+    verifyPasswordMock.mockResolvedValue(true);
+    verifyAccessTokenMock.mockResolvedValue({
+      sub: 'user-1',
+      clientId: 'other-client',
+      aud: 'api.example.com',
+      exp: 1234567890,
+      iat: 1234567800,
+      iss: 'https://auth.example.com',
+    });
+
+    const request = {
+      body: { token: 'cross-client-token', client_id: client.clientId, client_secret: 'secret' },
+      ip: '127.0.0.1',
+      headers: { 'user-agent': 'vitest' },
+    };
+
+    const reply = { send: (body: unknown) => body };
+
+    if (!handler) throw new Error('Introspect handler was not registered');
+
+    const result = await handler(request, reply);
+    expect(result).toEqual({ active: false });
+  });
+
   it('throws InvalidClientError for invalid client credentials', async () => {
     const { fastify, ctx } = createFastifyStub();
     await introspectRoute(fastify);

--- a/apps/auth-server/src/app/routes/oauth/introspect.ts
+++ b/apps/auth-server/src/app/routes/oauth/introspect.ts
@@ -21,7 +21,36 @@ import {
  * - Requires confidential client authentication (client_id + client_secret).
  * - Returns token activity and selected claims for valid tokens.
  * - Returns active: false for invalid, expired, or cross-client tokens.
+ *
+ * Authorization model (who may introspect what):
+ *   1. Same-client: a client may always introspect tokens it itself issued
+ *      (`payload.client_id === client.client_id`).
+ *   2. Audience-bound: a resource server holds a confidential introspection
+ *      client whose `audience` column lists the audiences it is authoritative
+ *      for. If the token's `aud` is a member of the client's `audience`, the
+ *      introspection is allowed. This is what lets a single resource server
+ *      validate tokens minted by many distinct callers, without giving the
+ *      resource server the ability to mint tokens for those audiences itself.
+ *   Any other cross-client introspection returns `active: false`.
  */
+
+/**
+ * Returns true if the introspecting client is authoritative for the token's
+ * audience: every token-aud value appears in the client's configured audience
+ * list. Undefined/null/empty on either side returns false. Accepts both string
+ * and string[] shapes for `payload.aud` per RFC 7519.
+ */
+function isClientAuthoritativeForAudience(
+  payloadAud: string | string[] | undefined,
+  clientAudience: string[] | null
+): boolean {
+  if (!payloadAud || !clientAudience || clientAudience.length === 0) {
+    return false;
+  }
+  const tokenAuds = Array.isArray(payloadAud) ? payloadAud : [payloadAud];
+  if (tokenAuds.length === 0) return false;
+  return tokenAuds.every((a) => clientAudience.includes(a));
+}
 export default async function (fastify: FastifyInstance) {
   fastify.withTypeProvider<ZodTypeProvider>().post(
     '/introspect',
@@ -101,8 +130,10 @@ export default async function (fastify: FastifyInstance) {
           throw error;
         }
 
-        // Restrict clients to introspecting only their own tokens
-        if (payload.clientId !== client.clientId) {
+        // Authorize the introspection: same-client OR audience-authoritative.
+        const sameClient = payload.clientId === client.clientId;
+        const audAuthoritative = isClientAuthoritativeForAudience(payload.aud, client.audience);
+        if (!sameClient && !audAuthoritative) {
           await fastify.repositories.auditLogs.create({
             userId: null,
             oauthClientId: client.id,
@@ -112,7 +143,7 @@ export default async function (fastify: FastifyInstance) {
             ipAddress: request.ip,
             userAgent: request.headers['user-agent'] || null,
             metadata: {
-              error: 'Token client mismatch',
+              error: 'Client not authorized for this token',
             },
           });
 

--- a/apps/auth-server/src/app/routes/oauth/introspect.ts
+++ b/apps/auth-server/src/app/routes/oauth/introspect.ts
@@ -44,11 +44,15 @@ function isClientAuthoritativeForAudience(
   payloadAud: string | string[] | undefined,
   clientAudience: string[] | null
 ): boolean {
-  if (!payloadAud || !clientAudience || clientAudience.length === 0) {
+  if (
+    !payloadAud ||
+    (Array.isArray(payloadAud) && payloadAud.length === 0) ||
+    !clientAudience ||
+    clientAudience.length === 0
+  ) {
     return false;
   }
   const tokenAuds = Array.isArray(payloadAud) ? payloadAud : [payloadAud];
-  if (tokenAuds.length === 0) return false;
   return tokenAuds.every((a) => clientAudience.includes(a));
 }
 export default async function (fastify: FastifyInstance) {


### PR DESCRIPTION
## Summary

The introspect endpoint previously restricted a client to introspecting only tokens it itself minted (same-client rule). That blocks the standard resource-server pattern: a single confidential introspection client verifying tokens minted by many distinct callers bound to the resource server's audience.

This PR extends the authorization model. Introspection is allowed when either:

1. the token was minted by the introspecting client (unchanged), **OR**
2. every `aud` value in the token is a member of the introspecting client's `audience` column — i.e. the client is declared authoritative for that audience at seed/configuration time.

Clients without an `audience` list retain the original same-client-only behaviour (regression guard covered by a new test).

### Why

Resource servers that consume JWTs need to validate tokens minted by many callers bound to the resource server's audience. The same-client-only rule forced every caller to share the resource server's credentials, which defeats the point of per-caller client identities and per-caller audit trails.

Keycloak, Ory Hydra, and similar IdPs all support this pattern — usually via a dedicated "resource-server" role or an explicit introspection allow-list. Reusing the existing `audience` column is the minimal expression of the same idea: the column already means "audiences this client is a party for", and "can introspect tokens bound to these audiences" is a natural corollary.

### Scope

- `apps/auth-server/src/app/routes/oauth/introspect.ts` — adds the audience check; single helper, ~15 lines of behaviour.
- `apps/auth-server/src/app/routes/oauth/introspect.test.ts` — 4 new tests: string-aud match, array-aud match, aud-mismatch, regression guard for clients with no audience.

### No schema change

The `audience` jsonb column already exists (added in the client_credentials/aud PR). Seed scripts can mark a client as authoritative by populating this column at seed time.

## Test plan

- [x] `pnpm nx run auth-server:test` passes (all existing + 4 new)
- [x] `pnpm nx run auth-server:typecheck` passes
- [ ] Manual: resource-server client with `audience=["api.example.com"]` introspects a caller's token with `aud=api.example.com` → `active: true`
- [ ] Manual: same client introspects a token with `aud=other.example.com` → `active: false`
- [ ] Manual: client with `audience=null` introspects cross-client token → `active: false` (regression)