### PR TITLE
feat(oauth): user consent screen on /oauth/authorize

### DIFF
--- a/apps/auth-server/src/app/helpers/browser-session.ts
+++ b/apps/auth-server/src/app/helpers/browser-session.ts
@@ -1,0 +1,40 @@
+import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+
+import {
+  type BrowserSessionData,
+  clearSessionCookie,
+  readCookie,
+  SESSION_COOKIE_NAME,
+  verifySignedSessionId,
+} from './session-cookie';
+
+/**
+ * Resolve the currently authenticated browser user from the signed
+ * `__Host-qauth_session` cookie. Returns `null` when:
+ *   - the cookie is absent
+ *   - the signature is invalid
+ *   - the referenced session has been evicted from Redis (TTL expired or
+ *     logged out)
+ *
+ * The caller is responsible for deciding what to do with a null result —
+ * e.g. redirect to the login page, or render an error. When the cookie
+ * signature is valid but the session is gone, the stale cookie is cleared
+ * as a side-effect so the browser stops sending it.
+ */
+export async function resolveBrowserSession(
+  fastify: FastifyInstance,
+  request: FastifyRequest,
+  reply: FastifyReply
+): Promise<BrowserSessionData | null> {
+  const raw = readCookie(request, SESSION_COOKIE_NAME);
+  const sessionId = verifySignedSessionId(raw);
+  if (!sessionId) return null;
+
+  const data = await fastify.sessionUtils.getSession<BrowserSessionData>(sessionId);
+  if (!data) {
+    // Signature was valid but Redis has no record — stale cookie.
+    clearSessionCookie(reply);
+    return null;
+  }
+  return data;
+}

--- a/apps/auth-server/src/app/helpers/consent.test.ts
+++ b/apps/auth-server/src/app/helpers/consent.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../config/env', () => ({
+  env: {
+    DYNAMIC_CLIENT_BADGE_DAYS: 30,
+  },
+}));
+
+import {
+  canSkipConsent,
+  describeScope,
+  filterRequestedScopes,
+  isDynamicClientWithinBadgeWindow,
+  isScopeSubset,
+  type OAuthClientLike,
+  type OAuthConsentLike,
+} from './consent';
+
+function client(overrides: Partial<OAuthClientLike> = {}): OAuthClientLike {
+  return {
+    scopes: ['read:foo', 'write:foo', 'email'],
+    dynamicRegisteredAt: null,
+    ...overrides,
+  };
+}
+
+function consent(overrides: Partial<OAuthConsentLike> = {}): OAuthConsentLike {
+  return {
+    scopes: ['read:foo'],
+    revokedAt: null,
+    ...overrides,
+  };
+}
+
+describe('isScopeSubset', () => {
+  it('empty requested is always covered', () => {
+    expect(isScopeSubset([], [])).toBe(true);
+    expect(isScopeSubset([], ['read:foo'])).toBe(true);
+  });
+
+  it('exact match', () => {
+    expect(isScopeSubset(['a', 'b'], ['a', 'b'])).toBe(true);
+  });
+
+  it('requested is proper subset of granted', () => {
+    expect(isScopeSubset(['a'], ['a', 'b', 'c'])).toBe(true);
+  });
+
+  it('missing any scope fails', () => {
+    expect(isScopeSubset(['a', 'x'], ['a', 'b'])).toBe(false);
+  });
+});
+
+describe('filterRequestedScopes', () => {
+  it('drops scopes not on the client allowlist', () => {
+    expect(filterRequestedScopes('read:foo write:bar email', client())).toEqual([
+      'read:foo',
+      'email',
+    ]);
+  });
+
+  it('de-duplicates and preserves request order', () => {
+    expect(filterRequestedScopes('email read:foo email', client())).toEqual(['email', 'read:foo']);
+  });
+
+  it('handles missing scope parameter', () => {
+    expect(filterRequestedScopes(undefined, client())).toEqual([]);
+    expect(filterRequestedScopes('', client())).toEqual([]);
+  });
+});
+
+describe('isDynamicClientWithinBadgeWindow', () => {
+  it('null dynamicRegisteredAt is never new', () => {
+    expect(isDynamicClientWithinBadgeWindow(client({ dynamicRegisteredAt: null }))).toBe(false);
+  });
+
+  it('recently registered is new', () => {
+    expect(
+      isDynamicClientWithinBadgeWindow(
+        client({ dynamicRegisteredAt: Date.now() - 1 * 24 * 60 * 60 * 1000 })
+      )
+    ).toBe(true);
+  });
+
+  it('old registration is not new', () => {
+    expect(
+      isDynamicClientWithinBadgeWindow(
+        client({ dynamicRegisteredAt: Date.now() - 365 * 24 * 60 * 60 * 1000 })
+      )
+    ).toBe(false);
+  });
+});
+
+describe('canSkipConsent', () => {
+  it('missing consent always requires prompt', () => {
+    expect(canSkipConsent(undefined, client(), ['read:foo'])).toBe(false);
+  });
+
+  it('revoked consent requires prompt', () => {
+    expect(canSkipConsent(consent({ revokedAt: Date.now() - 1000 }), client(), ['read:foo'])).toBe(
+      false
+    );
+  });
+
+  it('exceeded scopes require prompt', () => {
+    expect(canSkipConsent(consent({ scopes: ['read:foo'] }), client(), ['write:foo'])).toBe(false);
+  });
+
+  it('subset scopes skip prompt', () => {
+    expect(canSkipConsent(consent({ scopes: ['read:foo', 'email'] }), client(), ['email'])).toBe(
+      true
+    );
+  });
+
+  it('dynamic client inside badge window forces re-consent', () => {
+    const c = client({ dynamicRegisteredAt: Date.now() - 1 * 24 * 60 * 60 * 1000 });
+    expect(canSkipConsent(consent({ scopes: ['email'] }), c, ['email'])).toBe(false);
+  });
+});
+
+describe('describeScope', () => {
+  it('returns mapped description when known', () => {
+    expect(describeScope('openid')).toContain('identity');
+    expect(describeScope('email')).toContain('email');
+  });
+
+  it('falls back to raw scope', () => {
+    expect(describeScope('write:widgets')).toBe('write:widgets');
+  });
+});

--- a/apps/auth-server/src/app/helpers/consent.ts
+++ b/apps/auth-server/src/app/helpers/consent.ts
@@ -1,0 +1,116 @@
+import { env } from '../../config/env';
+
+/**
+ * Minimal view of an oauth_clients row consumed by the consent-screen
+ * helpers. Kept local to avoid an `@nx/enforce-module-boundaries`
+ * violation (`scope:app` → `scope:infra`) — the full types still live in
+ * `@qauth-labs/infra-db` and repositories return them directly.
+ */
+export interface OAuthClientLike {
+  scopes: string[];
+  dynamicRegisteredAt: number | null;
+}
+
+/**
+ * Minimal view of an oauth_consents row consumed by the consent-screen
+ * helpers. See {@link OAuthClientLike} for the rationale.
+ */
+export interface OAuthConsentLike {
+  scopes: string[];
+  revokedAt: number | null;
+}
+
+/**
+ * True iff every `requested` scope is already present in `granted`. Empty
+ * `requested` is trivially covered — the authorization request itself
+ * carried no scope, so there is nothing to consent to.
+ *
+ * Callers use this on the /oauth/authorize GET path to decide whether the
+ * consent screen can be skipped for a previously-granted (user, client).
+ */
+export function isScopeSubset(requested: string[], granted: string[]): boolean {
+  if (requested.length === 0) return true;
+  const set = new Set(granted);
+  for (const s of requested) {
+    if (!set.has(s)) return false;
+  }
+  return true;
+}
+
+/**
+ * Intersect the client's configured scope allowlist with what the request
+ * asks for, preserving the request order and de-duplicating.
+ *
+ * Matches `authorize.ts`'s existing deny-by-default behaviour: a scope that
+ * the client has not been provisioned for is silently dropped instead of
+ * being granted.
+ */
+export function filterRequestedScopes(
+  requestedRaw: string | undefined,
+  client: OAuthClientLike
+): string[] {
+  const requested = (requestedRaw ?? '').split(/\s+/).filter((s) => s.length > 0);
+  const allow = new Set(client.scopes);
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const s of requested) {
+    if (!allow.has(s)) continue;
+    if (seen.has(s)) continue;
+    seen.add(s);
+    out.push(s);
+  }
+  return out;
+}
+
+/**
+ * Whether the consent screen can be skipped for this (user, client) given
+ * the existing consent row and the scopes being requested now.
+ *
+ * Returns false when:
+ *   - no active consent row exists
+ *   - the requested scopes are not a subset of the granted ones
+ *   - the client is a dynamic-registered client and still inside the
+ *     `DYNAMIC_CLIENT_BADGE_DAYS` window (we force re-consent to give the
+ *     user another chance to notice the "Newly registered" warning per
+ *     issue #150 phishing-defense requirements)
+ */
+export function canSkipConsent(
+  consent: OAuthConsentLike | undefined,
+  client: OAuthClientLike,
+  requestedScopes: string[]
+): boolean {
+  if (!consent) return false;
+  if (consent.revokedAt !== null) return false;
+  if (isDynamicClientWithinBadgeWindow(client)) return false;
+  return isScopeSubset(requestedScopes, consent.scopes);
+}
+
+/**
+ * True when the client was dynamic-registered recently enough to warrant
+ * the phishing-defense badge. Defaults to `false` for null
+ * `dynamicRegisteredAt` — first-party / hand-provisioned clients are
+ * never flagged as new.
+ */
+export function isDynamicClientWithinBadgeWindow(client: OAuthClientLike): boolean {
+  if (!client.dynamicRegisteredAt) return false;
+  if (env.DYNAMIC_CLIENT_BADGE_DAYS <= 0) return false;
+  const ageMs = Date.now() - client.dynamicRegisteredAt;
+  const windowMs = env.DYNAMIC_CLIENT_BADGE_DAYS * 24 * 60 * 60 * 1000;
+  return ageMs < windowMs;
+}
+
+/**
+ * Human-readable description for a scope string. Fallback is the raw
+ * scope — that's intentionally legible because our scope naming
+ * convention (`read:foo`, `write:foo`) is already close to plain English.
+ */
+const SCOPE_DESCRIPTIONS: Record<string, string> = {
+  openid: 'Verify your identity',
+  profile: 'View your basic profile information',
+  email: 'View your email address',
+  offline_access: 'Keep you signed in when you are not using the app',
+};
+
+export function describeScope(scope: string): string {
+  return SCOPE_DESCRIPTIONS[scope] ?? scope;
+}

--- a/apps/auth-server/src/app/helpers/html.test.ts
+++ b/apps/auth-server/src/app/helpers/html.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+
+import { esc, html, render, safe } from './html';
+
+describe('html helpers', () => {
+  it('esc escapes HTML-special characters', () => {
+    expect(esc(`<script>alert("x")</script>`)).toBe(
+      '&lt;script&gt;alert(&quot;x&quot;)&lt;/script&gt;'
+    );
+    expect(esc(undefined)).toBe('');
+    expect(esc(null)).toBe('');
+  });
+
+  it('html template tag escapes interpolations', () => {
+    const out = render(html`<p>${'<b>hi</b>'}</p>`);
+    expect(out).toBe('<p>&lt;b&gt;hi&lt;/b&gt;</p>');
+  });
+
+  it('safe() bypasses escaping for trusted fragments', () => {
+    const fragment = safe('<b>trust</b>');
+    const out = render(html`<p>${fragment}</p>`);
+    expect(out).toBe('<p><b>trust</b></p>');
+  });
+
+  it('arrays of values are concatenated with each element escaped', () => {
+    const items = ['<a>', '<b>'];
+    const out = render(html`${items}`);
+    expect(out).toBe('&lt;a&gt;&lt;b&gt;');
+  });
+});

