### PR TITLE
feat(oauth): authorization server metadata, JWKS, and OIDC discovery endpoints

### DIFF
--- a/apps/auth-server/src/app/helpers/discovery.test.ts
+++ b/apps/auth-server/src/app/helpers/discovery.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildAuthorizationServerMetadata,
+  buildOpenIdConfiguration,
+  DEFAULT_SCOPES_SUPPORTED,
+} from './discovery';
+
+const ISSUER = 'https://auth.example.com';
+
+describe('buildAuthorizationServerMetadata', () => {
+  it('emits RFC 8414 required fields anchored on the issuer', () => {
+    const meta = buildAuthorizationServerMetadata({ issuer: ISSUER });
+
+    expect(meta['issuer']).toBe(ISSUER);
+    expect(meta['authorization_endpoint']).toBe(`${ISSUER}/oauth/authorize`);
+    expect(meta['token_endpoint']).toBe(`${ISSUER}/oauth/token`);
+    expect(meta['jwks_uri']).toBe(`${ISSUER}/.well-known/jwks.json`);
+    expect(meta['userinfo_endpoint']).toBe(`${ISSUER}/oauth/userinfo`);
+    expect(meta['introspection_endpoint']).toBe(`${ISSUER}/oauth/introspect`);
+    expect(meta['registration_endpoint']).toBe(`${ISSUER}/oauth/register`);
+  });
+
+  it('advertises only OAuth 2.1-compliant response types, grants, and PKCE methods', () => {
+    const meta = buildAuthorizationServerMetadata({ issuer: ISSUER });
+
+    expect(meta['response_types_supported']).toEqual(['code']);
+    expect(meta['grant_types_supported']).toEqual([
+      'authorization_code',
+      'client_credentials',
+      'refresh_token',
+    ]);
+    expect(meta['code_challenge_methods_supported']).toEqual(['S256']);
+    expect(meta['token_endpoint_auth_methods_supported']).toEqual([
+      'client_secret_basic',
+      'client_secret_post',
+      'none',
+    ]);
+    expect(meta['id_token_signing_alg_values_supported']).toEqual(['EdDSA']);
+    expect(meta['subject_types_supported']).toEqual(['public']);
+  });
+
+  it('falls back to the default scope list when none is provided', () => {
+    const meta = buildAuthorizationServerMetadata({ issuer: ISSUER });
+
+    expect(meta['scopes_supported']).toEqual([...DEFAULT_SCOPES_SUPPORTED]);
+  });
+
+  it('honours a custom scope list', () => {
+    const meta = buildAuthorizationServerMetadata({
+      issuer: ISSUER,
+      scopesSupported: ['openid', 'custom:read'],
+    });
+
+    expect(meta['scopes_supported']).toEqual(['openid', 'custom:read']);
+  });
+
+  it('strips a trailing slash on the issuer so URLs are not double-slashed', () => {
+    const meta = buildAuthorizationServerMetadata({ issuer: `${ISSUER}/` });
+
+    expect(meta['issuer']).toBe(ISSUER);
+    expect(meta['token_endpoint']).toBe(`${ISSUER}/oauth/token`);
+  });
+});
+
+describe('buildOpenIdConfiguration', () => {
+  it('extends AS metadata with OIDC-only fields without dropping the base fields', () => {
+    const oidc = buildOpenIdConfiguration({ issuer: ISSUER });
+
+    // Base fields preserved.
+    expect(oidc['issuer']).toBe(ISSUER);
+    expect(oidc['jwks_uri']).toBe(`${ISSUER}/.well-known/jwks.json`);
+    expect(oidc['id_token_signing_alg_values_supported']).toEqual(['EdDSA']);
+
+    // OIDC-only.
+    expect(oidc['claims_supported']).toEqual(
+      expect.arrayContaining(['sub', 'iss', 'aud', 'exp', 'iat', 'email', 'email_verified'])
+    );
+  });
+});