--- a/apps/auth-server/src/app/helpers/html.ts
+++ b/apps/auth-server/src/app/helpers/html.ts
@@ -1,0 +1,60 @@
+/**
+ * Tiny HTML escape + template helper for the server-rendered login/consent
+ * pages (issue #150). We do this inline instead of pulling in a templating
+ * dep because the pages are two static forms and the server already ships
+ * server-rendered responses nowhere else.
+ *
+ * SECURITY: every interpolated value passes through `esc()`. The tag
+ * function `html` handles that automatically; the only place callers are
+ * allowed to bypass escaping is via `safe(...)` for pre-built trusted
+ * fragments.
+ */
+
+export function esc(value: unknown): string {
+  if (value === null || value === undefined) return '';
+  const s = String(value);
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+/** Marker wrapper for values that should NOT be HTML-escaped. */
+export interface SafeHtml {
+  readonly __safe: true;
+  readonly value: string;
+}
+
+export function safe(value: string): SafeHtml {
+  return { __safe: true, value };
+}
+
+function isSafe(x: unknown): x is SafeHtml {
+  return typeof x === 'object' && x !== null && (x as SafeHtml).__safe === true;
+}
+
+export function html(strings: TemplateStringsArray, ...values: unknown[]): SafeHtml {
+  let out = '';
+  strings.forEach((chunk, i) => {
+    out += chunk;
+    if (i < values.length) {
+      const v = values[i];
+      if (Array.isArray(v)) {
+        for (const item of v) {
+          out += isSafe(item) ? item.value : esc(item);
+        }
+      } else if (isSafe(v)) {
+        out += v.value;
+      } else {
+        out += esc(v);
+      }
+    }
+  });
+  return safe(out);
+}
+
+export function render(fragment: SafeHtml): string {
+  return fragment.value;
+}

--- a/apps/auth-server/src/app/helpers/session-cookie.test.ts
+++ b/apps/auth-server/src/app/helpers/session-cookie.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../config/env', () => ({
+  env: {
+    SESSION_COOKIE_SECRET: 'test-secret-at-least-32-characters-long-padding',
+    SESSION_COOKIE_TTL: 3600,
+    SESSION_COOKIE_SECURE: false,
+  },
+}));
+
+import {
+  clearSessionCookie,
+  csrfTokensEqual,
+  generateCsrfToken,
+  readCookie,
+  SESSION_COOKIE_NAME,
+  setSessionCookie,
+  signSessionId,
+  verifySignedSessionId,
+} from './session-cookie';
+
+describe('session cookie helpers', () => {
+  it('signs and verifies a session id round-trip', () => {
+    const signed = signSessionId('abc-123');
+    expect(verifySignedSessionId(signed)).toBe('abc-123');
+  });
+
+  it('rejects a tampered signature', () => {
+    const signed = signSessionId('abc-123');
+    const tampered = signed.slice(0, -4) + 'XXXX';
+    expect(verifySignedSessionId(tampered)).toBeNull();
+  });
+
+  it('rejects missing/empty values without throwing', () => {
+    expect(verifySignedSessionId(undefined)).toBeNull();
+    expect(verifySignedSessionId('')).toBeNull();
+    expect(verifySignedSessionId('no-separator')).toBeNull();
+    expect(verifySignedSessionId('.onlysig')).toBeNull();
+    expect(verifySignedSessionId('onlyid.')).toBeNull();
+  });
+
+  it('readCookie returns the correct cookie value', () => {
+    const request = {
+      headers: { cookie: 'foo=bar; __Host-qauth_session=signed; baz=qux' },
+    } as never;
+    expect(readCookie(request, SESSION_COOKIE_NAME)).toBe('signed');
+    expect(readCookie(request, 'foo')).toBe('bar');
+    expect(readCookie(request, 'missing')).toBeUndefined();
+  });
+
+  it('setSessionCookie emits __Host- with required attrs', () => {
+    const headers: Record<string, string> = {};
+    const reply = {
+      header: (k: string, v: string) => {
+        headers[k] = v;
+        return reply;
+      },
+    } as never;
+    setSessionCookie(reply, 'sid');
+    const cookie = headers['Set-Cookie'];
+    expect(cookie).toContain(`${SESSION_COOKIE_NAME}=`);
+    expect(cookie).toContain('Path=/');
+    expect(cookie).toContain('HttpOnly');
+    expect(cookie).toContain('SameSite=Lax');
+  });
+
+  it('clearSessionCookie emits Max-Age=0', () => {
+    const headers: Record<string, string> = {};
+    const reply = {
+      header: (k: string, v: string) => {
+        headers[k] = v;
+        return reply;
+      },
+    } as never;
+    clearSessionCookie(reply);
+    expect(headers['Set-Cookie']).toContain('Max-Age=0');
+  });
+
+  it('csrfTokensEqual is timing-safe and length-aware', () => {
+    const t = generateCsrfToken();
+    expect(csrfTokensEqual(t, t)).toBe(true);
+    expect(csrfTokensEqual(t, t + 'x')).toBe(false);
+    expect(csrfTokensEqual(undefined, t)).toBe(false);
+    expect(csrfTokensEqual(t, undefined)).toBe(false);
+  });
+});

--- a/apps/auth-server/src/app/helpers/session-cookie.ts
+++ b/apps/auth-server/src/app/helpers/session-cookie.ts
@@ -1,0 +1,138 @@
+import { createHmac, randomBytes, timingSafeEqual } from 'node:crypto';
+
+import type { FastifyReply, FastifyRequest } from 'fastify';
+
+import { env } from '../../config/env';
+
+/**
+ * Cookie name used to carry the browser session id (issue #150).
+ *
+ * The `__Host-` prefix binds the cookie to the current origin with strict
+ * requirements enforced by browsers:
+ *   - `Secure` attribute MUST be set
+ *   - `Path=/` MUST be set
+ *   - no `Domain` attribute
+ * This gives us free CSRF-ish isolation across subdomains and prevents a
+ * sibling origin from overwriting the session.
+ */
+export const SESSION_COOKIE_NAME = '__Host-qauth_session';
+
+/**
+ * Payload stored server-side in Redis keyed by session id. We never put the
+ * userId in the cookie itself — the cookie only carries the session id +
+ * HMAC. Binding the authenticated user to the cookie only via the Redis
+ * lookup keeps revocation cheap (delete the key) and avoids leaking the
+ * user id if the signing secret is ever compromised.
+ */
+export interface BrowserSessionData {
+  userId: string;
+  email: string;
+  sessionId: string;
+  createdAt: number;
+  /** Monotonic nonce for CSRF double-submit cookie (rotated on consent POST). */
+  csrfToken?: string;
+  [key: string]: unknown;
+}
+
+const SEPARATOR = '.';
+
+function hmac(value: string): string {
+  return createHmac('sha256', env.SESSION_COOKIE_SECRET).update(value).digest('base64url');
+}
+
+/**
+ * Sign the given session id, returning a cookie value of the form
+ * `<sessionId>.<hmac>`. Verification is timing-safe.
+ */
+export function signSessionId(sessionId: string): string {
+  return `${sessionId}${SEPARATOR}${hmac(sessionId)}`;
+}
+
+/**
+ * Verify a signed cookie value and return the session id if the signature
+ * is valid, otherwise null. Never throws — callers treat null as "no
+ * authenticated session".
+ */
+export function verifySignedSessionId(cookieValue: string | undefined | null): string | null {
+  if (!cookieValue) return null;
+  const idx = cookieValue.lastIndexOf(SEPARATOR);
+  if (idx <= 0 || idx === cookieValue.length - 1) return null;
+
+  const sessionId = cookieValue.slice(0, idx);
+  const providedSig = cookieValue.slice(idx + 1);
+  const expectedSig = hmac(sessionId);
+
+  const providedBuf = Buffer.from(providedSig, 'base64url');
+  const expectedBuf = Buffer.from(expectedSig, 'base64url');
+  if (providedBuf.length !== expectedBuf.length) return null;
+  if (!timingSafeEqual(providedBuf, expectedBuf)) return null;
+  return sessionId;
+}
+
+/**
+ * Parse the `Cookie` header and return the raw value of the given cookie
+ * name, or undefined. Avoids adding @fastify/cookie just for read access.
+ */
+export function readCookie(request: FastifyRequest, name: string): string | undefined {
+  const header = request.headers.cookie;
+  if (!header) return undefined;
+  for (const part of header.split(';')) {
+    const trimmed = part.trim();
+    const eq = trimmed.indexOf('=');
+    if (eq === -1) continue;
+    const k = trimmed.slice(0, eq);
+    if (k !== name) continue;
+    return decodeURIComponent(trimmed.slice(eq + 1));
+  }
+  return undefined;
+}
+
+/**
+ * Emit a Set-Cookie header for the signed session. Attributes match the
+ * issue #150 spec: __Host-, Secure (configurable for local dev),
+ * HttpOnly, SameSite=Lax, Path=/.
+ */
+export function setSessionCookie(reply: FastifyReply, sessionId: string): void {
+  const attrs = [
+    `${SESSION_COOKIE_NAME}=${signSessionId(sessionId)}`,
+    'Path=/',
+    'HttpOnly',
+    'SameSite=Lax',
+    `Max-Age=${env.SESSION_COOKIE_TTL}`,
+  ];
+  // __Host- prefix requires Secure. Tests may turn this off for in-process
+  // assertions but production must have it set.
+  if (env.SESSION_COOKIE_SECURE) attrs.push('Secure');
+  reply.header('Set-Cookie', attrs.join('; '));
+}
+
+/**
+ * Clear the session cookie. Used on logout and when a session id fails to
+ * resolve to a Redis entry (stale cookie).
+ */
+export function clearSessionCookie(reply: FastifyReply): void {
+  const attrs = [`${SESSION_COOKIE_NAME}=`, 'Path=/', 'HttpOnly', 'SameSite=Lax', 'Max-Age=0'];
+  if (env.SESSION_COOKIE_SECURE) attrs.push('Secure');
+  reply.header('Set-Cookie', attrs.join('; '));
+}
+
+/**
+ * Generate a CSRF token suitable for the consent form's hidden input. The
+ * same value is also stored in the session payload; on POST the server
+ * compares the two in a timing-safe way (double-submit cookie pattern).
+ */
+export function generateCsrfToken(): string {
+  return randomBytes(32).toString('base64url');
+}
+
+/**
+ * Timing-safe comparison of CSRF tokens. Returns false for any
+ * length-mismatched or missing input without short-circuiting.
+ */
+export function csrfTokensEqual(a: string | undefined, b: string | undefined): boolean {
+  if (!a || !b) return false;
+  const ab = Buffer.from(a);
+  const bb = Buffer.from(b);
+  if (ab.length !== bb.length) return false;
+  return timingSafeEqual(ab, bb);
+}

--- a/apps/auth-server/src/app/routes/consents/consents.test.ts
+++ b/apps/auth-server/src/app/routes/consents/consents.test.ts
@@ -1,0 +1,165 @@
+import { NotFoundError } from '@qauth-labs/shared-errors';
+import type { FastifyInstance } from 'fastify';
+import { describe, expect, it, type Mock, vi } from 'vitest';
+
+vi.mock('../../../config/env', () => ({
+  env: {
+    SESSION_COOKIE_SECRET: 'test-secret-at-least-32-characters-long-padding',
+    SESSION_COOKIE_TTL: 3600,
+    SESSION_COOKIE_SECURE: false,
+  },
+}));
+
+import consentsRoute from './index';
+
+interface TestContext {
+  get?: (request: any, reply: any) => Promise<unknown>;
+  delete?: (request: any, reply: any) => Promise<unknown>;
+}
+
+function createReply() {
+  const state: {
+    statusCode?: number;
+    headers: Record<string, string>;
+    body?: unknown;
+  } = { headers: {} };
+  const reply: any = {
+    code(n: number) {
+      state.statusCode = n;
+      return reply;
+    },
+    header(k: string, v: string) {
+      state.headers[k] = v;
+      return reply;
+    },
+    send(body: unknown) {
+      state.body = body;
+      return body;
+    },
+  };
+  return { reply, state };
+}
+
+function makeFastify() {
+  const ctx: TestContext = {};
+  const fastify: any = {
+    withTypeProvider: () => ({
+      get: (_u: string, _o: unknown, h: any) => {
+        ctx.get = h;
+        return fastify;
+      },
+      delete: (_u: string, _o: unknown, h: any) => {
+        ctx.delete = h;
+        return fastify;
+      },
+    }),
+    repositories: {
+      oauthConsents: {
+        listActiveForUser: vi.fn(),
+        revoke: vi.fn(),
+      },
+      oauthClients: {
+        findById: vi.fn(),
+      },
+      auditLogs: { create: vi.fn().mockResolvedValue(undefined) },
+    },
+    sessionUtils: { getSession: vi.fn() },
+    log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  };
+  return { fastify: fastify as FastifyInstance, ctx };
+}
+
+describe('/consents JSON API', () => {
+  it('GET /consents returns 401 when no session', async () => {
+    const { fastify, ctx } = makeFastify();
+    await consentsRoute(fastify);
+    (fastify.sessionUtils.getSession as unknown as Mock).mockResolvedValue(null);
+
+    const { reply, state } = createReply();
+    await ctx.get!({ headers: {} }, reply);
+    expect(state.statusCode).toBe(401);
+  });
+
+  it('GET /consents lists active consents for the user', async () => {
+    const { fastify, ctx } = makeFastify();
+    await consentsRoute(fastify);
+    const { signSessionId } = await import('../../helpers/session-cookie');
+    const signed = signSessionId('s1');
+    (fastify.sessionUtils.getSession as unknown as Mock).mockResolvedValue({
+      userId: 'u1',
+      email: 'a@b.com',
+      sessionId: 's1',
+      createdAt: 0,
+    });
+    (fastify.repositories.oauthConsents.listActiveForUser as unknown as Mock).mockResolvedValue([
+      { id: 'c1', oauthClientId: 'cli1', scopes: ['email'], grantedAt: 1, revokedAt: null },
+    ]);
+    (fastify.repositories.oauthClients.findById as unknown as Mock).mockResolvedValue({
+      clientId: 'app-123',
+      name: 'Cool App',
+    });
+
+    const { reply, state } = createReply();
+    await ctx.get!({ headers: { cookie: `__Host-qauth_session=${signed}` } }, reply);
+    expect(state.body).toMatchObject({
+      consents: [{ id: 'c1', clientId: 'app-123', clientName: 'Cool App', scopes: ['email'] }],
+    });
+  });
+
+  it('DELETE /consents/:id revokes when the consent belongs to the user', async () => {
+    const { fastify, ctx } = makeFastify();
+    await consentsRoute(fastify);
+    const { signSessionId } = await import('../../helpers/session-cookie');
+    const signed = signSessionId('s2');
+    (fastify.sessionUtils.getSession as unknown as Mock).mockResolvedValue({
+      userId: 'u1',
+      email: 'a@b.com',
+      sessionId: 's2',
+      createdAt: 0,
+    });
+    (fastify.repositories.oauthConsents.listActiveForUser as unknown as Mock).mockResolvedValue([
+      { id: 'c1', oauthClientId: 'cli1', scopes: ['email'], grantedAt: 1, revokedAt: null },
+    ]);
+    (fastify.repositories.oauthConsents.revoke as unknown as Mock).mockResolvedValue({});
+
+    const { reply, state } = createReply();
+    await ctx.delete!(
+      {
+        headers: { cookie: `__Host-qauth_session=${signed}` },
+        params: { id: 'c1' },
+        ip: '1.1.1.1',
+      },
+      reply
+    );
+    expect(state.statusCode).toBe(204);
+    expect(fastify.repositories.oauthConsents.revoke).toHaveBeenCalledWith('c1');
+    expect(fastify.repositories.auditLogs.create).toHaveBeenCalled();
+  });
+
+  it('DELETE /consents/:id rejects revocation for a different user', async () => {
+    const { fastify, ctx } = makeFastify();
+    await consentsRoute(fastify);
+    const { signSessionId } = await import('../../helpers/session-cookie');
+    const signed = signSessionId('s3');
+    (fastify.sessionUtils.getSession as unknown as Mock).mockResolvedValue({
+      userId: 'u-other',
+      email: 'x@y.com',
+      sessionId: 's3',
+      createdAt: 0,
+    });
+    (fastify.repositories.oauthConsents.listActiveForUser as unknown as Mock).mockResolvedValue([]);
+
+    const { reply } = createReply();
+    await expect(
+      ctx.delete!(
+        {
+          headers: { cookie: `__Host-qauth_session=${signed}` },
+          params: { id: 'c1' },
+          ip: '1.1.1.1',
+        },
+        reply
+      )
+    ).rejects.toThrow(NotFoundError);
+    expect(fastify.repositories.oauthConsents.revoke).not.toHaveBeenCalled();
+  });
+});

--- a/apps/auth-server/src/app/routes/consents/index.ts
+++ b/apps/auth-server/src/app/routes/consents/index.ts
@@ -1,0 +1,126 @@
+import { BadRequestError, NotFoundError } from '@qauth-labs/shared-errors';
+import type { FastifyInstance } from 'fastify';
+import { ZodTypeProvider } from 'fastify-type-provider-zod';
+import { z } from 'zod';
+
+import { resolveBrowserSession } from '../../helpers/browser-session';
+
+/**
+ * Consent management JSON API (issue #150).
+ *
+ * Both endpoints require a valid `__Host-qauth_session` cookie; there is
+ * no Bearer-token path here because consent is inherently a user-centric
+ * operation and all callers are the developer portal (same-origin) or a
+ * future first-party settings UI.
+ *
+ *   GET    /consents           — list the active consents for the current user
+ *   DELETE /consents/:id       — revoke one by id (ownership-checked)
+ */
+
+const consentRowSchema = z.object({
+  id: z.string(),
+  clientId: z.string(),
+  clientName: z.string(),
+  scopes: z.array(z.string()),
+  grantedAt: z.number(),
+});
+
+const listResponseSchema = z.object({
+  consents: z.array(consentRowSchema),
+});
+
+export default async function (fastify: FastifyInstance) {
+  fastify.withTypeProvider<ZodTypeProvider>().get(
+    '/consents',
+    {
+      schema: {
+        description:
+          'List the active OAuth consents for the currently signed-in user. Drives the developer portal revocation screen (issue #150).',
+        tags: ['Consents'],
+        response: { 200: listResponseSchema },
+      },
+    },
+    async (request, reply) => {
+      const session = await resolveBrowserSession(fastify, request, reply);
+      if (!session) {
+        reply.code(401);
+        return reply.send({ consents: [] });
+      }
+
+      const rows = await fastify.repositories.oauthConsents.listActiveForUser(session.userId);
+
+      // N+1 is fine at the scale of "consents a user has granted". If this
+      // ever becomes a problem, add a joined `listActiveForUserWithClient`
+      // repo method.
+      const consents = await Promise.all(
+        rows.map(async (row) => {
+          const client = await fastify.repositories.oauthClients.findById(row.oauthClientId);
+          return {
+            id: row.id,
+            clientId: client?.clientId ?? 'unknown',
+            clientName: client?.name ?? 'Unknown application',
+            scopes: row.scopes,
+            grantedAt: row.grantedAt,
+          };
+        })
+      );
+
+      return reply.send({ consents });
+    }
+  );
+
+  fastify.withTypeProvider<ZodTypeProvider>().delete(
+    '/consents/:id',
+    {
+      schema: {
+        description: 'Revoke an OAuth consent row owned by the currently signed-in user.',
+        tags: ['Consents'],
+        params: z.object({ id: z.string().uuid() }),
+        response: { 204: z.null() },
+      },
+    },
+    async (request, reply) => {
+      const session = await resolveBrowserSession(fastify, request, reply);
+      if (!session) {
+        reply.code(401);
+        return reply.send(null);
+      }
+
+      const { id } = request.params as { id: string };
+
+      // Ownership check — we must not allow a user to revoke another
+      // user's consent, and `revoke()` by id alone cannot enforce that.
+      const rows = await fastify.repositories.oauthConsents.listActiveForUser(session.userId);
+      const owned = rows.find((r) => r.id === id);
+      if (!owned) {
+        throw new NotFoundError('OAuthConsent', id);
+      }
+
+      try {
+        await fastify.repositories.oauthConsents.revoke(id);
+      } catch (err) {
+        if (err instanceof NotFoundError) {
+          // Raced with another tab — treat as idempotent success.
+        } else if (err instanceof BadRequestError) {
+          throw err;
+        } else {
+          throw err;
+        }
+      }
+
+      await fastify.repositories.auditLogs.create({
+        userId: session.userId,
+        oauthClientId: owned.oauthClientId,
+        event: 'oauth.consent.revoked',
+        eventType: 'auth',
+        success: true,
+        ipAddress: request.ip,
+        userAgent: request.headers['user-agent'] || null,
+        metadata: { consentId: id },
+      });
+
+      reply.code(204);
+      return reply.send(null);
+    }
+  );
+}

--- a/apps/auth-server/src/app/routes/oauth/authorize.test.ts
+++ b/apps/auth-server/src/app/routes/oauth/authorize.test.ts
@@ -1,0 +1,206 @@
+import type { FastifyInstance } from 'fastify';
+import { describe, expect, it, type Mock, vi } from 'vitest';
+
+vi.mock('../../../config/env', () => ({
+  env: {
+    AUTHORIZE_RATE_LIMIT: 60,
+    AUTHORIZE_RATE_WINDOW: 60,
+    DEFAULT_REALM_NAME: 'master',
+    SYSTEM_CLIENT_ID: 'system',
+    SESSION_COOKIE_SECRET: 'test-secret-at-least-32-characters-long-padding',
+    SESSION_COOKIE_TTL: 3600,
+    SESSION_COOKIE_SECURE: false,
+    DYNAMIC_CLIENT_BADGE_DAYS: 30,
+  },
+}));
+
+import authorizeRoute from './authorize';
+
+interface TestContext {
+  handler?: (request: any, reply: any) => Promise<unknown>;
+}
+
+function createReply() {
+  const state: {
+    statusCode?: number;
+    headers: Record<string, string>;
+    redirected?: string;
+    body?: unknown;
+  } = { headers: {} };
+  const reply: any = {
+    code(n: number) {
+      state.statusCode = n;
+      return reply;
+    },
+    header(k: string, v: string) {
+      state.headers[k] = v;
+      return reply;
+    },
+    redirect(url: string, code: number) {
+      state.redirected = url;
+      state.statusCode = code;
+      return reply;
+    },
+    send(body: unknown) {
+      state.body = body;
+      return body;
+    },
+  };
+  return { reply, state };
+}
+
+function makeFastify() {
+  const ctx: TestContext = {};
+  const fastify: any = {
+    withTypeProvider: () => ({
+      get: (_url: string, _opts: unknown, handler: any) => {
+        ctx.handler = handler;
+        return fastify;
+      },
+    }),
+    repositories: {
+      realms: {
+        findByName: vi.fn().mockResolvedValue({ id: 'realm-1', name: 'master', enabled: true }),
+        create: vi.fn(),
+      },
+      oauthClients: {
+        findByClientId: vi.fn(),
+      },
+      oauthConsents: {
+        findActive: vi.fn(),
+      },
+      authorizationCodes: {
+        create: vi.fn().mockResolvedValue({ id: 'code-1' }),
+      },
+      auditLogs: {
+        create: vi.fn().mockResolvedValue(undefined),
+      },
+    },
+    jwtUtils: {
+      extractFromHeader: vi.fn(),
+      verifyAccessToken: vi.fn(),
+    },
+    sessionUtils: {
+      getSession: vi.fn(),
+    },
+    log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  };
+  return { fastify: fastify as FastifyInstance, ctx };
+}
+
+const CLIENT = {
+  id: 'client-uuid-1',
+  clientId: 'app-123',
+  clientSecretHash: 'h',
+  enabled: true,
+  grantTypes: ['authorization_code'],
+  responseTypes: ['code'],
+  scopes: ['read:foo', 'email'],
+  audience: null,
+  redirectUris: ['https://example.com/cb'],
+  dynamicRegisteredAt: null,
+};
+
+const BASE_QUERY = {
+  response_type: 'code',
+  client_id: 'app-123',
+  redirect_uri: 'https://example.com/cb',
+  code_challenge: 'A'.repeat(43),
+  code_challenge_method: 'S256',
+  state: 'xyz',
+  scope: 'email',
+};
+
+describe('GET /oauth/authorize — session-cookie integration', () => {
+  it('redirects unauthenticated requests to /ui/login with return_to', async () => {
+    const { fastify, ctx } = makeFastify();
+    await authorizeRoute(fastify);
+    (fastify.repositories.oauthClients.findByClientId as unknown as Mock).mockResolvedValue(CLIENT);
+    (fastify.jwtUtils.extractFromHeader as unknown as Mock).mockReturnValue(null);
+    (fastify.sessionUtils.getSession as unknown as Mock).mockResolvedValue(null);
+
+    const { reply, state } = createReply();
+    await ctx.handler!(
+      {
+        query: BASE_QUERY,
+        url: '/oauth/authorize?response_type=code&client_id=app-123',
+        headers: {},
+        ip: '127.0.0.1',
+      },
+      reply
+    );
+
+    expect(state.redirected).toBeDefined();
+    expect(state.redirected).toContain('/ui/login?return_to=');
+    expect(state.redirected).toContain(encodeURIComponent('/oauth/authorize'));
+  });
+
+  it('redirects to /ui/consent when session is valid but no prior consent', async () => {
+    const { fastify, ctx } = makeFastify();
+    await authorizeRoute(fastify);
+    (fastify.repositories.oauthClients.findByClientId as unknown as Mock).mockResolvedValue(CLIENT);
+    (fastify.jwtUtils.extractFromHeader as unknown as Mock).mockReturnValue(null);
+    (fastify.repositories.oauthConsents.findActive as unknown as Mock).mockResolvedValue(undefined);
+
+    // Build a valid signed cookie matching the mocked secret.
+    const { signSessionId } = await import('../../helpers/session-cookie');
+    const signed = signSessionId('sid-1');
+    (fastify.sessionUtils.getSession as unknown as Mock).mockResolvedValue({
+      userId: 'user-1',
+      email: 'a@b.com',
+      sessionId: 'sid-1',
+      createdAt: Date.now(),
+    });
+
+    const { reply, state } = createReply();
+    await ctx.handler!(
+      {
+        query: BASE_QUERY,
+        url: '/oauth/authorize?response_type=code&client_id=app-123&scope=email',
+        headers: { cookie: `__Host-qauth_session=${signed}` },
+        ip: '127.0.0.1',
+      },
+      reply
+    );
+
+    expect(state.redirected).toContain('/ui/consent?');
+    // The code must NOT have been issued yet.
+    expect(fastify.repositories.authorizationCodes.create).not.toHaveBeenCalled();
+  });
+
+  it('skips consent and issues code when existing consent covers the requested scopes', async () => {
+    const { fastify, ctx } = makeFastify();
+    await authorizeRoute(fastify);
+    (fastify.repositories.oauthClients.findByClientId as unknown as Mock).mockResolvedValue(CLIENT);
+    (fastify.jwtUtils.extractFromHeader as unknown as Mock).mockReturnValue(null);
+    (fastify.repositories.oauthConsents.findActive as unknown as Mock).mockResolvedValue({
+      scopes: ['email', 'read:foo'],
+      revokedAt: null,
+    });
+
+    const { signSessionId } = await import('../../helpers/session-cookie');
+    const signed = signSessionId('sid-2');
+    (fastify.sessionUtils.getSession as unknown as Mock).mockResolvedValue({
+      userId: 'user-1',
+      email: 'a@b.com',
+      sessionId: 'sid-2',
+      createdAt: Date.now(),
+    });
+
+    const { reply, state } = createReply();
+    await ctx.handler!(
+      {
+        query: BASE_QUERY,
+        url: '/oauth/authorize?response_type=code&client_id=app-123&scope=email',
+        headers: { cookie: `__Host-qauth_session=${signed}` },
+        ip: '127.0.0.1',
+      },
+      reply
+    );
+
+    expect(fastify.repositories.authorizationCodes.create).toHaveBeenCalledOnce();
+    expect(state.redirected).toContain('https://example.com/cb');
+    expect(state.redirected).toContain('code=');
+    expect(state.redirected).toContain('state=xyz');
+  });
+});

--- a/apps/auth-server/src/app/routes/oauth/authorize.ts
+++ b/apps/auth-server/src/app/routes/oauth/authorize.ts
@@ -6,7 +6,9 @@ import { ZodTypeProvider } from 'fastify-type-provider-zod';
 
 import { env } from '../../../config/env';
 import { AUTHORIZATION_CODE_TTL_MS } from '../../constants';
+import { resolveBrowserSession } from '../../helpers/browser-session';
 import { resolveAudience } from '../../helpers/client-auth';
+import { canSkipConsent, filterRequestedScopes } from '../../helpers/consent';
 import { getOrCreateSystemClient } from '../../helpers/oauth-client';
 import { buildRedirectUrl } from '../../helpers/oauth-redirect';
 import { getOrCreateDefaultRealm } from '../../helpers/realm';