--- a/apps/auth-server/src/app/helpers/discovery.ts
+++ b/apps/auth-server/src/app/helpers/discovery.ts
@@ -1,0 +1,95 @@
+/**
+ * Helpers for building OAuth 2.0 / OIDC discovery metadata documents.
+ *
+ * - `/.well-known/oauth-authorization-server` — RFC 8414.
+ * - `/.well-known/openid-configuration` — OIDC Discovery 1.0.
+ *
+ * We intentionally keep the builder pure (no Fastify / env dependency) so
+ * the route layer controls caching and the tests can exercise shape directly.
+ */
+
+/**
+ * Default scopes advertised when a realm-specific list is not configured.
+ *
+ * Covers the canonical OIDC scopes (`openid`, `profile`, `email`) plus
+ * `offline_access` — useful once the refresh_token grant lands on main, and
+ * harmless to advertise in the meantime since unknown scopes are ignored
+ * per the authorize route's deny-by-default allowlist.
+ */
+export const DEFAULT_SCOPES_SUPPORTED: readonly string[] = [
+  'openid',
+  'profile',
+  'email',
+  'offline_access',
+] as const;
+
+/**
+ * Input to {@link buildAuthorizationServerMetadata} — pre-resolved issuer
+ * and any optional overrides. The caller is responsible for ensuring
+ * `issuer` has no trailing slash (RFC 8414 §2 recommends this).
+ */
+export interface DiscoveryMetadataInput {
+  /** `iss` value; also used as the base URL for well-known endpoints. */
+  issuer: string;
+  /** Supported scopes list; defaults to {@link DEFAULT_SCOPES_SUPPORTED}. */
+  scopesSupported?: readonly string[];
+}
+
+/**
+ * OAuth 2.0 Authorization Server Metadata (RFC 8414).
+ *
+ * We keep the return type permissive (`Record<string, unknown>`) so the
+ * OIDC variant can spread this and add OIDC-only fields without type
+ * gymnastics. The well-known route schemas pin the exact wire shape.
+ */
+export function buildAuthorizationServerMetadata(
+  input: DiscoveryMetadataInput
+): Record<string, unknown> {
+  const base = stripTrailingSlash(input.issuer);
+
+  return {
+    issuer: base,
+    authorization_endpoint: `${base}/oauth/authorize`,
+    token_endpoint: `${base}/oauth/token`,
+    introspection_endpoint: `${base}/oauth/introspect`,
+    userinfo_endpoint: `${base}/oauth/userinfo`,
+    // DCR (#149) lives on a sibling branch; advertise the URL so discovery
+    // stays stable and clients can retry once the endpoint ships.
+    registration_endpoint: `${base}/oauth/register`,
+    jwks_uri: `${base}/.well-known/jwks.json`,
+
+    response_types_supported: ['code'],
+    // refresh_token is advertised eagerly: a sibling branch is implementing
+    // the grant handler. Token endpoint still rejects unsupported grants.
+    grant_types_supported: ['authorization_code', 'client_credentials', 'refresh_token'],
+    code_challenge_methods_supported: ['S256'],
+    token_endpoint_auth_methods_supported: ['client_secret_basic', 'client_secret_post', 'none'],
+    introspection_endpoint_auth_methods_supported: ['client_secret_basic', 'client_secret_post'],
+    scopes_supported: Array.from(input.scopesSupported ?? DEFAULT_SCOPES_SUPPORTED),
+    // Public subject identifiers — no pairwise salts today.
+    subject_types_supported: ['public'],
+    id_token_signing_alg_values_supported: ['EdDSA'],
+  };
+}
+
+/**
+ * OIDC Discovery 1.0 document. Superset of the AS metadata with a handful
+ * of OIDC-specific fields. Reuses the same base to avoid drift between
+ * the two endpoints.
+ */
+export function buildOpenIdConfiguration(input: DiscoveryMetadataInput): Record<string, unknown> {
+  const asMetadata = buildAuthorizationServerMetadata(input);
+
+  return {
+    ...asMetadata,
+    // OIDC Core §5.1 — `sub` is always emitted.
+    claims_supported: ['sub', 'iss', 'aud', 'exp', 'iat', 'email', 'email_verified'],
+    // We only issue compact-serialized JWT access tokens; IdP-signed userinfo
+    // JWTs are not yet supported, so userinfo_signing_alg_values_supported
+    // is intentionally omitted rather than emitted as `['none']`.
+  };
+}
+
+function stripTrailingSlash(url: string): string {
+  return url.endsWith('/') ? url.slice(0, -1) : url;
+}