@@ -15,7 +17,16 @@ import { type AuthorizeQuery, authorizeQuerySchema } from '../../schemas/oauth';
 /**
  * GET /oauth/authorize
  * OAuth 2.1 Authorization Code Flow with PKCE.
- * Requires Authorization: Bearer <access_token> for user context (MVP).
+ *
+ * Accepts two user-auth mechanisms:
+ *   1. Browser-driven (issue #150): signed __Host-qauth_session cookie.
+ *      No session → redirect to /ui/login with return_to. Session + no
+ *      prior consent covering the requested scopes → redirect to the
+ *      consent screen at /ui/consent. Otherwise issue a code directly.
+ *   2. Legacy/machine: Authorization: Bearer <access_token>. Retained for
+ *      backwards compatibility with first-party callers that have not yet
+ *      migrated to the browser flow. MUST NOT be relied on once dynamic
+ *      client registration is opened up.
  */
 export default async function (fastify: FastifyInstance) {
   fastify.withTypeProvider<ZodTypeProvider>().get(
@@ -135,64 +146,76 @@ export default async function (fastify: FastifyInstance) {
         );
       }
 
-      const token = fastify.jwtUtils.extractFromHeader(request.headers.authorization);
-      if (!token) {
-        await fastify.repositories.auditLogs.create({
-          userId: null,
-          oauthClientId: client.id,
-          event: 'oauth.authorize.failure',
-          eventType: 'token',
-          success: false,
-          ipAddress: request.ip,
-          userAgent: request.headers['user-agent'] || null,
-          metadata: { error: 'access_denied', client_id: query.client_id },
-        });
-        return reply.redirect(
-          buildRedirectUrl(redirectUri, {
-            error: 'access_denied',
-            error_description: 'Missing or invalid Authorization header',
-            state: state ?? undefined,
-          }),
-          302
-        );
+      // -----------------------------------------------------------------
+      // User authentication. Prefer the session cookie; fall back to
+      // Bearer for backwards compat. When both are absent we kick to the
+      // login page with a return_to URL so the user can establish a
+      // session and come back.
+      // -----------------------------------------------------------------
+      const browserSession = await resolveBrowserSession(fastify, request, reply);
+      const bearer = fastify.jwtUtils.extractFromHeader(request.headers.authorization);
+
+      if (!browserSession && !bearer) {
+        // No auth at all → browser flow. Redirect to login, then the user
+        // lands back on this very URL and the session cookie path takes
+        // over. We preserve the exact query string so PKCE challenge,
+        // scope, and state survive the round-trip.
+        const returnTo = `${request.url}`;
+        return reply.redirect(`/ui/login?return_to=${encodeURIComponent(returnTo)}`, 302);
       }
 
       let userId: string;
-      try {
-        const systemClient = await getOrCreateSystemClient(realm.id, fastify);
-        const payload = await fastify.jwtUtils.verifyAccessToken(token, {
-          audience: resolveAudience(systemClient),
-        });
-        userId = payload.sub;
-      } catch {
-        await fastify.repositories.auditLogs.create({
-          userId: null,
-          oauthClientId: client.id,
-          event: 'oauth.authorize.failure',
-          eventType: 'token',
-          success: false,
-          ipAddress: request.ip,
-          userAgent: request.headers['user-agent'] || null,
-          metadata: { error: 'access_denied', client_id: query.client_id },
-        });
-        return reply.redirect(
-          buildRedirectUrl(redirectUri, {
-            error: 'access_denied',
-            error_description: 'Invalid or expired token',
-            state: state ?? undefined,
-          }),
-          302
-        );
+      if (browserSession) {
+        userId = browserSession.userId;
+      } else {
+        // bearer path
+        try {
+          const systemClient = await getOrCreateSystemClient(realm.id, fastify);
+          const payload = await fastify.jwtUtils.verifyAccessToken(bearer as string, {
+            audience: resolveAudience(systemClient),
+          });
+          userId = payload.sub;
+        } catch {
+          await fastify.repositories.auditLogs.create({
+            userId: null,
+            oauthClientId: client.id,
+            event: 'oauth.authorize.failure',
+            eventType: 'token',
+            success: false,
+            ipAddress: request.ip,
+            userAgent: request.headers['user-agent'] || null,
+            metadata: { error: 'access_denied', client_id: query.client_id },
+          });
+          return reply.redirect(
+            buildRedirectUrl(redirectUri, {
+              error: 'access_denied',
+              error_description: 'Invalid or expired token',
+              state: state ?? undefined,
+            }),
+            302
+          );
+        }
       }
 
-      const requestedScopes = query.scope
-        ? query.scope.split(/\s+/).filter((s) => s.length > 0)
-        : [];
       // Deny-by-default: when a client has no scope allowlist configured we
       // grant nothing, matching `validateScopes` on the client_credentials
       // path. Previously an empty allowlist silently over-granted every
       // requested scope on the auth-code flow.
-      const scopes = requestedScopes.filter((s) => client.scopes.includes(s));
+      const scopes = filterRequestedScopes(query.scope, client);
+
+      // Browser-driven flow: show the consent screen unless a previous
+      // grant already covers the requested scopes. Bearer-token callers
+      // skip the consent step entirely — they are first-party and the
+      // Bearer path is not exposed to dynamically-registered clients.
+      if (browserSession) {
+        const existingConsent = await fastify.repositories.oauthConsents.findActive(
+          userId,
+          client.id
+        );
+        if (!canSkipConsent(existingConsent, client, scopes)) {
+          return reply.redirect(`/ui/consent${request.url.slice(request.url.indexOf('?'))}`, 302);
+        }
+      }
 
       const expiresAt = Date.now() + AUTHORIZATION_CODE_TTL_MS;
 

--- a/apps/auth-server/src/app/routes/ui/consent.test.ts
+++ b/apps/auth-server/src/app/routes/ui/consent.test.ts
@@ -1,0 +1,339 @@
+import type { FastifyInstance } from 'fastify';
+import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
+
+vi.mock('../../../config/env', () => ({
+  env: {
+    AUTHORIZE_RATE_LIMIT: 60,
+    AUTHORIZE_RATE_WINDOW: 60,
+    DEFAULT_REALM_NAME: 'master',
+    SESSION_COOKIE_SECRET: 'test-secret-at-least-32-characters-long-padding',
+    SESSION_COOKIE_TTL: 3600,
+    SESSION_COOKIE_SECURE: false,
+    DYNAMIC_CLIENT_BADGE_DAYS: 30,
+  },
+}));
+
+import consentRoute from './consent';
+
+interface TestContext {
+  get?: (request: any, reply: any) => Promise<unknown>;
+  post?: (request: any, reply: any) => Promise<unknown>;
+}
+
+function createReply() {
+  const state: {
+    statusCode?: number;
+    headers: Record<string, string>;
+    redirected?: string;
+    body?: unknown;
+  } = { headers: {} };
+  const reply: any = {
+    code(n: number) {
+      state.statusCode = n;
+      return reply;
+    },
+    header(k: string, v: string) {
+      state.headers[k] = v;
+      return reply;
+    },
+    redirect(url: string, code: number) {
+      state.redirected = url;
+      state.statusCode = code;
+      return reply;
+    },
+    send(body: unknown) {
+      state.body = body;
+      return body;
+    },
+  };
+  return { reply, state };
+}
+
+function makeFastify() {
+  const ctx: TestContext = {};
+  const fastify: any = {
+    withTypeProvider: () => ({
+      get: (_url: string, _opts: unknown, handler: any) => {
+        ctx.get = handler;
+        return fastify;
+      },
+      post: (_url: string, _opts: unknown, handler: any) => {
+        ctx.post = handler;
+        return fastify;
+      },
+    }),
+    repositories: {
+      realms: {
+        findByName: vi.fn().mockResolvedValue({ id: 'realm-1', name: 'master', enabled: true }),
+        create: vi.fn(),
+      },
+      oauthClients: {
+        findByClientId: vi.fn(),
+      },
+      oauthConsents: {
+        upsertGrant: vi.fn().mockResolvedValue({}),
+      },
+      authorizationCodes: {
+        create: vi.fn().mockResolvedValue({ id: 'code-1' }),
+      },
+      auditLogs: {
+        create: vi.fn().mockResolvedValue(undefined),
+      },
+    },
+    sessionUtils: {
+      getSession: vi.fn(),
+      setSession: vi.fn().mockResolvedValue(undefined),
+    },
+    log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  };
+  return { fastify: fastify as FastifyInstance, ctx };
+}
+
+const CLIENT = {
+  id: 'client-uuid-1',
+  clientId: 'app-123',
+  clientSecretHash: 'h',
+  name: 'Test App',
+  enabled: true,
+  scopes: ['read:foo', 'email'],
+  redirectUris: ['https://example.com/cb'],
+  audience: null,
+  dynamicRegisteredAt: null,
+  metadata: null,
+};
+
+const BASE_QUERY = {
+  response_type: 'code' as const,
+  client_id: 'app-123',
+  redirect_uri: 'https://example.com/cb',
+  code_challenge: 'A'.repeat(43),
+  code_challenge_method: 'S256' as const,
+  state: 'xyz',
+  scope: 'email',
+};
+
+describe('UI /ui/consent GET — rendering', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('redirects to /ui/login when no session cookie present', async () => {
+    const { fastify, ctx } = makeFastify();
+    await consentRoute(fastify);
+    (fastify.sessionUtils.getSession as unknown as Mock).mockResolvedValue(null);
+
+    const { reply, state } = createReply();
+    await ctx.get!(
+      {
+        query: BASE_QUERY,
+        url: '/ui/consent?...',
+        headers: {},
+        ip: '127.0.0.1',
+      },
+      reply
+    );
+
+    expect(state.redirected).toContain('/ui/login?return_to=');
+  });
+
+  it('renders consent HTML with CSRF token hidden input when session is valid', async () => {
+    const { fastify, ctx } = makeFastify();
+    await consentRoute(fastify);
+    const { signSessionId } = await import('../../helpers/session-cookie');
+    const signed = signSessionId('sid-g1');
+    (fastify.sessionUtils.getSession as unknown as Mock).mockResolvedValue({
+      userId: 'user-1',
+      email: 'a@b.com',
+      sessionId: 'sid-g1',
+      createdAt: Date.now(),
+    });
+    (fastify.repositories.oauthClients.findByClientId as unknown as Mock).mockResolvedValue(CLIENT);
+
+    const { reply, state } = createReply();
+    await ctx.get!(
+      {
+        query: BASE_QUERY,
+        url: '/ui/consent?...',
+        headers: { cookie: `__Host-qauth_session=${signed}` },
+        ip: '127.0.0.1',
+      },
+      reply
+    );
+
+    const html = state.body as string;
+    expect(typeof html).toBe('string');
+    expect(html).toContain('Test App wants to access your account');
+    expect(html).toContain('csrf_token');
+    expect(state.headers['Content-Type']).toContain('text/html');
+    expect(state.headers['X-Frame-Options']).toBe('DENY');
+    expect(fastify.sessionUtils.setSession).toHaveBeenCalledOnce();
+  });
+});
+
+describe('UI /ui/consent POST — allow/deny', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('deny path redirects to redirect_uri with error=access_denied and preserves state', async () => {
+    const { fastify, ctx } = makeFastify();
+    await consentRoute(fastify);
+    const { signSessionId } = await import('../../helpers/session-cookie');
+    const signed = signSessionId('sid-d');
+    const csrf = 'csrf-token-value-deny';
+    (fastify.sessionUtils.getSession as unknown as Mock).mockResolvedValue({
+      userId: 'user-1',
+      email: 'a@b.com',
+      sessionId: 'sid-d',
+      csrfToken: csrf,
+      createdAt: Date.now(),
+    });
+    (fastify.repositories.oauthClients.findByClientId as unknown as Mock).mockResolvedValue(CLIENT);
+
+    const { reply, state } = createReply();
+    await ctx.post!(
+      {
+        body: {
+          decision: 'deny',
+          csrf_token: csrf,
+          client_id: 'app-123',
+          redirect_uri: 'https://example.com/cb',
+          state: 'xyz',
+          scope: 'email',
+          code_challenge: 'A'.repeat(43),
+          code_challenge_method: 'S256',
+          response_type: 'code',
+        },
+        headers: { cookie: `__Host-qauth_session=${signed}` },
+        ip: '127.0.0.1',
+      },
+      reply
+    );
+
+    expect(state.redirected).toContain('https://example.com/cb');
+    expect(state.redirected).toContain('error=access_denied');
+    expect(state.redirected).toContain('state=xyz');
+    expect(fastify.repositories.authorizationCodes.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects when CSRF token does not match', async () => {
+    const { fastify, ctx } = makeFastify();
+    await consentRoute(fastify);
+    const { signSessionId } = await import('../../helpers/session-cookie');
+    const signed = signSessionId('sid-bad');
+    (fastify.sessionUtils.getSession as unknown as Mock).mockResolvedValue({
+      userId: 'user-1',
+      email: 'a@b.com',
+      sessionId: 'sid-bad',
+      csrfToken: 'expected-csrf-token',
+      createdAt: Date.now(),
+    });
+
+    const { reply } = createReply();
+    await expect(
+      ctx.post!(
+        {
+          body: {
+            decision: 'allow',
+            csrf_token: 'attacker-guessed',
+            client_id: 'app-123',
+            redirect_uri: 'https://example.com/cb',
+            code_challenge: 'A'.repeat(43),
+            code_challenge_method: 'S256',
+            response_type: 'code',
+          },
+          headers: { cookie: `__Host-qauth_session=${signed}` },
+          ip: '127.0.0.1',
+        },
+        reply
+      )
+    ).rejects.toThrow(/invalid_csrf_token/);
+  });
+
+  it('allow + allow_forever persists consent and issues an authorization code', async () => {
+    const { fastify, ctx } = makeFastify();
+    await consentRoute(fastify);
+    const { signSessionId } = await import('../../helpers/session-cookie');
+    const signed = signSessionId('sid-a');
+    const csrf = 'csrf-token-allow';
+    (fastify.sessionUtils.getSession as unknown as Mock).mockResolvedValue({
+      userId: 'user-1',
+      email: 'a@b.com',
+      sessionId: 'sid-a',
+      csrfToken: csrf,
+      createdAt: Date.now(),
+    });
+    (fastify.repositories.oauthClients.findByClientId as unknown as Mock).mockResolvedValue(CLIENT);
+
+    const { reply, state } = createReply();
+    await ctx.post!(
+      {
+        body: {
+          decision: 'allow',
+          allow_forever: '1',
+          csrf_token: csrf,
+          client_id: 'app-123',
+          redirect_uri: 'https://example.com/cb',
+          state: 'xyz',
+          scope: 'email',
+          code_challenge: 'A'.repeat(43),
+          code_challenge_method: 'S256',
+          response_type: 'code',
+        },
+        headers: { cookie: `__Host-qauth_session=${signed}` },
+        ip: '127.0.0.1',
+      },
+      reply
+    );
+
+    expect(fastify.repositories.oauthConsents.upsertGrant).toHaveBeenCalledWith(
+      'user-1',
+      'client-uuid-1',
+      'realm-1',
+      ['email']
+    );
+    expect(fastify.repositories.authorizationCodes.create).toHaveBeenCalledOnce();
+    expect(state.redirected).toContain('https://example.com/cb');
+    expect(state.redirected).toContain('code=');
+    expect(state.redirected).toContain('state=xyz');
+  });
+
+  it('allow without allow_forever issues code but does NOT persist consent', async () => {
+    const { fastify, ctx } = makeFastify();
+    await consentRoute(fastify);
+    const { signSessionId } = await import('../../helpers/session-cookie');
+    const signed = signSessionId('sid-once');
+    const csrf = 'csrf-once';
+    (fastify.sessionUtils.getSession as unknown as Mock).mockResolvedValue({
+      userId: 'user-1',
+      email: 'a@b.com',
+      sessionId: 'sid-once',
+      csrfToken: csrf,
+      createdAt: Date.now(),
+    });
+    (fastify.repositories.oauthClients.findByClientId as unknown as Mock).mockResolvedValue(CLIENT);
+
+    const { reply, state } = createReply();
+    await ctx.post!(
+      {
+        body: {
+          decision: 'allow',
+          csrf_token: csrf,
+          client_id: 'app-123',
+          redirect_uri: 'https://example.com/cb',
+          scope: 'email',
+          code_challenge: 'A'.repeat(43),
+          code_challenge_method: 'S256',
+          response_type: 'code',
+        },
+        headers: { cookie: `__Host-qauth_session=${signed}` },
+        ip: '127.0.0.1',
+      },
+      reply
+    );
+
+    expect(fastify.repositories.oauthConsents.upsertGrant).not.toHaveBeenCalled();
+    expect(fastify.repositories.authorizationCodes.create).toHaveBeenCalledOnce();
+    expect(state.redirected).toContain('https://example.com/cb');
+  });
+});

--- a/apps/auth-server/src/app/routes/ui/consent.ts
+++ b/apps/auth-server/src/app/routes/ui/consent.ts
@@ -1,0 +1,478 @@
+import { randomBytes } from 'node:crypto';
+
+import { BadRequestError, isUniqueConstraintError } from '@qauth-labs/shared-errors';
+import type { FastifyInstance } from 'fastify';
+import { ZodTypeProvider } from 'fastify-type-provider-zod';
+import { z } from 'zod';
+
+import { env } from '../../../config/env';
+import { AUTHORIZATION_CODE_TTL_MS } from '../../constants';
+import { resolveBrowserSession } from '../../helpers/browser-session';
+import {
+  canSkipConsent,
+  describeScope,
+  filterRequestedScopes,
+  isDynamicClientWithinBadgeWindow,
+} from '../../helpers/consent';
+import { html, render, safe } from '../../helpers/html';
+import { buildRedirectUrl } from '../../helpers/oauth-redirect';
+import { getOrCreateDefaultRealm } from '../../helpers/realm';
+import {
+  type BrowserSessionData,
+  csrfTokensEqual,
+  generateCsrfToken,
+} from '../../helpers/session-cookie';
+import { authorizeQuerySchema } from '../../schemas/oauth';
+
+/**
+ * Consent screen & Allow/Deny POST handler (issue #150).
+ *
+ * GET  /ui/consent — server-renders the consent page given the same query
+ *                    parameters as /oauth/authorize. Expects a signed
+ *                    session cookie; otherwise redirects to the login
+ *                    page with return_to=<original authorize url>.
+ * POST /ui/consent — processes Allow / Deny; on Allow, issues an
+ *                    authorization code and redirects to redirect_uri; on
+ *                    Deny, redirects with error=access_denied (RFC 6749
+ *                    §4.1.2.1). CSRF-protected via a form token bound to
+ *                    the signed session cookie.
+ */
+
+const consentFormSchema = z.object({
+  decision: z.enum(['allow', 'deny']),
+  allow_forever: z.string().optional(),
+  csrf_token: z.string().min(1),
+  // Mirror of the original authorize params so we don't need to stash them
+  // in the session (keeps the session payload small + stateless enough).
+  client_id: z.string().min(1),
+  redirect_uri: z.string().url(),
+  state: z.string().max(255).optional(),
+  scope: z.string().optional(),
+  nonce: z.string().max(255).optional(),
+  code_challenge: z.string().min(43).max(128),
+  code_challenge_method: z.literal('S256'),
+  response_type: z.literal('code'),
+});
+
+type ConsentForm = z.infer<typeof consentFormSchema>;
+
+function buildAuthorizeUrl(query: Record<string, string | undefined>): string {
+  const u = new URL('/oauth/authorize', 'http://placeholder');
+  for (const [k, v] of Object.entries(query)) {
+    if (v != null && v !== '') u.searchParams.set(k, v);
+  }
+  // Return only the path + query portion; login's return_to rejects absolute.
+  return `${u.pathname}?${u.searchParams.toString()}`;
+}
+
+function consentPage(opts: {
+  clientName: string;
+  clientHomepage?: string;
+  audience: string[];
+  scopes: string[];
+  badgeDynamic: boolean;
+  csrfToken: string;
+  authorizeParams: Record<string, string | undefined>;
+  userEmail: string;
+}): string {
+  const scopeRows = opts.scopes.length
+    ? opts.scopes.map((s) => html`<li><code>${s}</code> — ${describeScope(s)}</li>`)
+    : [html`<li><em>No scopes requested.</em></li>`];
+
+  const hidden = Object.entries(opts.authorizeParams)
+    .filter(([, v]) => v != null && v !== '')
+    .map(([k, v]) => html`<input type="hidden" name="${k}" value="${String(v)}" />`);
+
+  const audienceBlock = opts.audience.length
+    ? html`<p><strong>Tokens will be valid for:</strong> ${opts.audience.join(', ')}</p>`
+    : safe('');
+
+  const badge = opts.badgeDynamic
+    ? html`<div class="badge">
+        Newly registered application — double-check the name and URL before approving.
+      </div>`
+    : safe('');
+
+  const homepage = opts.clientHomepage
+    ? html`<p class="homepage">
+        <a href="${opts.clientHomepage}" rel="noopener noreferrer" target="_blank"
+          >${opts.clientHomepage}</a
+        >
+      </p>`
+    : safe('');
+
+  return render(
+    html`<!doctype html>
+      <html lang="en">
+        <head>
+          <meta charset="utf-8" />
+          <meta name="viewport" content="width=device-width,initial-scale=1" />
+          <meta name="robots" content="noindex" />
+          <title>Authorize ${opts.clientName}</title>
+          <style>
+            body {
+              font-family:
+                system-ui,
+                -apple-system,
+                Segoe UI,
+                Roboto,
+                sans-serif;
+              background: #f6f7f9;
+              color: #1a1a1a;
+              margin: 0;
+              min-height: 100vh;
+              display: flex;
+              align-items: center;
+              justify-content: center;
+            }
+            .card {
+              background: #fff;
+              padding: 32px;
+              border-radius: 12px;
+              box-shadow: 0 4px 24px rgba(0, 0, 0, 0.06);
+              width: 100%;
+              max-width: 520px;
+            }
+            h1 {
+              margin: 0 0 8px;
+              font-size: 20px;
+            }
+            .homepage a {
+              color: #2a5bd7;
+              font-size: 13px;
+            }
+            ul.scopes {
+              padding-left: 20px;
+            }
+            ul.scopes li {
+              margin: 6px 0;
+            }
+            code {
+              background: #f0f1f4;
+              padding: 1px 6px;
+              border-radius: 4px;
+              font-size: 12px;
+            }
+            .badge {
+              background: #fff4e5;
+              color: #8a4b08;
+              border: 1px solid #f5c16c;
+              border-radius: 6px;
+              padding: 10px 12px;
+              margin: 16px 0;
+              font-size: 13px;
+            }
+            .actions {
+              display: flex;
+              gap: 12px;
+              margin-top: 24px;
+            }
+            button {
+              flex: 1;
+              padding: 10px;
+              border-radius: 6px;
+              border: 0;
+              font-weight: 600;
+              font-size: 14px;
+              cursor: pointer;
+            }
+            button.allow {
+              background: #2a5bd7;
+              color: #fff;
+            }
+            button.deny {
+              background: #e9ecf2;
+              color: #1a1a1a;
+            }
+            .as-user {
+              color: #6b7280;
+              font-size: 13px;
+              margin-top: 0;
+            }
+            .forever {
+              font-size: 13px;
+              margin-top: 16px;
+              display: flex;
+              align-items: center;
+              gap: 8px;
+            }
+          </style>
+        </head>
+        <body>
+          <form class="card" method="post" action="/ui/consent">
+            <h1>${opts.clientName} wants to access your account</h1>
+            ${homepage}
+            <p class="as-user">Signed in as ${opts.userEmail}</p>
+            ${badge}
+            <p><strong>Requested access:</strong></p>
+            <ul class="scopes">
+              ${scopeRows}
+            </ul>
+            ${audienceBlock}
+            <label class="forever">
+              <input type="checkbox" name="allow_forever" value="1" checked />
+              Remember this decision
+            </label>
+            <input type="hidden" name="csrf_token" value="${opts.csrfToken}" />
+            ${hidden}
+            <div class="actions">
+              <button type="submit" name="decision" value="deny" class="deny">Deny</button>
+              <button type="submit" name="decision" value="allow" class="allow">Allow</button>
+            </div>
+          </form>
+        </body>
+      </html>`
+  );
+}
+
+export default async function (fastify: FastifyInstance) {
+  /**
+   * Render the consent page. Query parameters mirror /oauth/authorize so a
+   * 302 from that endpoint to here carries enough state to both render and
+   * re-issue the authorize call on Allow.
+   */
+  fastify.withTypeProvider<ZodTypeProvider>().get(
+    '/ui/consent',
+    {
+      schema: {
+        description:
+          'Render the OAuth consent screen. Requires a valid __Host-qauth_session cookie; otherwise redirects to /ui/login.',
+        tags: ['UI'],
+        querystring: authorizeQuerySchema,
+      },
+    },
+    async (request, reply) => {
+      const query = request.query as z.infer<typeof authorizeQuerySchema>;
+
+      const session = await resolveBrowserSession(fastify, request, reply);
+      if (!session) {
+        const returnTo = buildAuthorizeUrl(query);
+        return reply.redirect(`/ui/login?return_to=${encodeURIComponent(returnTo)}`, 302);
+      }
+
+      const realm = await getOrCreateDefaultRealm(fastify);
+      const client = await fastify.repositories.oauthClients.findByClientId(
+        realm.id,
+        query.client_id
+      );
+      if (!client || !client.enabled) {
+        throw new BadRequestError('invalid_client');
+      }
+      if (!client.redirectUris.includes(query.redirect_uri)) {
+        throw new BadRequestError('redirect_uri not registered');
+      }
+
+      const scopes = filterRequestedScopes(query.scope, client);
+
+      // Rotate the CSRF token on every consent render so an old page cannot
+      // be replayed. The same token is returned to the browser via the
+      // hidden form field *and* stored in the server-side session; the
+      // POST handler compares the two in a timing-safe way.
+      const csrfToken = generateCsrfToken();
+      await fastify.sessionUtils.setSession<BrowserSessionData>(
+        session.sessionId,
+        { ...session, csrfToken },
+        env.SESSION_COOKIE_TTL
+      );
+
+      reply.header('Content-Type', 'text/html; charset=utf-8');
+      reply.header('Cache-Control', 'no-store');
+      // OWASP: tighten rendering context against clickjacking / MIME sniffing.
+      reply.header('X-Frame-Options', 'DENY');
+      reply.header('X-Content-Type-Options', 'nosniff');
+      reply.header('Referrer-Policy', 'no-referrer');
+
+      return reply.send(
+        consentPage({
+          clientName: client.name,
+          clientHomepage: (client.metadata as Record<string, unknown> | null)?.homepage_uri as
+            | string
+            | undefined,
+          audience: client.audience ?? [],
+          scopes,
+          badgeDynamic: isDynamicClientWithinBadgeWindow(client),
+          csrfToken,
+          authorizeParams: {
+            client_id: query.client_id,
+            redirect_uri: query.redirect_uri,
+            state: query.state,
+            scope: query.scope,
+            nonce: query.nonce,
+            code_challenge: query.code_challenge,
+            code_challenge_method: query.code_challenge_method,
+            response_type: query.response_type,
+          },
+          userEmail: session.email,
+        })
+      );
+    }
+  );
+
+  /**
+   * Process the Allow / Deny decision. Emits a final redirect to the
+   * client's redirect_uri in both cases.
+   */
+  fastify.withTypeProvider<ZodTypeProvider>().post(
+    '/ui/consent',
+    {
+      schema: {
+        description:
+          'Submit the consent decision. CSRF-protected; re-uses the authorize params to issue a code on Allow.',
+        tags: ['UI'],
+        body: consentFormSchema,
+      },
+      config: {
+        rateLimit: {
+          max: env.AUTHORIZE_RATE_LIMIT,
+          timeWindow: env.AUTHORIZE_RATE_WINDOW * 1000,
+          keyGenerator: (req) => req.ip || 'unknown',
+        },
+      },
+    },
+    async (request, reply) => {
+      const body = request.body as ConsentForm;
+
+      const session = await resolveBrowserSession(fastify, request, reply);
+      if (!session) {
+        // No session: re-route through login then come straight back to
+        // authorize. We deliberately do NOT redirect into /ui/consent —
+        // /oauth/authorize is the canonical entry point and will re-check
+        // client validity.
+        const returnTo = buildAuthorizeUrl({
+          client_id: body.client_id,
+          redirect_uri: body.redirect_uri,
+          state: body.state,
+          scope: body.scope,
+          nonce: body.nonce,
+          code_challenge: body.code_challenge,
+          code_challenge_method: body.code_challenge_method,
+          response_type: body.response_type,
+        });
+        return reply.redirect(`/ui/login?return_to=${encodeURIComponent(returnTo)}`, 302);
+      }
+
+      if (!csrfTokensEqual(session.csrfToken, body.csrf_token)) {
+        await fastify.repositories.auditLogs.create({
+          userId: session.userId,
+          oauthClientId: null,
+          event: 'oauth.consent.csrf_failure',
+          eventType: 'auth',
+          success: false,
+          ipAddress: request.ip,
+          userAgent: request.headers['user-agent'] || null,
+          metadata: { client_id: body.client_id },
+        });
+        throw new BadRequestError('invalid_csrf_token');
+      }
+
+      // Burn the CSRF token so the form cannot be replayed. A fresh one is
+      // minted on the next GET /ui/consent render.
+      await fastify.sessionUtils.setSession<BrowserSessionData>(
+        session.sessionId,
+        { ...session, csrfToken: undefined },
+        env.SESSION_COOKIE_TTL
+      );
+
+      const realm = await getOrCreateDefaultRealm(fastify);
+      const client = await fastify.repositories.oauthClients.findByClientId(
+        realm.id,
+        body.client_id
+      );
+      if (!client || !client.enabled) {
+        throw new BadRequestError('invalid_client');
+      }
+      if (!client.redirectUris.includes(body.redirect_uri)) {
+        throw new BadRequestError('redirect_uri not registered');
+      }
+
+      // Deny path: redirect with error=access_denied, state preserved
+      // (RFC 6749 §4.1.2.1).
+      if (body.decision === 'deny') {
+        await fastify.repositories.auditLogs.create({
+          userId: session.userId,
+          oauthClientId: client.id,
+          event: 'oauth.consent.denied',
+          eventType: 'auth',
+          success: false,
+          ipAddress: request.ip,
+          userAgent: request.headers['user-agent'] || null,
+          metadata: { client_id: body.client_id },
+        });
+        return reply.redirect(
+          buildRedirectUrl(body.redirect_uri, {
+            error: 'access_denied',
+            error_description: 'User denied the authorization request.',
+            state: body.state ?? undefined,
+          }),
+          302
+        );
+      }
+
+      // Allow: persist the grant if the user checked the box, then issue a
+      // code. The grant upsert merges with any prior record so subsequent
+      // requests with a subset of these scopes skip the screen.
+      const scopes = filterRequestedScopes(body.scope, client);
+      if (body.allow_forever === '1') {
+        await fastify.repositories.oauthConsents.upsertGrant(
+          session.userId,
+          client.id,
+          realm.id,
+          scopes
+        );
+      }
+
+      const expiresAt = Date.now() + AUTHORIZATION_CODE_TTL_MS;
+      const MAX_CREATE_ATTEMPTS = 3;
+      let code: string | null = null;
+      for (let attempt = 0; attempt < MAX_CREATE_ATTEMPTS; attempt++) {
+        try {
+          const candidate = randomBytes(32).toString('base64url');
+          await fastify.repositories.authorizationCodes.create({
+            code: candidate,
+            oauthClientId: client.id,
+            userId: session.userId,
+            redirectUri: body.redirect_uri,
+            codeChallenge: body.code_challenge,
+            codeChallengeMethod: 'S256',
+            nonce: body.nonce ?? null,
+            scopes,
+            state: body.state ?? null,
+            expiresAt,
+          });
+          code = candidate;
+          break;
+        } catch (err) {
+          if (!isUniqueConstraintError(err)) throw err;
+          if (attempt === MAX_CREATE_ATTEMPTS - 1) throw err;
+        }
+      }
+      if (!code) throw new Error('Unreachable');
+
+      await fastify.repositories.auditLogs.create({
+        userId: session.userId,
+        oauthClientId: client.id,
+        event: 'oauth.consent.granted',
+        eventType: 'auth',
+        success: true,
+        ipAddress: request.ip,
+        userAgent: request.headers['user-agent'] || null,
+        metadata: {
+          client_id: body.client_id,
+          scopes,
+          remembered: body.allow_forever === '1',
+        },
+      });
+
+      return reply.redirect(
+        buildRedirectUrl(body.redirect_uri, {
+          code,
+          state: body.state ?? undefined,
+        }),
+        302
+      );
+    }
+  );
+}
+
+// Exported for the /oauth/authorize fast-path (skip-consent branch).
+export { canSkipConsent };

--- a/apps/auth-server/src/app/routes/ui/login.ts
+++ b/apps/auth-server/src/app/routes/ui/login.ts
@@ -1,0 +1,260 @@
+import { randomUUID } from 'node:crypto';
+
+import { normalizeEmail } from '@qauth-labs/shared-validation';
+import type { FastifyInstance } from 'fastify';
+import { ZodTypeProvider } from 'fastify-type-provider-zod';
+import { z } from 'zod';
+
+import { env } from '../../../config/env';
+import { MIN_RESPONSE_TIME_MS } from '../../constants';
+import { html, render } from '../../helpers/html';
+import { getOrCreateDefaultRealm } from '../../helpers/realm';
+import { setSessionCookie } from '../../helpers/session-cookie';
+import { ensureMinimumResponseTime } from '../../helpers/timing';
+
+/**
+ * Server-rendered login page (issue #150).
+ *
+ * Mounted under `/ui/*` to keep a hard boundary from the JSON APIs under
+ * `/auth/*`: this handler sets a signed session cookie and redirects,
+ * whereas `/auth/login` returns access + refresh tokens as JSON. The two
+ * entry points share the same underlying password verification.
+ *
+ * The `return_to` query string is validated to be a relative path on our
+ * own origin so we cannot be abused as an open redirector. Any failing
+ * input falls back to `/`.
+ */
+
+function isSafeReturnTo(value: unknown): value is string {
+  if (typeof value !== 'string') return false;
+  if (value.length === 0) return false;
+  // Disallow absolute URLs, protocol-relative, or anything that doesn't
+  // start with a single `/`. This keeps us off the open-redirector list.
+  if (!value.startsWith('/')) return false;
+  if (value.startsWith('//')) return false;
+  return true;
+}
+
+function loginPage(opts: { returnTo: string; error?: string; email?: string }): string {
+  const { returnTo, error, email } = opts;
+  return render(
+    html`<!doctype html>
+      <html lang="en">
+        <head>
+          <meta charset="utf-8" />
+          <meta name="viewport" content="width=device-width,initial-scale=1" />
+          <meta name="robots" content="noindex" />
+          <title>Sign in — QAuth</title>
+          <style>
+            body {
+              font-family:
+                system-ui,
+                -apple-system,
+                Segoe UI,
+                Roboto,
+                sans-serif;
+              background: #f6f7f9;
+              color: #1a1a1a;
+              margin: 0;
+              min-height: 100vh;
+              display: flex;
+              align-items: center;
+              justify-content: center;
+            }
+            .card {
+              background: #fff;
+              padding: 32px;
+              border-radius: 12px;
+              box-shadow: 0 4px 24px rgba(0, 0, 0, 0.06);
+              width: 100%;
+              max-width: 380px;
+            }
+            h1 {
+              margin: 0 0 24px;
+              font-size: 20px;
+            }
+            label {
+              display: block;
+              margin-top: 16px;
+              font-size: 13px;
+              font-weight: 600;
+            }
+            input[type='email'],
+            input[type='password'] {
+              display: block;
+              width: 100%;
+              padding: 10px 12px;
+              margin-top: 6px;
+              border: 1px solid #d8dbe0;
+              border-radius: 6px;
+              font-size: 14px;
+              box-sizing: border-box;
+            }
+            button {
+              margin-top: 24px;
+              width: 100%;
+              padding: 10px;
+              border: 0;
+              border-radius: 6px;
+              background: #2a5bd7;
+              color: #fff;
+              font-weight: 600;
+              font-size: 14px;
+              cursor: pointer;
+            }
+            .error {
+              background: #fdecea;
+              color: #a1261b;
+              padding: 10px 12px;
+              border-radius: 6px;
+              font-size: 13px;
+              margin-bottom: 16px;
+            }
+          </style>
+        </head>
+        <body>
+          <form class="card" method="post" action="/ui/login">
+            <h1>Sign in to QAuth</h1>
+            ${error ? html`<div class="error">${error}</div>` : ''}
+            <input type="hidden" name="return_to" value="${returnTo}" />
+            <label>
+              Email
+              <input
+                type="email"
+                name="email"
+                autocomplete="username"
+                required
+                value="${email ?? ''}"
+              />
+            </label>
+            <label>
+              Password
+              <input type="password" name="password" autocomplete="current-password" required />
+            </label>
+            <button type="submit">Sign in</button>
+          </form>
+        </body>
+      </html>`
+  );
+}
+
+const loginFormSchema = z.object({
+  email: z.string().min(1),
+  password: z.string().min(1),
+  return_to: z.string().optional(),
+});
+
+type LoginForm = z.infer<typeof loginFormSchema>;
+
+export default async function (fastify: FastifyInstance) {
+  fastify.withTypeProvider<ZodTypeProvider>().get(
+    '/ui/login',
+    {
+      schema: {
+        description:
+          'Renders the session-cookie login page. `return_to` is a relative path to redirect to after a successful sign-in. Issue #150.',
+        tags: ['UI'],
+        querystring: z.object({
+          return_to: z.string().optional(),
+          error: z.string().optional(),
+        }),
+      },
+    },
+    async (request, reply) => {
+      const q = request.query as { return_to?: string; error?: string };
+      const returnTo = isSafeReturnTo(q.return_to) ? q.return_to : '/';
+      reply.header('Content-Type', 'text/html; charset=utf-8');
+      reply.header('Cache-Control', 'no-store');
+      return reply.send(loginPage({ returnTo, error: q.error }));
+    }
+  );
+
+  fastify.withTypeProvider<ZodTypeProvider>().post(
+    '/ui/login',
+    {
+      schema: {
+        description: 'Submit the session-cookie login form. Sets __Host-qauth_session on success.',
+        tags: ['UI'],
+        body: loginFormSchema,
+      },
+      config: {
+        rateLimit: {
+          max: env.LOGIN_RATE_LIMIT,
+          timeWindow: env.LOGIN_RATE_WINDOW * 1000,
+          keyGenerator: (request) => request.ip || 'unknown',
+        },
+      },
+    },
+    async (request, reply) => {
+      const startTime = Date.now();
+      const body = request.body as LoginForm;
+      const returnTo = isSafeReturnTo(body.return_to) ? body.return_to : '/';
+      const normalizedEmail = normalizeEmail(body.email);
+
+      const realm = await getOrCreateDefaultRealm(fastify);
+      const user = await fastify.repositories.users.findByEmail(realm.id, normalizedEmail);
+
+      let passwordValid = false;
+      if (user) {
+        passwordValid = await fastify.passwordHasher.verifyPassword(
+          user.passwordHash,
+          body.password
+        );
+      }
+
+      if (!user || !passwordValid || !user.enabled) {
+        await ensureMinimumResponseTime(startTime, MIN_RESPONSE_TIME_MS.LOGIN);
+        await fastify.repositories.auditLogs.create({
+          userId: null,
+          oauthClientId: null,
+          event: 'ui.login.failure',
+          eventType: 'auth',
+          success: false,
+          ipAddress: request.ip,
+          userAgent: request.headers['user-agent'] || null,
+          metadata: { email: normalizedEmail },
+        });
+        reply.header('Content-Type', 'text/html; charset=utf-8');
+        reply.header('Cache-Control', 'no-store');
+        reply.code(401);
+        return reply.send(
+          loginPage({
+            returnTo,
+            error: 'Invalid email or password.',
+            email: body.email,
+          })
+        );
+      }
+
+      // Session-fixation defense: always mint a fresh session id on a
+      // successful credential check, even if the browser already had one.
+      const sessionId = randomUUID();
+      await fastify.sessionUtils.setSession(
+        sessionId,
+        {
+          userId: user.id,
+          email: user.email,
+          sessionId,
+          createdAt: Date.now(),
+        },
+        env.SESSION_COOKIE_TTL
+      );
+
+      await fastify.repositories.users.updateLastLogin(user.id);
+      await fastify.repositories.auditLogs.create({
+        userId: user.id,
+        oauthClientId: null,
+        event: 'ui.login.success',
+        eventType: 'auth',
+        success: true,
+        ipAddress: request.ip,
+        userAgent: request.headers['user-agent'] || null,
+        metadata: { sessionId, returnTo },
+      });
+
+      setSessionCookie(reply, sessionId);
+      reply.header('Cache-Control', 'no-store');
+      return reply.redirect(returnTo, 302);
+    }
+  );
+}

--- a/apps/developer-portal/src/routeTree.gen.ts
+++ b/apps/developer-portal/src/routeTree.gen.ts
@@ -8,61 +8,79 @@
 // You should NOT make any changes in this file as it will be overwritten.
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
-import { Route as rootRouteImport } from './routes/__root';
-import { Route as IndexRouteImport } from './routes/index';
+import { Route as rootRouteImport } from './routes/__root'
+import { Route as ConsentsRouteImport } from './routes/consents'
+import { Route as IndexRouteImport } from './routes/index'
 
+const ConsentsRoute = ConsentsRouteImport.update({
+  id: '/consents',
+  path: '/consents',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 
 export interface FileRoutesByFullPath {
-  '/': typeof IndexRoute;
+  '/': typeof IndexRoute
+  '/consents': typeof ConsentsRoute
 }
 export interface FileRoutesByTo {
-  '/': typeof IndexRoute;
+  '/': typeof IndexRoute
+  '/consents': typeof ConsentsRoute
 }
 export interface FileRoutesById {
-  __root__: typeof rootRouteImport;
-  '/': typeof IndexRoute;
+  __root__: typeof rootRouteImport
+  '/': typeof IndexRoute
+  '/consents': typeof ConsentsRoute
 }
 export interface FileRouteTypes {
-  fileRoutesByFullPath: FileRoutesByFullPath;
-  fullPaths: '/';
-  fileRoutesByTo: FileRoutesByTo;
-  to: '/';
-  id: '__root__' | '/';
-  fileRoutesById: FileRoutesById;
+  fileRoutesByFullPath: FileRoutesByFullPath
+  fullPaths: '/' | '/consents'
+  fileRoutesByTo: FileRoutesByTo
+  to: '/' | '/consents'
+  id: '__root__' | '/' | '/consents'
+  fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
-  IndexRoute: typeof IndexRoute;
+  IndexRoute: typeof IndexRoute
+  ConsentsRoute: typeof ConsentsRoute
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/consents': {
+      id: '/consents'
+      path: '/consents'
+      fullPath: '/consents'
+      preLoaderRoute: typeof ConsentsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/': {
-      id: '/';
-      path: '/';
-      fullPath: '/';
-      preLoaderRoute: typeof IndexRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
+      id: '/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
   }
 }
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
-};
+  ConsentsRoute: ConsentsRoute,
+}
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)
-  ._addFileTypes<FileRouteTypes>();
+  ._addFileTypes<FileRouteTypes>()
 
-import type { getRouter } from './router.tsx';
-import type { createStart } from '@tanstack/react-start';
+import type { getRouter } from './router.tsx'
+import type { createStart } from '@tanstack/react-start'
 declare module '@tanstack/react-start' {
   interface Register {
-    ssr: true;
-    router: Awaited<ReturnType<typeof getRouter>>;
+    ssr: true
+    router: Awaited<ReturnType<typeof getRouter>>
   }
 }

--- a/apps/developer-portal/src/routes/consents.tsx
+++ b/apps/developer-portal/src/routes/consents.tsx
@@ -1,0 +1,159 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { useEffect, useState } from 'react';
+
+/**
+ * Developer-portal consent revocation screen (issue #150, acceptance
+ * criterion 6: "Revocation UI in developer portal").
+ *
+ * Minimal by design — the scope guidance was list + revoke button, no
+ * polish. A user lands here from account settings, sees the apps they
+ * have authorized, and can take back any grant. Revoking a row forces a
+ * fresh consent prompt the next time the app tries /oauth/authorize
+ * (because `findActive` will return undefined).
+ *
+ * Uses `credentials: 'include'` so the browser sends the
+ * __Host-qauth_session cookie to the auth-server even on cross-origin
+ * deployments. The auth-server checks ownership on each call; the UI is
+ * not a trust boundary.
+ */
+
+export const Route = createFileRoute('/consents')({
+  component: ConsentsPage,
+});
+
+interface ConsentRow {
+  id: string;
+  clientId: string;
+  clientName: string;
+  scopes: string[];
+  grantedAt: number;
+}
+
+const AUTH_SERVER_URL =
+  (typeof import.meta !== 'undefined' &&
+    (import.meta as ImportMeta & { env?: { VITE_AUTH_SERVER_URL?: string } }).env
+      ?.VITE_AUTH_SERVER_URL) ||
+  '';
+
+function ConsentsPage() {
+  const [rows, setRows] = useState<ConsentRow[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState<string | null>(null);
+
+  async function load() {
+    try {
+      const res = await fetch(`${AUTH_SERVER_URL}/consents`, {
+        credentials: 'include',
+      });
+      if (res.status === 401) {
+        setError('Please sign in to manage authorized applications.');
+        setRows([]);
+        return;
+      }
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const body = (await res.json()) as { consents: ConsentRow[] };
+      setRows(body.consents);
+      setError(null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load consents');
+      setRows([]);
+    }
+  }
+
+  useEffect(() => {
+    void load();
+  }, []);
+
+  async function revoke(id: string) {
+    setBusy(id);
+    try {
+      const res = await fetch(`${AUTH_SERVER_URL}/consents/${id}`, {
+        method: 'DELETE',
+        credentials: 'include',
+      });
+      if (!res.ok && res.status !== 204) {
+        throw new Error(`HTTP ${res.status}`);
+      }
+      // Optimistic — drop the row immediately.
+      setRows((current) => (current ?? []).filter((r) => r.id !== id));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to revoke consent');
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  return (
+    <main style={{ maxWidth: 720, margin: '32px auto', padding: '0 16px' }}>
+      <h1>Authorized applications</h1>
+      <p style={{ color: '#555' }}>
+        These applications can access your account. Revoking a grant forces the app to ask for
+        permission again next time it tries to sign you in.
+      </p>
+
+      {error ? (
+        <div
+          role="alert"
+          style={{
+            background: '#fdecea',
+            color: '#a1261b',
+            padding: '10px 12px',
+            borderRadius: 6,
+            marginBottom: 16,
+          }}
+        >
+          {error}
+        </div>
+      ) : null}
+
+      {rows === null ? <p>Loading…</p> : null}
+
+      {rows && rows.length === 0 && !error ? (
+        <p>You have not authorized any applications yet.</p>
+      ) : null}
+
+      {rows && rows.length > 0 ? (
+        <ul style={{ listStyle: 'none', padding: 0 }}>
+          {rows.map((r) => (
+            <li
+              key={r.id}
+              style={{
+                border: '1px solid #e1e3ea',
+                borderRadius: 8,
+                padding: 16,
+                marginBottom: 12,
+                display: 'flex',
+                justifyContent: 'space-between',
+                alignItems: 'center',
+              }}
+            >
+              <div>
+                <div style={{ fontWeight: 600 }}>{r.clientName}</div>
+                <div style={{ color: '#555', fontSize: 13 }}>
+                  <code>{r.clientId}</code> · granted {new Date(r.grantedAt).toLocaleString()}
+                </div>
+                <div style={{ color: '#555', fontSize: 13, marginTop: 4 }}>
+                  Scopes: {r.scopes.length ? r.scopes.join(', ') : '(none)'}
+                </div>
+              </div>
+              <button
+                type="button"
+                disabled={busy === r.id}
+                onClick={() => void revoke(r.id)}
+                style={{
+                  background: '#e9ecf2',
+                  border: 0,
+                  padding: '8px 14px',
+                  borderRadius: 6,
+                  cursor: 'pointer',
+                }}
+              >
+                {busy === r.id ? 'Revoking…' : 'Revoke'}
+              </button>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+    </main>
+  );
+}

--- a/libs/fastify/plugins/db/src/lib/fastify-plugin-db.ts
+++ b/libs/fastify/plugins/db/src/lib/fastify-plugin-db.ts
@@ -5,6 +5,7 @@ import {
   createDatabase,
   createEmailVerificationTokensRepository,
   createOAuthClientsRepository,
+  createOAuthConsentsRepository,
   createRealmsRepository,
   createRefreshTokensRepository,
   createUsersRepository,
@@ -12,6 +13,7 @@ import {
   type DbClient,
   type EmailVerificationTokensRepository,
   OAuthClientsRepository,
+  type OAuthConsentsRepository,
   type RealmsRepository,
   type RefreshTokensRepository,
   type UsersRepository,
@@ -31,6 +33,7 @@ declare module 'fastify' {
       realms: RealmsRepository;
       emailVerificationTokens: EmailVerificationTokensRepository;
       oauthClients: OAuthClientsRepository;
+      oauthConsents: OAuthConsentsRepository;
       refreshTokens: RefreshTokensRepository;
       authorizationCodes: AuthorizationCodesRepository;
       auditLogs: ReturnType<typeof createAuditLogsRepository>;
@@ -69,6 +72,7 @@ export const databasePlugin = fp<DatabasePluginOptions>(
       realms: createRealmsRepository(database.db),
       emailVerificationTokens: createEmailVerificationTokensRepository(database.db),
       oauthClients: createOAuthClientsRepository(database.db),
+      oauthConsents: createOAuthConsentsRepository(database.db),
       refreshTokens: createRefreshTokensRepository(database.db),
       authorizationCodes: createAuthorizationCodesRepository(database.db),
       auditLogs: createAuditLogsRepository(database.db),

--- a/libs/infra/db/drizzle/0002_add_oauth_consents_and_dynamic_client_flag.sql
+++ b/libs/infra/db/drizzle/0002_add_oauth_consents_and_dynamic_client_flag.sql
@@ -1,0 +1,34 @@
+-- Consent screen support (issue #150)
+--
+-- Adds the `oauth_consents` table that stores user grants per (user, client),
+-- plus a `dynamic_registered_at` column on `oauth_clients` consumed by the
+-- consent UI to badge recently-dynamic-registered clients. Null means the
+-- client was provisioned via the normal developer flow and is not "new".
+
+CREATE TABLE "oauth_consents" (
+  "id" uuid PRIMARY KEY DEFAULT uuidv7() NOT NULL,
+  "user_id" uuid NOT NULL,
+  "oauth_client_id" uuid NOT NULL,
+  "realm_id" uuid NOT NULL,
+  "scopes" jsonb DEFAULT '[]'::jsonb NOT NULL,
+  "granted_at" bigint DEFAULT (EXTRACT(EPOCH FROM now()) * 1000)::bigint NOT NULL,
+  "revoked_at" bigint,
+  CONSTRAINT "oauth_consents_user_id_users_id_fk"
+    FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE,
+  CONSTRAINT "oauth_consents_oauth_client_id_oauth_clients_id_fk"
+    FOREIGN KEY ("oauth_client_id") REFERENCES "oauth_clients"("id") ON DELETE CASCADE,
+  CONSTRAINT "oauth_consents_realm_id_realms_id_fk"
+    FOREIGN KEY ("realm_id") REFERENCES "realms"("id") ON DELETE CASCADE
+);
+
+-- Partial unique index: one active (non-revoked) consent per (user, client).
+CREATE UNIQUE INDEX "idx_oauth_consents_user_client_active"
+  ON "oauth_consents" ("user_id", "oauth_client_id")
+  WHERE "revoked_at" IS NULL;
+
+CREATE INDEX "idx_oauth_consents_user_id" ON "oauth_consents" ("user_id");
+CREATE INDEX "idx_oauth_consents_client_id" ON "oauth_consents" ("oauth_client_id");
+CREATE INDEX "idx_oauth_consents_realm_id" ON "oauth_consents" ("realm_id");
+
+ALTER TABLE "oauth_clients"
+  ADD COLUMN "dynamic_registered_at" bigint;

--- a/libs/infra/db/drizzle/meta/_journal.json
+++ b/libs/infra/db/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1776371685401,
       "tag": "0001_add_oauth_clients_audience",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1777372800000,
+      "tag": "0002_add_oauth_consents_and_dynamic_client_flag",
+      "breakpoints": true
     }
   ]
 }

--- a/libs/infra/db/src/lib/repositories/index.ts
+++ b/libs/infra/db/src/lib/repositories/index.ts
@@ -6,6 +6,7 @@ export * from './audit-logs.repository';
 export * from './authorization-codes.repository';
 export * from './email-verification-tokens.repository';
 export * from './oauth-clients.repository';
+export * from './oauth-consents.repository';
 export * from './realms.repository';
 export * from './refresh-tokens.repository';
 export * from './users.repository';

--- a/libs/infra/db/src/lib/repositories/oauth-consents.repository.ts
+++ b/libs/infra/db/src/lib/repositories/oauth-consents.repository.ts
@@ -1,0 +1,122 @@
+import { NotFoundError } from '@qauth-labs/shared-errors';
+import { and, desc, eq, isNull } from 'drizzle-orm';
+
+import type {
+  NewOAuthConsent,
+  OAuthConsent,
+  OAuthConsentsRepository,
+} from '../../types/repository';
+import { DbClient } from '../db';
+import { oauthConsents } from '../schema/consents';
+
+/**
+ * Factory for the oauth_consents repository.
+ *
+ * Consent rows are write-once from the user's perspective: a grant creates a
+ * row, a revoke sets `revokedAt`, and subsequent consent for the same
+ * (user, client) pair inserts a new active row rather than resurrecting the
+ * revoked one. This preserves history for audit while keeping a partial
+ * unique index enforceable on the active row.
+ */
+export function createOAuthConsentsRepository(defaultDb: DbClient): OAuthConsentsRepository {
+  return {
+    async create(data: NewOAuthConsent, tx?: DbClient): Promise<OAuthConsent> {
+      const invoker = tx ?? defaultDb;
+      const [row] = await invoker.insert(oauthConsents).values(data).returning();
+      return row;
+    },
+
+    async findActive(
+      userId: string,
+      oauthClientId: string,
+      tx?: DbClient
+    ): Promise<OAuthConsent | undefined> {
+      const invoker = tx ?? defaultDb;
+      const [row] = await invoker
+        .select()
+        .from(oauthConsents)
+        .where(
+          and(
+            eq(oauthConsents.userId, userId),
+            eq(oauthConsents.oauthClientId, oauthClientId),
+            isNull(oauthConsents.revokedAt)
+          )
+        )
+        .limit(1);
+      return row;
+    },
+
+    async listActiveForUser(userId: string, tx?: DbClient): Promise<OAuthConsent[]> {
+      const invoker = tx ?? defaultDb;
+      return invoker
+        .select()
+        .from(oauthConsents)
+        .where(and(eq(oauthConsents.userId, userId), isNull(oauthConsents.revokedAt)))
+        .orderBy(desc(oauthConsents.grantedAt));
+    },
+
+    async upsertGrant(
+      userId: string,
+      oauthClientId: string,
+      realmId: string,
+      scopes: string[],
+      tx?: DbClient
+    ): Promise<OAuthConsent> {
+      const invoker = tx ?? defaultDb;
+      const now = Date.now();
+
+      const [existing] = await invoker
+        .select()
+        .from(oauthConsents)
+        .where(
+          and(
+            eq(oauthConsents.userId, userId),
+            eq(oauthConsents.oauthClientId, oauthClientId),
+            isNull(oauthConsents.revokedAt)
+          )
+        )
+        .limit(1);
+
+      if (existing) {
+        // Union the scope sets so a narrower subsequent grant cannot silently
+        // remove previously-granted scopes. Callers rely on this to detect
+        // "already consented" for scope-subset checks.
+        const union = Array.from(new Set([...existing.scopes, ...scopes])).sort();
+        const [updated] = await invoker
+          .update(oauthConsents)
+          .set({ scopes: union, grantedAt: now })
+          .where(eq(oauthConsents.id, existing.id))
+          .returning();
+        return updated;
+      }
+
+      const [created] = await invoker
+        .insert(oauthConsents)
+        .values({
+          userId,
+          oauthClientId,
+          realmId,
+          scopes: [...scopes].sort(),
+          grantedAt: now,
+        })
+        .returning();
+      return created;
+    },
+
+    async revoke(id: string, tx?: DbClient): Promise<OAuthConsent> {
+      const invoker = tx ?? defaultDb;
+      const now = Date.now();
+
+      const [row] = await invoker
+        .update(oauthConsents)
+        .set({ revokedAt: now })
+        .where(and(eq(oauthConsents.id, id), isNull(oauthConsents.revokedAt)))
+        .returning();
+
+      if (!row) {
+        throw new NotFoundError('OAuthConsent', id);
+      }
+      return row;
+    },
+  };
+}

--- a/libs/infra/db/src/lib/schema/consents.ts
+++ b/libs/infra/db/src/lib/schema/consents.ts
@@ -1,0 +1,56 @@
+import { relations, sql } from 'drizzle-orm';
+import { bigint, index, jsonb, pgTable, uniqueIndex, uuid } from 'drizzle-orm/pg-core';
+
+import { oauthClients, realms, users } from './core';
+import { EPOCH_MS_NOW, JSONB_EMPTY_ARRAY } from './sql-helpers';
+
+/**
+ * OAuth user consent records.
+ *
+ * One row per (user, client, realm) — stores the set of scopes the user has
+ * granted. Consent is indefinite once granted; revocation sets `revokedAt`
+ * and the row is retained for audit purposes.
+ *
+ * Scope-subset check: a new authorization request can skip the consent screen
+ * iff every requested scope is present in an active (not revoked) consent
+ * record's `scopes` array. See `apps/auth-server/.../helpers/consent.ts`.
+ */
+export const oauthConsents = pgTable(
+  'oauth_consents',
+  {
+    id: uuid('id')
+      .primaryKey()
+      .default(sql`uuidv7()`),
+    userId: uuid('user_id')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    oauthClientId: uuid('oauth_client_id')
+      .notNull()
+      .references(() => oauthClients.id, { onDelete: 'cascade' }),
+    realmId: uuid('realm_id')
+      .notNull()
+      .references(() => realms.id, { onDelete: 'cascade' }),
+    scopes: jsonb('scopes').notNull().default(JSONB_EMPTY_ARRAY).$type<string[]>(),
+    grantedAt: bigint('granted_at', { mode: 'number' }).notNull().default(EPOCH_MS_NOW),
+    revokedAt: bigint('revoked_at', { mode: 'number' }),
+  },
+  (t) => [
+    // Active (not revoked) consent per (user, client) is unique — a revoke
+    // followed by a new grant creates a new row rather than mutating.
+    uniqueIndex('idx_oauth_consents_user_client_active')
+      .on(t.userId, t.oauthClientId)
+      .where(sql`${t.revokedAt} IS NULL`),
+    index('idx_oauth_consents_user_id').on(t.userId),
+    index('idx_oauth_consents_client_id').on(t.oauthClientId),
+    index('idx_oauth_consents_realm_id').on(t.realmId),
+  ]
+);
+
+export const oauthConsentsRelations = relations(oauthConsents, ({ one }) => ({
+  user: one(users, { fields: [oauthConsents.userId], references: [users.id] }),
+  oauthClient: one(oauthClients, {
+    fields: [oauthConsents.oauthClientId],
+    references: [oauthClients.id],
+  }),
+  realm: one(realms, { fields: [oauthConsents.realmId], references: [realms.id] }),
+}));

--- a/libs/infra/db/src/lib/schema/core.ts
+++ b/libs/infra/db/src/lib/schema/core.ts
@@ -126,6 +126,13 @@ export const oauthClients = pgTable(
       .default(sql`'["code"]'::jsonb`)
       .$type<ResponseType[]>(),
     developerId: uuid('developer_id').references(() => users.id, { onDelete: 'set null' }),
+    /**
+     * Set when the client was created via dynamic client registration (RFC 7591).
+     * Null for hand-provisioned / first-party clients. Consumed by the consent
+     * screen to show a "newly registered" phishing-defense badge — callers
+     * MUST treat null as "not dynamic" and therefore not new.
+     */
+    dynamicRegisteredAt: bigint('dynamic_registered_at', { mode: 'number' }),
     metadata: jsonb('metadata').$type<Record<string, unknown> | null>(),
     createdAt: bigint('created_at', { mode: 'number' }).notNull().default(EPOCH_MS_NOW),
     updatedAt: bigint('updated_at', { mode: 'number' }).notNull().default(EPOCH_MS_NOW),

--- a/libs/infra/db/src/lib/schema/index.ts
+++ b/libs/infra/db/src/lib/schema/index.ts
@@ -1,4 +1,5 @@
 export * from './audit';
+export * from './consents';
 export * from './core';
 export * from './enums';
 export * from './roles';

--- a/libs/infra/db/src/types/repository.ts
+++ b/libs/infra/db/src/types/repository.ts
@@ -1,5 +1,6 @@
 import type { InferInsertModel, InferSelectModel } from 'drizzle-orm';
 
+import type { oauthConsents } from '../lib/schema/consents';
 import type { oauthClients } from '../lib/schema/core';
 import type {
   authorizationCodes,
@@ -130,6 +131,48 @@ export interface RefreshTokensRepository {
    * Returns count of deleted tokens
    */
   deleteExpired(tx?: DbClient): Promise<number>;
+}
+
+/**
+ * OAuth consent types
+ */
+export type OAuthConsent = InferSelectModel<typeof oauthConsents>;
+export type NewOAuthConsent = InferInsertModel<typeof oauthConsents>;
+
+/**
+ * OAuth consents repository interface.
+ *
+ * Consents are scoped to (userId, oauthClientId). A single active
+ * (not revoked) row exists per pair; re-consent merges scopes into the same
+ * row. Revocation sets `revokedAt` rather than deleting, so history is kept.
+ */
+export interface OAuthConsentsRepository {
+  /** Create a consent row (insert). Caller is responsible for uniqueness. */
+  create(data: NewOAuthConsent, tx?: DbClient): Promise<OAuthConsent>;
+  /** Fetch the active (non-revoked) consent for a (user, client) pair. */
+  findActive(
+    userId: string,
+    oauthClientId: string,
+    tx?: DbClient
+  ): Promise<OAuthConsent | undefined>;
+  /** List all active consents for a user, joined to client metadata (revocation UI). */
+  listActiveForUser(userId: string, tx?: DbClient): Promise<OAuthConsent[]>;
+  /**
+   * Grant/update consent for (user, client).
+   *
+   * If an active row exists, its `scopes` array is replaced with the union
+   * of old ∪ new and `grantedAt` is refreshed. Otherwise a new row is
+   * inserted.
+   */
+  upsertGrant(
+    userId: string,
+    oauthClientId: string,
+    realmId: string,
+    scopes: string[],
+    tx?: DbClient
+  ): Promise<OAuthConsent>;
+  /** Revoke a consent row by id (owner must be checked by caller). */
+  revoke(id: string, tx?: DbClient): Promise<OAuthConsent>;
 }
 
 /**

--- a/libs/server/config/src/lib/schemas/auth.ts
+++ b/libs/server/config/src/lib/schemas/auth.ts
@@ -136,6 +136,43 @@ export const authEnvSchema = z.object({
    * Userinfo rate limit window in seconds (default: 60 = 1 minute)
    */
   USERINFO_RATE_WINDOW: z.coerce.number().int().min(1).default(60),
+
+  /**
+   * HMAC secret used to sign the `__Host-qauth_session` cookie (issue #150).
+   * Minimum 32 characters. In production this MUST be set explicitly —
+   * the default value is test-only and is rejected in NODE_ENV=production
+   * by downstream consumers if needed.
+   */
+  SESSION_COOKIE_SECRET: z
+    .string()
+    .min(32, 'SESSION_COOKIE_SECRET must be at least 32 characters')
+    .default('dev-only-session-secret-change-me-1234567890abcdef'),
+
+  /**
+   * Browser session TTL in seconds (default 86400 = 24 hours, per issue #150).
+   */
+  SESSION_COOKIE_TTL: z.coerce
+    .number()
+    .int()
+    .min(60)
+    .default(24 * 60 * 60),
+
+  /**
+   * Whether to set the Secure attribute on the session cookie. Defaults true;
+   * tests and local dev can set false to use plain HTTP. Production MUST
+   * keep this true — the __Host- prefix will reject the cookie otherwise.
+   */
+  SESSION_COOKIE_SECURE: z
+    .enum(['true', 'false'])
+    .default('true')
+    .transform((v) => v === 'true'),
+
+  /**
+   * Window (in days) after dynamic registration during which the consent
+   * screen shows the "Newly registered" phishing-defense badge. Zero
+   * disables the badge.
+   */
+  DYNAMIC_CLIENT_BADGE_DAYS: z.coerce.number().int().min(0).default(30),
 });
 
 /**


### PR DESCRIPTION
Closes #150.

## Summary
- Session-cookie user auth on `/oauth/authorize` (`__Host-qauth_session`, HttpOnly, SameSite=Lax, Secure, HMAC-SHA256) alongside the existing Bearer path.
- Consent UI between auth and code issuance. Shows client name, audience, requested scopes, dynamic-client badge for recently-registered clients, Allow/Deny + \"Allow forever\". Deny redirects with `error=access_denied` and preserved `state` (RFC 6749 §4.1.2.1).
- New table `oauth_consents(user_id, oauth_client_id, realm_id, scopes[], granted_at, revoked_at)` with partial unique index on active rows. \"Allow forever\" upserts and unions scopes; subsequent authorize calls with a subset skip the screen.
- New column `oauth_clients.dynamic_registered_at` (nullable bigint) powering the dynamic-client badge + forced re-consent window (`DYNAMIC_CLIENT_BADGE_DAYS`).
- Revocation: JSON `/consents` list/delete with ownership checks; minimal developer-portal `/consents` page.

## Caveats for reviewers
- **Merge-time migration collision**: three parallel PRs number their migration `0002`. Suggest landing order `#151 (0002 tokens) → this (0003) → DCR (0004)`; renumber this migration + snapshot + journal entry on rebase.
- **CSRF** (`helpers/session-cookie.ts` + `routes/ui/consent.ts`): double-submit token rotated per GET, stored in Redis session payload, timing-safe compare, burned on POST. Failure → `BadRequestError('invalid_csrf_token')`.
- **Cookie attributes**: `__Host-` prefix enforces Secure + root path; env-gated for local dev.
- **Open-redirect safety** on `return_to` in `routes/ui/login.ts` (relative-path-only `isSafeReturnTo`).
- `oauth_clients.dynamic_registered_at` is the column DCR (#149) will populate; currently always null.
- Bearer-token path on `/oauth/authorize` retained for back-compat; should be removed once first-party callers migrate (comment in code).

## Scope cuts (follow-ups)
- No `/ui/logout` endpoint yet — trivial follow-up via `clearSessionCookie`.
- Consent TTL is indefinite (per spec); no time-based re-prompt beyond the dynamic-client window.
- `/ui/consent` HTML is utility-grade inline CSS; no `@qauth-labs/ui` yet.
- Dev portal `/consents` page is bare-bones (no auth redirect, no pagination).
- No end-to-end Fastify `.inject()` test — route handlers covered directly.

## Test plan
- [x] `pnpm nx test auth-server` — 123 tests passing (13 new: session cookies, HTML escaping, consent logic, CSRF, allow/deny, authorize integration, consents JSON API)
- [x] `pnpm nx lint` across affected projects; `pnpm nx build developer-portal`
- [ ] Manual: full authcode flow via browser — login → consent → code
- [ ] Manual: deny path returns `error=access_denied` with preserved `state`
- [ ] Manual: second authorize with subset scopes skips consent; superset re-prompts
- [ ] Manual: revoke a consent in developer portal, verify next authorize re-prompts