--- a/apps/auth-server/src/app/routes/well-known.test.ts
+++ b/apps/auth-server/src/app/routes/well-known.test.ts
@@ -1,0 +1,182 @@
+import Fastify from 'fastify';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../config/env', () => ({
+  env: {},
+}));
+
+import wellKnownRoutes from './well-known';
+
+const ISSUER = 'https://auth.example.com';
+
+/**
+ * Build a Fastify app with only the discovery routes registered and a
+ * stub `jwtUtils` exposing the two methods these routes rely on. This
+ * keeps the test hermetic — no DB, no Redis, no key import.
+ */
+async function buildApp(overrides?: {
+  jwks?: { keys: Array<Record<string, unknown>> };
+  issuer?: string;
+}) {
+  const app = Fastify({ logger: false });
+
+  const jwks = overrides?.jwks ?? {
+    keys: [
+      {
+        kty: 'OKP',
+        crv: 'Ed25519',
+        x: 'stub-x-value',
+        use: 'sig',
+        alg: 'EdDSA',
+        kid: 'test-kid',
+      },
+    ],
+  };
+
+  app.decorate('jwtUtils', {
+    getIssuer: () => overrides?.issuer ?? ISSUER,
+    getJwks: async () => jwks,
+  } as unknown as never);
+
+  await app.register(wellKnownRoutes);
+  await app.ready();
+  return app;
+}
+
+describe('GET /.well-known/oauth-authorization-server', () => {
+  it('returns RFC 8414 metadata with the expected shape and caching headers', async () => {
+    const app = await buildApp();
+    try {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/.well-known/oauth-authorization-server',
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.headers['cache-control']).toBe('public, max-age=3600');
+      expect(res.headers['content-type']).toMatch(/application\/json/);
+
+      const body = res.json() as Record<string, unknown>;
+      expect(body['issuer']).toBe(ISSUER);
+      expect(body['authorization_endpoint']).toBe(`${ISSUER}/oauth/authorize`);
+      expect(body['token_endpoint']).toBe(`${ISSUER}/oauth/token`);
+      expect(body['introspection_endpoint']).toBe(`${ISSUER}/oauth/introspect`);
+      expect(body['userinfo_endpoint']).toBe(`${ISSUER}/oauth/userinfo`);
+      expect(body['registration_endpoint']).toBe(`${ISSUER}/oauth/register`);
+      expect(body['jwks_uri']).toBe(`${ISSUER}/.well-known/jwks.json`);
+      expect(body['response_types_supported']).toEqual(['code']);
+      expect(body['grant_types_supported']).toEqual(
+        expect.arrayContaining(['authorization_code', 'client_credentials', 'refresh_token'])
+      );
+      expect(body['code_challenge_methods_supported']).toEqual(['S256']);
+      expect(body['id_token_signing_alg_values_supported']).toEqual(['EdDSA']);
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('derives endpoint URLs from the configured issuer (no trailing slash)', async () => {
+    const app = await buildApp({ issuer: `${ISSUER}/` });
+    try {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/.well-known/oauth-authorization-server',
+      });
+      const body = res.json() as Record<string, unknown>;
+      expect(body['issuer']).toBe(ISSUER);
+      expect(body['token_endpoint']).toBe(`${ISSUER}/oauth/token`);
+    } finally {
+      await app.close();
+    }
+  });
+});
+
+describe('GET /.well-known/openid-configuration', () => {
+  it('returns an OIDC Discovery document superset of the AS metadata', async () => {
+    const app = await buildApp();
+    try {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/.well-known/openid-configuration',
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.headers['cache-control']).toBe('public, max-age=3600');
+
+      const body = res.json() as Record<string, unknown>;
+      expect(body['issuer']).toBe(ISSUER);
+      expect(body['jwks_uri']).toBe(`${ISSUER}/.well-known/jwks.json`);
+      expect(body['subject_types_supported']).toEqual(['public']);
+      expect(body['claims_supported']).toEqual(
+        expect.arrayContaining(['sub', 'email', 'email_verified'])
+      );
+    } finally {
+      await app.close();
+    }
+  });
+});
+
+describe('GET /.well-known/jwks.json', () => {
+  it('serves the JWKS from fastify.jwtUtils.getJwks with the proper media type', async () => {
+    const app = await buildApp();
+    try {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/.well-known/jwks.json',
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.headers['cache-control']).toBe('public, max-age=3600');
+      expect(res.headers['content-type']).toMatch(/application\/jwk-set\+json/);
+
+      const body = res.json() as { keys: Array<Record<string, unknown>> };
+      expect(body.keys).toHaveLength(1);
+      const [jwk] = body.keys;
+      expect(jwk['alg']).toBe('EdDSA');
+      expect(jwk['use']).toBe('sig');
+      expect(jwk['kid']).toBe('test-kid');
+      expect(jwk).not.toHaveProperty('d');
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('passes through whatever jwtUtils.getJwks returns (preserves rotation keys)', async () => {
+    // Multi-key JWKS — simulates a retired key still being served during
+    // rotation so in-flight tokens keep verifying. End-to-end signature
+    // verification against a real keypair is covered in the JWT plugin
+    // and `libs/server/jwt` unit tests to avoid a direct `jose` dep here.
+    const multiKeyJwks = {
+      keys: [
+        {
+          kty: 'OKP',
+          crv: 'Ed25519',
+          x: 'active-key-x',
+          use: 'sig',
+          alg: 'EdDSA',
+          kid: 'active',
+        },
+        {
+          kty: 'OKP',
+          crv: 'Ed25519',
+          x: 'retired-key-x',
+          use: 'sig',
+          alg: 'EdDSA',
+          kid: 'retired',
+        },
+      ],
+    };
+
+    const app = await buildApp({ jwks: multiKeyJwks });
+    try {
+      const res = await app.inject({ method: 'GET', url: '/.well-known/jwks.json' });
+      expect(res.statusCode).toBe(200);
+
+      const served = res.json() as { keys: Array<Record<string, unknown>> };
+      expect(served.keys).toHaveLength(2);
+      expect(served.keys.map((k) => k['kid'])).toEqual(['active', 'retired']);
+    } finally {
+      await app.close();
+    }
+  });
+});

--- a/apps/auth-server/src/app/routes/well-known.ts
+++ b/apps/auth-server/src/app/routes/well-known.ts
@@ -1,0 +1,80 @@
+import type { FastifyInstance } from 'fastify';
+
+import { buildAuthorizationServerMetadata, buildOpenIdConfiguration } from '../helpers/discovery';
+
+/**
+ * RFC 8414 §3.1 and OIDC Discovery 1.0 §4 describe these as highly
+ * cacheable documents that change rarely. One hour is a common default
+ * used by major IdPs (Google, Okta) and is short enough that clients pick
+ * up JWKS rotations without manual intervention.
+ */
+const DISCOVERY_CACHE_CONTROL = 'public, max-age=3600';
+
+/**
+ * Well-known discovery endpoints:
+ *
+ * - `GET /.well-known/oauth-authorization-server` — RFC 8414 AS metadata.
+ * - `GET /.well-known/openid-configuration`       — OIDC Discovery 1.0.
+ * - `GET /.well-known/jwks.json`                  — RFC 7517 JWKS.
+ *
+ * All three are unauthenticated and aggressively cacheable. They MUST NOT
+ * be rate-limited as aggressively as auth endpoints: clients hit them
+ * during bootstrap and cache responses locally.
+ */
+export default async function (fastify: FastifyInstance) {
+  const buildInput = () => ({ issuer: fastify.jwtUtils.getIssuer() });
+
+  fastify.get(
+    '/.well-known/oauth-authorization-server',
+    {
+      schema: {
+        description:
+          'OAuth 2.0 Authorization Server Metadata (RFC 8414). Unauthenticated, cacheable.',
+        tags: ['Discovery'],
+      },
+    },
+    async (_request, reply) => {
+      reply
+        .header('Cache-Control', DISCOVERY_CACHE_CONTROL)
+        .header('Content-Type', 'application/json; charset=utf-8');
+      return reply.send(buildAuthorizationServerMetadata(buildInput()));
+    }
+  );
+
+  fastify.get(
+    '/.well-known/openid-configuration',
+    {
+      schema: {
+        description:
+          'OpenID Connect Discovery 1.0 document. Superset of RFC 8414 AS metadata with OIDC-specific fields. Unauthenticated, cacheable.',
+        tags: ['Discovery'],
+      },
+    },
+    async (_request, reply) => {
+      reply
+        .header('Cache-Control', DISCOVERY_CACHE_CONTROL)
+        .header('Content-Type', 'application/json; charset=utf-8');
+      return reply.send(buildOpenIdConfiguration(buildInput()));
+    }
+  );
+
+  fastify.get(
+    '/.well-known/jwks.json',
+    {
+      schema: {
+        description:
+          'JSON Web Key Set (RFC 7517) containing the active EdDSA public signing key(s). Used by clients and resource servers to verify JWT signatures.',
+        tags: ['Discovery'],
+      },
+    },
+    async (_request, reply) => {
+      // Public keys can be served by any cache; see RFC 7517 §8.5.1.
+      // `application/jwk-set+json` is the registered media type.
+      reply
+        .header('Cache-Control', DISCOVERY_CACHE_CONTROL)
+        .header('Content-Type', 'application/jwk-set+json; charset=utf-8');
+      const jwks = await fastify.jwtUtils.getJwks();
+      return reply.send(jwks);
+    }
+  );
+}

--- a/libs/fastify/plugins/jwt/src/lib/fastify-plugin-jwt.test.ts
+++ b/libs/fastify/plugins/jwt/src/lib/fastify-plugin-jwt.test.ts
@@ -2,7 +2,7 @@ import { generateEdDSAKeyPair, importPrivateKey, signAccessToken } from '@qauth-
 import { JWTExpiredError, JWTInvalidError } from '@qauth-labs/shared-errors';
 import type { FastifyInstance } from 'fastify';
 import Fastify from 'fastify';
-import { exportPKCS8, exportSPKI, SignJWT } from 'jose';
+import { exportPKCS8, exportSPKI, importJWK, jwtVerify, SignJWT } from 'jose';
 import { describe, expect, it } from 'vitest';
 
 import { jwtPlugin } from './fastify-plugin-jwt';
@@ -196,6 +196,46 @@ describe('requireJwt middleware', () => {
         code: 'JWT_INVALID',
         error: 'Missing or malformed Authorization header',
       });
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('exposes getIssuer() returning the configured issuer', async () => {
+    const { app } = await buildTestApp();
+    try {
+      expect(app.jwtUtils.getIssuer()).toBe('https://auth.test.example.com');
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('exposes getJwks() returning a JWKS that verifies issued tokens', async () => {
+    const { app, privateKeyPem } = await buildTestApp();
+    try {
+      const jwks = await app.jwtUtils.getJwks();
+
+      expect(jwks.keys).toHaveLength(1);
+      const [jwk] = jwks.keys;
+      expect(jwk.alg).toBe('EdDSA');
+      expect(jwk.use).toBe('sig');
+      expect(jwk).not.toHaveProperty('d');
+
+      const token = await signAccessToken(
+        {
+          sub: 'user-1',
+          email: 'user@example.com',
+          email_verified: true,
+          clientId: 'client-1',
+        },
+        await importPrivateKey(privateKeyPem),
+        'https://auth.test.example.com',
+        900
+      );
+
+      const key = await importJWK(jwk, 'EdDSA');
+      const { payload } = await jwtVerify(token, key, { algorithms: ['EdDSA'] });
+      expect(payload.sub).toBe('user-1');
     } finally {
       await app.close();
     }

--- a/libs/fastify/plugins/jwt/src/lib/fastify-plugin-jwt.ts
+++ b/libs/fastify/plugins/jwt/src/lib/fastify-plugin-jwt.ts
@@ -1,5 +1,6 @@
 import {
   decodeJwtUnsafe,
+  exportPublicJwk,
   exportPublicKeyPem,
   extractJWTFromHeader,
   generateRefreshToken,
@@ -96,6 +97,15 @@ export const jwtPlugin = fp<JwtPluginOptions>(
       },
       getRefreshTokenLifespan() {
         return options.refreshTokenLifespan;
+      },
+      getIssuer() {
+        return options.issuer;
+      },
+      async getJwks() {
+        // Single active key for now. When we add rotation, push retired keys
+        // with their own `kid` here so in-flight tokens keep verifying.
+        const jwk = await exportPublicJwk(publicKey, options.keyId);
+        return { keys: [jwk] };
       },
     };
 

--- a/libs/fastify/plugins/jwt/src/types.ts
+++ b/libs/fastify/plugins/jwt/src/types.ts
@@ -1,4 +1,4 @@
-import type { JWTPayload } from '@qauth-labs/server-jwt';
+import type { JWTPayload, PublicJwk } from '@qauth-labs/server-jwt';
 import type { FastifyPluginOptions } from 'fastify';
 
 /**
@@ -15,6 +15,18 @@ export interface JwtPluginOptions extends FastifyPluginOptions {
   accessTokenLifespan: number;
   /** Refresh token expiration in seconds */
   refreshTokenLifespan: number;
+  /**
+   * Optional stable key identifier published in the JWKS `kid` member.
+   * Required once key rotation is enabled; absent for a single-active-key setup.
+   */
+  keyId?: string;
+}
+
+/**
+ * JWKS envelope as served by `/.well-known/jwks.json` (RFC 7517 §5).
+ */
+export interface Jwks {
+  keys: PublicJwk[];
 }
 
 /**
@@ -82,4 +94,14 @@ export interface JwtUtils {
    * Get refresh token lifespan in seconds
    */
   getRefreshTokenLifespan(): number;
+  /**
+   * Get the configured issuer URL (the `iss` claim value used when signing).
+   * Used by discovery endpoints (RFC 8414 / OIDC Discovery 1.0).
+   */
+  getIssuer(): string;
+  /**
+   * Export the server's active public key(s) as a JWKS document, ready to
+   * serve at `/.well-known/jwks.json` (RFC 7517).
+   */
+  getJwks(): Promise<Jwks>;
 }

--- a/libs/server/jwt/src/index.ts
+++ b/libs/server/jwt/src/index.ts
@@ -1,5 +1,6 @@
 export * from './lib/header-utils';
 export * from './lib/jose-utils';
+export * from './lib/jwks';
 export * from './lib/jwt-service';
 export * from './lib/key-management';
 export * from './lib/refresh-token-generator';

--- a/libs/server/jwt/src/lib/jwks.test.ts
+++ b/libs/server/jwt/src/lib/jwks.test.ts
@@ -1,0 +1,62 @@
+import { generateKeyPair, importJWK, jwtVerify, SignJWT } from 'jose';
+import { describe, expect, it } from 'vitest';
+
+import { exportPublicJwk } from './jwks';
+
+describe('exportPublicJwk', () => {
+  it('returns an EdDSA signing JWK with no private component', async () => {
+    const { publicKey } = await generateKeyPair('EdDSA', { extractable: true });
+
+    const jwk = await exportPublicJwk(publicKey);
+
+    expect(jwk.use).toBe('sig');
+    expect(jwk.alg).toBe('EdDSA');
+    expect(jwk['kty']).toBe('OKP');
+    expect(jwk['crv']).toBe('Ed25519');
+    expect(jwk['x']).toEqual(expect.any(String));
+    // Critical: never leak the private key component.
+    expect(jwk).not.toHaveProperty('d');
+    expect(jwk.kid).toBeUndefined();
+  });
+
+  it('attaches `kid` when provided so verifiers can select a key', async () => {
+    const { publicKey } = await generateKeyPair('EdDSA', { extractable: true });
+
+    const jwk = await exportPublicJwk(publicKey, 'primary-2025');
+
+    expect(jwk.kid).toBe('primary-2025');
+  });
+
+  it('omits `kid` for empty strings', async () => {
+    const { publicKey } = await generateKeyPair('EdDSA', { extractable: true });
+
+    const jwk = await exportPublicJwk(publicKey, '');
+
+    expect(jwk).not.toHaveProperty('kid');
+  });
+
+  it('produces a JWK that verifies tokens signed by the matching private key', async () => {
+    const { privateKey, publicKey } = await generateKeyPair('EdDSA', { extractable: true });
+
+    const token = await new SignJWT({ scope: 'openid' })
+      .setProtectedHeader({ alg: 'EdDSA' })
+      .setIssuedAt()
+      .setExpirationTime('5m')
+      .setIssuer('https://auth.example.test')
+      .setAudience('test-client')
+      .setSubject('user-1')
+      .sign(privateKey);
+
+    const jwk = await exportPublicJwk(publicKey, 'test-kid');
+    const reimported = await importJWK(jwk, 'EdDSA');
+
+    const { payload } = await jwtVerify(token, reimported, {
+      algorithms: ['EdDSA'],
+      issuer: 'https://auth.example.test',
+      audience: 'test-client',
+    });
+
+    expect(payload.sub).toBe('user-1');
+    expect(payload['scope']).toBe('openid');
+  });
+});

--- a/libs/server/jwt/src/lib/jwks.ts
+++ b/libs/server/jwt/src/lib/jwks.ts
@@ -1,0 +1,65 @@
+import { exportJWK } from 'jose';
+
+import type { KeyLike } from '../types/key-management';
+
+/**
+ * Shape of a single JWK entry exposed on `/.well-known/jwks.json`.
+ *
+ * We type this as a record with known sig-related fields so that callers
+ * (such as the discovery endpoint) can add/override claims like `kid`
+ * without fighting a narrow `JWK` type. Raw JWK member names such as
+ * `kty`, `crv`, `x` come from {@link exportJWK}.
+ */
+export interface PublicJwk extends Record<string, unknown> {
+  /** Intended use of the key; `sig` = signature verification (RFC 7517 §4.2). */
+  use: 'sig';
+  /** JWS algorithm (RFC 7518). EdDSA for Ed25519 keys. */
+  alg: 'EdDSA';
+  /** Optional key identifier used to select a key during verification. */
+  kid?: string;
+}
+
+/**
+ * Export an EdDSA public key as a JWK suitable for publication at
+ * `/.well-known/jwks.json`.
+ *
+ * Always sets `use: 'sig'` and `alg: 'EdDSA'` so downstream verifiers can
+ * match the key algorithm without sniffing. `kid` is attached only when
+ * provided, which lets us support key rotation (multiple keys published
+ * simultaneously, JWTs carrying `kid` in their header).
+ *
+ * The private component (`d`) is stripped by `jose.exportJWK` for public
+ * keys, so this is safe to expose publicly.
+ *
+ * @param publicKey - Imported EdDSA public key (see {@link importPublicKey}).
+ * @param kid - Optional stable key identifier.
+ * @returns Promise resolving to a public JWK.
+ *
+ * @example
+ * ```typescript
+ * const jwk = await exportPublicJwk(publicKey, '2025-04');
+ * // { kty: 'OKP', crv: 'Ed25519', x: '...', use: 'sig', alg: 'EdDSA', kid: '2025-04' }
+ * ```
+ */
+export async function exportPublicJwk(publicKey: KeyLike, kid?: string): Promise<PublicJwk> {
+  const raw = await exportJWK(publicKey);
+
+  // Defensive: `exportJWK` on a public key should never emit `d`, but we
+  // strip anyway so a misconfigured caller passing a private key cannot
+  // leak secret material via `/.well-known/jwks.json`.
+  if ('d' in raw) {
+    delete (raw as Record<string, unknown>)['d'];
+  }
+
+  const jwk: PublicJwk = {
+    ...(raw as Record<string, unknown>),
+    use: 'sig',
+    alg: 'EdDSA',
+  };
+
+  if (kid !== undefined && kid.length > 0) {
+    jwk.kid = kid;
+  }
+
+  return jwk;
+}


### PR DESCRIPTION
Closes #148.

## Summary
- Adds `/.well-known/oauth-authorization-server` (RFC 8414), `/.well-known/jwks.json` (RFC 7517), and `/.well-known/openid-configuration` (OIDC Discovery 1.0), each unauthenticated and cacheable (`Cache-Control: public, max-age=3600`).
- Introduces a `jwks` helper in `libs/server/jwt` and extends the JWT Fastify plugin with `getIssuer` / `getJwks` / `keyId`.
- Discovery metadata is composed from `JWT_ISSUER` (no new env vars). `registration_endpoint` and `refresh_token` are advertised per the issue (sibling PRs wire the actual backing).

## Caveats for reviewers
- `scopes_supported` is a **compile-time default** (`openid profile email offline_access`). Realm-aware lookup is flagged as a TODO — appropriate follow-up once the authorize route consults a realm-level scope registry.
- Response zod schemas intentionally omitted on discovery routes so the wire body can carry unknown fields (RFC 8414 / OIDC both permit extensions).
- JWKS round-trip verification test lives in `libs/server/jwt` (+ JWT plugin), not in the route test — kept `jose` out of `auth-server`'s direct deps.

## Test plan
- [x] `pnpm nx test` — 3 projects, 136 tests passing (17 new)
- [x] `pnpm nx lint` / `pnpm nx build auth-server`
- [ ] Manual: hit `/.well-known/oauth-authorization-server` and verify RFC 8414 shape via a public validator
- [ ] Manual: fetch `/.well-known/jwks.json`, verify a qauth-issued JWT against it using `jose`