### PR TITLE
feat(oauth): Dynamic Client Registration (RFC 7591), open mode

### DIFF
--- a/apps/auth-server/src/app/helpers/dynamic-client-registration.test.ts
+++ b/apps/auth-server/src/app/helpers/dynamic-client-registration.test.ts
@@ -1,0 +1,140 @@
+import { BadRequestError } from '@qauth-labs/shared-errors';
+import { describe, expect, it } from 'vitest';
+
+import { validateAndNormalize, validateRedirectUri } from './dynamic-client-registration';
+
+describe('validateRedirectUri', () => {
+  it('accepts https URIs', () => {
+    expect(() => validateRedirectUri('https://app.example/cb')).not.toThrow();
+  });
+
+  it('accepts http only for loopback addresses', () => {
+    expect(() => validateRedirectUri('http://127.0.0.1:8080/cb')).not.toThrow();
+    expect(() => validateRedirectUri('http://[::1]:8080/cb')).not.toThrow();
+    expect(() => validateRedirectUri('http://localhost:9000/cb')).not.toThrow();
+  });
+
+  it('rejects http for non-loopback hosts', () => {
+    expect(() => validateRedirectUri('http://app.example/cb')).toThrow(BadRequestError);
+  });
+
+  it('accepts custom schemes for native apps', () => {
+    expect(() => validateRedirectUri('com.example.app:/oauth/callback')).not.toThrow();
+  });
+
+  it('rejects redirect URIs containing a fragment', () => {
+    expect(() => validateRedirectUri('https://app.example/cb#fragment')).toThrow(BadRequestError);
+  });
+
+  it('rejects malformed URIs', () => {
+    expect(() => validateRedirectUri('not a url')).toThrow(BadRequestError);
+  });
+});
+
+describe('validateAndNormalize', () => {
+  const allowedScopes = ['openid', 'profile', 'email', 'offline_access'];
+
+  it('defaults grant_types/response_types/token_endpoint_auth_method when omitted', () => {
+    const n = validateAndNormalize({ redirect_uris: ['https://app.example/cb'] }, allowedScopes);
+    expect(n.grantTypes).toEqual(['authorization_code', 'refresh_token']);
+    expect(n.responseTypes).toEqual(['code']);
+    expect(n.tokenEndpointAuthMethod).toBe('none');
+    expect(n.isPublic).toBe(true);
+  });
+
+  it('caps requested scopes to the realm allowlist', () => {
+    const n = validateAndNormalize(
+      {
+        redirect_uris: ['https://app.example/cb'],
+        scope: 'openid email',
+      },
+      allowedScopes
+    );
+    expect(n.scopes).toEqual(['openid', 'email']);
+    expect(n.scopeString).toBe('openid email');
+  });
+
+  it('rejects scopes outside the realm allowlist', () => {
+    expect(() =>
+      validateAndNormalize(
+        {
+          redirect_uris: ['https://app.example/cb'],
+          scope: 'openid memory:admin',
+        },
+        allowedScopes
+      )
+    ).toThrow(/invalid_client_metadata.*memory:admin/);
+  });
+
+  it('rejects all scopes when the realm allowlist is empty', () => {
+    expect(() =>
+      validateAndNormalize(
+        {
+          redirect_uris: ['https://app.example/cb'],
+          scope: 'openid',
+        },
+        []
+      )
+    ).toThrow(BadRequestError);
+  });
+
+  it('requires redirect_uris for authorization_code grants', () => {
+    expect(() =>
+      validateAndNormalize(
+        { grant_types: ['authorization_code'], response_types: ['code'] },
+        allowedScopes
+      )
+    ).toThrow(/invalid_redirect_uri/);
+  });
+
+  it('allows client_credentials without redirect_uris', () => {
+    const n = validateAndNormalize(
+      {
+        grant_types: ['client_credentials'],
+        response_types: [],
+        token_endpoint_auth_method: 'client_secret_basic',
+      },
+      allowedScopes
+    );
+    expect(n.redirectUris).toEqual([]);
+    expect(n.isPublic).toBe(false);
+  });
+
+  it('rejects client_credentials with token_endpoint_auth_method=none', () => {
+    expect(() =>
+      validateAndNormalize(
+        {
+          grant_types: ['client_credentials'],
+          response_types: [],
+          token_endpoint_auth_method: 'none',
+        },
+        allowedScopes
+      )
+    ).toThrow(/invalid_client_metadata.*client_credentials/);
+  });
+
+  it('rejects authorization_code grant without code response_type', () => {
+    expect(() =>
+      validateAndNormalize(
+        {
+          redirect_uris: ['https://app.example/cb'],
+          grant_types: ['authorization_code'],
+          response_types: [],
+        },
+        allowedScopes
+      )
+    ).toThrow(/invalid_client_metadata.*code.*response type/);
+  });
+
+  it('marks confidential clients as non-public', () => {
+    const n = validateAndNormalize(
+      {
+        redirect_uris: ['https://app.example/cb'],
+        token_endpoint_auth_method: 'client_secret_basic',
+      },
+      allowedScopes
+    );
+    expect(n.isPublic).toBe(false);
+    expect(n.tokenEndpointAuthMethod).toBe('client_secret_basic');
+  });
+});

--- a/apps/auth-server/src/app/helpers/dynamic-client-registration.ts
+++ b/apps/auth-server/src/app/helpers/dynamic-client-registration.ts
@@ -1,0 +1,221 @@
+import { BadRequestError } from '@qauth-labs/shared-errors';
+
+import type { DynamicClientRegistrationRequest } from '../schemas/oauth';
+
+/**
+ * RFC 7591 error codes we return for client-metadata validation failures.
+ * These follow RFC 7591 §3.2.2 ("invalid_client_metadata", "invalid_redirect_uri",
+ * "invalid_software_statement" — the latter is n/a for us in MVP).
+ *
+ * We surface them as a `BadRequestError` whose message is the error code
+ * (matching how the rest of the codebase encodes OAuth error codes into
+ * `error` — see InvalidClientError, etc.). The `details` go in the log;
+ * callers should not leak internal state to responders.
+ */
+export type DynamicRegistrationErrorCode = 'invalid_client_metadata' | 'invalid_redirect_uri';
+
+export function rejectRegistration(code: DynamicRegistrationErrorCode, description: string): never {
+  throw new BadRequestError(`${code}: ${description}`);
+}
+
+/**
+ * OAuth 2.1 §10.3 / RFC 8252: `http://` redirect URIs are permitted only for
+ * loopback (native app) flows. Anything else MUST be `https://` (or a
+ * non-HTTP custom scheme for native clients — those we allow without
+ * further restriction since we can't meaningfully validate them here).
+ *
+ * The `localhost` hostname SHOULD be avoided in native apps (RFC 8252 §7.3
+ * recommends `127.0.0.1` / `[::1]`), but we accept it because many desktop
+ * tools still use it — we just require the URL parse as loopback.
+ */
+const LOOPBACK_HOSTS = new Set(['127.0.0.1', '[::1]', '::1', 'localhost']);
+
+export function validateRedirectUri(uri: string): void {
+  let parsed: URL;
+  try {
+    parsed = new URL(uri);
+  } catch {
+    rejectRegistration('invalid_redirect_uri', `${uri} is not a valid URI`);
+  }
+
+  // Reject fragments per RFC 6749 §3.1.2
+  if (parsed.hash && parsed.hash.length > 0) {
+    rejectRegistration('invalid_redirect_uri', 'redirect_uri must not include a fragment');
+  }
+
+  if (parsed.protocol === 'http:') {
+    const host = parsed.hostname.toLowerCase();
+    if (!LOOPBACK_HOSTS.has(host)) {
+      rejectRegistration(
+        'invalid_redirect_uri',
+        'http:// redirect_uri is only permitted for loopback addresses'
+      );
+    }
+    return;
+  }
+
+  if (parsed.protocol === 'https:') {
+    return;
+  }
+
+  // Non-http custom scheme (e.g. `com.example.app:/cb`) — allowed for native
+  // clients per RFC 8252. We don't attempt structural validation here.
+  if (/^[a-z][a-z0-9+\-.]*:$/i.test(parsed.protocol)) {
+    return;
+  }
+
+  rejectRegistration('invalid_redirect_uri', `unsupported scheme: ${parsed.protocol}`);
+}
+
+/**
+ * Policy defaults, applied when a dyn-reg request omits fields.
+ * We pick conservative defaults: authorization_code + refresh_token,
+ * `code` response type, public client (PKCE required).
+ */
+export const DYN_REG_DEFAULTS = {
+  grantTypes: ['authorization_code', 'refresh_token'] as const,
+  responseTypes: ['code'] as const,
+  // RFC 7591 §2 default is `client_secret_basic`. OAuth 2.1 / MCP
+  // expect most dyn-reg clients to be public, so we default to `none`
+  // when no redirect URIs imply a user-involving flow AND when the
+  // caller didn't declare a method. The route handler makes the call.
+  tokenEndpointAuthMethod: 'none' as const,
+} as const;
+
+/**
+ * Internal, normalized view of a DCR request after validation.
+ * Callers get exactly the fields we persist, no optionals-on-optionals.
+ */
+export interface NormalizedRegistrationRequest {
+  clientName: string | null;
+  redirectUris: string[];
+  grantTypes: ('authorization_code' | 'refresh_token' | 'client_credentials')[];
+  responseTypes: 'code'[];
+  tokenEndpointAuthMethod: 'none' | 'client_secret_basic' | 'client_secret_post';
+  /** Parsed + capped-against-realm scope list. Empty array means no scopes. */
+  scopes: string[];
+  /** Unchanged string form, used for RFC 7591 echo-back. */
+  scopeString: string | undefined;
+  clientUri: string | null;
+  logoUri: string | null;
+  tosUri: string | null;
+  policyUri: string | null;
+  contacts: string[] | null;
+  softwareId: string | null;
+  softwareVersion: string | null;
+  /** Whether this is a public client (token_endpoint_auth_method = none). */
+  isPublic: boolean;
+}
+
+/**
+ * Validate + normalize an incoming RFC 7591 request against realm policy.
+ *
+ * - Caps requested scopes to the realm's `dynamic_registration_allowed_scopes`.
+ * - Enforces grant_type / response_type consistency (authorization_code
+ *   requires the `code` response type).
+ * - Requires redirect_uris for any user-involving grant.
+ * - Validates every redirect_uri per OAuth 2.1 §10.3.
+ * - Forces `token_endpoint_auth_method=none` for clients that only use
+ *   authorization_code (public client posture) when not explicitly
+ *   declared as confidential.
+ *
+ * Throws `BadRequestError` with an RFC 7591 error code in the message on
+ * any policy violation. Returns a normalized shape ready to persist.
+ */
+export function validateAndNormalize(
+  body: DynamicClientRegistrationRequest,
+  realmAllowedScopes: string[]
+): NormalizedRegistrationRequest {
+  const grantTypes = (body.grant_types ?? [...DYN_REG_DEFAULTS.grantTypes]) as (
+    | 'authorization_code'
+    | 'refresh_token'
+    | 'client_credentials'
+  )[];
+  const responseTypes = (body.response_types ?? [...DYN_REG_DEFAULTS.responseTypes]) as 'code'[];
+
+  // RFC 7591 §2 / OIDC Reg §2: authorization_code grant pairs with `code`
+  // response type. refresh_token / client_credentials have no response
+  // type at the authorization endpoint (they're token-endpoint-only).
+  if (grantTypes.includes('authorization_code') && !responseTypes.includes('code')) {
+    rejectRegistration(
+      'invalid_client_metadata',
+      'authorization_code grant requires the "code" response type'
+    );
+  }
+  if (!grantTypes.includes('authorization_code') && responseTypes.length > 0) {
+    rejectRegistration(
+      'invalid_client_metadata',
+      'response_types without authorization_code grant is not supported'
+    );
+  }
+
+  const userInvolving =
+    grantTypes.includes('authorization_code') || grantTypes.includes('refresh_token');
+
+  const redirectUris = body.redirect_uris ?? [];
+  if (userInvolving && redirectUris.length === 0) {
+    rejectRegistration(
+      'invalid_redirect_uri',
+      'redirect_uris is required for grants that involve a user-agent'
+    );
+  }
+  for (const uri of redirectUris) {
+    validateRedirectUri(uri);
+  }
+
+  // Scope cap: intersect with the realm's allowlist. An empty allowlist
+  // means "no custom scopes allowed" and we reject any requested scope.
+  let scopes: string[] = [];
+  const scopeString = body.scope;
+  if (scopeString && scopeString.trim().length > 0) {
+    const requested = scopeString.split(/\s+/).filter((s) => s.length > 0);
+    const disallowed = requested.filter((s) => !realmAllowedScopes.includes(s));
+    if (disallowed.length > 0) {
+      rejectRegistration(
+        'invalid_client_metadata',
+        `scope not permitted for dynamic registration: ${disallowed.join(' ')}`
+      );
+    }
+    scopes = requested;
+  }
+
+  // Auth method gating.
+  // - Explicit `none` → public client, no secret, PKCE required (caller).
+  // - Explicit `client_secret_basic` or `client_secret_post` → confidential.
+  // - Omitted → default to `none` (public client) per OAuth 2.1 / MCP
+  //   expectation. This is intentionally tighter than RFC 7591's
+  //   `client_secret_basic` default, because on-401-discover-and-register
+  //   clients are public by construction.
+  const tokenEndpointAuthMethod =
+    body.token_endpoint_auth_method ?? DYN_REG_DEFAULTS.tokenEndpointAuthMethod;
+
+  // client_credentials + `none` is a configuration error: a public client
+  // cannot hold a secret, so it cannot authenticate to the token endpoint
+  // for the client_credentials grant (RFC 6749 §4.4).
+  if (tokenEndpointAuthMethod === 'none' && grantTypes.includes('client_credentials')) {
+    rejectRegistration(
+      'invalid_client_metadata',
+      'client_credentials grant requires a confidential client (token_endpoint_auth_method must not be "none")'
+    );
+  }
+
+  const isPublic = tokenEndpointAuthMethod === 'none';
+
+  return {
+    clientName: body.client_name ?? null,
+    redirectUris,
+    grantTypes,
+    responseTypes,
+    tokenEndpointAuthMethod,
+    scopes,
+    scopeString: scopes.length > 0 ? scopes.join(' ') : undefined,
+    clientUri: body.client_uri ?? null,
+    logoUri: body.logo_uri ?? null,
+    tosUri: body.tos_uri ?? null,
+    policyUri: body.policy_uri ?? null,
+    contacts: body.contacts ?? null,
+    softwareId: body.software_id ?? null,
+    softwareVersion: body.software_version ?? null,
+    isPublic,
+  };
+}

--- a/apps/auth-server/src/app/routes/oauth/register.test.ts
+++ b/apps/auth-server/src/app/routes/oauth/register.test.ts
@@ -1,0 +1,295 @@
+import { BadRequestError } from '@qauth-labs/shared-errors';
+import type { FastifyInstance } from 'fastify';
+import { describe, expect, it, type Mock, vi } from 'vitest';
+
+vi.mock('../../../config/env', () => ({
+  env: {
+    DATABASE_URL: 'postgresql://test:test@localhost:5432/test',
+    EMAIL_FROM_ADDRESS: 'noreply@example.com',
+    EMAIL_BASE_URL: 'http://localhost:3000',
+    DEFAULT_REALM_NAME: 'master',
+    REGISTER_CLIENT_RATE_LIMIT: 30,
+    REGISTER_CLIENT_RATE_WINDOW: 60,
+    DEFAULT_DYNAMIC_REGISTRATION_SCOPES: ['openid', 'profile', 'email', 'offline_access'],
+  },
+}));
+
+import registerRoute from './register';
+
+interface TestContext {
+  handler?: (request: any, reply: any) => Promise<unknown>;
+}
+
+function createReply() {
+  const state: { statusCode: number; body: unknown; headers: Record<string, string> } = {
+    statusCode: 200,
+    body: undefined,
+    headers: {},
+  };
+  const reply = {
+    code(n: number) {
+      state.statusCode = n;
+      return reply;
+    },
+    header(k: string, v: string) {
+      state.headers[k] = v;
+      return reply;
+    },
+    send(body: unknown) {
+      state.body = body;
+      return body;
+    },
+  } as const;
+  return { reply, state };
+}
+
+function createFastifyStub(
+  realmOverrides: Partial<{
+    dynamicRegistrationAllowedScopes: string[];
+  }> = {}
+) {
+  const ctx: TestContext = {};
+
+  const realm = {
+    id: 'realm-1',
+    name: 'master',
+    enabled: true,
+    dynamicRegistrationAllowedScopes: realmOverrides.dynamicRegistrationAllowedScopes ?? [
+      'openid',
+      'profile',
+      'email',
+      'offline_access',
+    ],
+  };
+
+  const createdClients: any[] = [];
+  const auditLogs: any[] = [];
+
+  const fastify: any = {
+    withTypeProvider: () => ({
+      post: (
+        _url: string,
+        _opts: unknown,
+        handler: (request: any, reply: any) => Promise<unknown>
+      ) => {
+        ctx.handler = handler;
+        return fastify;
+      },
+    }),
+    repositories: {
+      realms: {
+        findByName: vi.fn().mockResolvedValue(realm),
+        update: vi.fn().mockResolvedValue({ ...realm }),
+        create: vi.fn(),
+      },
+      oauthClients: {
+        create: vi.fn(async (row: any) => {
+          const persisted = {
+            ...row,
+            id: `client-row-${createdClients.length + 1}`,
+            createdAt: 1_700_000_000_000,
+            updatedAt: 1_700_000_000_000,
+          };
+          createdClients.push(persisted);
+          return persisted;
+        }),
+      },
+      auditLogs: {
+        create: vi.fn(async (row: any) => {
+          auditLogs.push(row);
+          return row;
+        }),
+      },
+    },
+    passwordHasher: {
+      hashPassword: vi.fn(async (v: string) => `argon2id$${v.slice(0, 8)}`),
+    },
+    log: {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    },
+  };
+
+  return {
+    fastify: fastify as FastifyInstance,
+    ctx,
+    state: { createdClients, auditLogs, realm },
+  };
+}
+
+describe('POST /oauth/register — Dynamic Client Registration (RFC 7591)', () => {
+  it('creates a public client for the happy-path authorization_code flow', async () => {
+    const { fastify, ctx, state } = createFastifyStub();
+    await registerRoute(fastify);
+    const handler = ctx.handler;
+    expect(handler).toBeDefined();
+
+    const { reply, state: replyState } = createReply();
+
+    const result = await handler!(
+      {
+        body: {
+          client_name: 'My MCP Client',
+          redirect_uris: ['https://client.example/callback'],
+          grant_types: ['authorization_code', 'refresh_token'],
+          response_types: ['code'],
+          scope: 'openid email',
+        },
+        ip: '127.0.0.1',
+        headers: { 'user-agent': 'vitest' },
+      },
+      reply
+    );
+
+    expect(replyState.statusCode).toBe(201);
+    expect(replyState.headers['Cache-Control']).toBe('no-store');
+    expect(result).toMatchObject({
+      client_id: expect.stringMatching(/[0-9a-f-]{36}/),
+      token_endpoint_auth_method: 'none',
+      grant_types: ['authorization_code', 'refresh_token'],
+      response_types: ['code'],
+      scope: 'openid email',
+      client_name: 'My MCP Client',
+      redirect_uris: ['https://client.example/callback'],
+      client_id_issued_at: Math.floor(1_700_000_000_000 / 1000),
+    });
+    // Public client → no secret in response
+    expect(result).not.toHaveProperty('client_secret');
+    expect(result).not.toHaveProperty('client_secret_expires_at');
+
+    // Persisted row reflects public-client posture
+    const persisted = state.createdClients[0];
+    expect(persisted.tokenEndpointAuthMethod).toBe('none');
+    expect(persisted.requirePkce).toBe(true);
+    expect(persisted.realmId).toBe('realm-1');
+
+    // Audit log written
+    expect(state.auditLogs[0]).toMatchObject({
+      event: 'oauth.client.registered',
+      eventType: 'client',
+      success: true,
+    });
+  });
+
+  it('returns a plaintext client_secret exactly once for confidential clients', async () => {
+    const { fastify, ctx } = createFastifyStub();
+    await registerRoute(fastify);
+
+    const { reply } = createReply();
+    const result = (await ctx.handler!(
+      {
+        body: {
+          client_name: 'Confidential Service',
+          redirect_uris: ['https://svc.example/cb'],
+          grant_types: ['authorization_code', 'refresh_token'],
+          response_types: ['code'],
+          token_endpoint_auth_method: 'client_secret_basic',
+        },
+        ip: '127.0.0.1',
+        headers: {},
+      },
+      reply
+    )) as Record<string, unknown>;
+
+    expect(result.token_endpoint_auth_method).toBe('client_secret_basic');
+    expect(typeof result.client_secret).toBe('string');
+    expect((result.client_secret as string).length).toBeGreaterThanOrEqual(32);
+    expect(result.client_secret_expires_at).toBe(0);
+  });
+
+  it('rejects scopes outside the realm allowlist (scope cap)', async () => {
+    const { fastify, ctx } = createFastifyStub();
+    await registerRoute(fastify);
+
+    const { reply } = createReply();
+
+    await expect(
+      ctx.handler!(
+        {
+          body: {
+            redirect_uris: ['https://app.example/cb'],
+            grant_types: ['authorization_code'],
+            response_types: ['code'],
+            scope: 'openid memory:admin',
+          },
+          ip: '127.0.0.1',
+          headers: {},
+        },
+        reply
+      )
+    ).rejects.toBeInstanceOf(BadRequestError);
+  });
+
+  it('rejects http:// redirect_uris for non-loopback hosts (OAuth 2.1 §10.3)', async () => {
+    const { fastify, ctx } = createFastifyStub();
+    await registerRoute(fastify);
+
+    const { reply } = createReply();
+
+    await expect(
+      ctx.handler!(
+        {
+          body: {
+            redirect_uris: ['http://app.example/cb'],
+            grant_types: ['authorization_code'],
+            response_types: ['code'],
+          },
+          ip: '127.0.0.1',
+          headers: {},
+        },
+        reply
+      )
+    ).rejects.toThrow(/invalid_redirect_uri/);
+  });
+
+  it('rejects client_credentials with token_endpoint_auth_method=none', async () => {
+    const { fastify, ctx } = createFastifyStub();
+    await registerRoute(fastify);
+
+    const { reply } = createReply();
+
+    await expect(
+      ctx.handler!(
+        {
+          body: {
+            grant_types: ['client_credentials'],
+            response_types: [],
+            token_endpoint_auth_method: 'none',
+          },
+          ip: '127.0.0.1',
+          headers: {},
+        },
+        reply
+      )
+    ).rejects.toThrow(/invalid_client_metadata/);
+  });
+
+  it('seeds the realm default allowlist on first use when empty', async () => {
+    const { fastify, ctx, state } = createFastifyStub({
+      dynamicRegistrationAllowedScopes: [],
+    });
+    await registerRoute(fastify);
+
+    const { reply } = createReply();
+    const result = (await ctx.handler!(
+      {
+        body: {
+          redirect_uris: ['https://app.example/cb'],
+          scope: 'openid profile',
+        },
+        ip: '127.0.0.1',
+        headers: {},
+      },
+      reply
+    )) as Record<string, unknown>;
+
+    // Scope accepted → default allowlist must have been seeded
+    expect(result.scope).toBe('openid profile');
+    expect((fastify.repositories.realms.update as unknown as Mock).mock.calls[0][1]).toMatchObject({
+      dynamicRegistrationAllowedScopes: ['openid', 'profile', 'email', 'offline_access'],
+    });
+    expect(state.realm.id).toBe('realm-1');
+  });
+});

--- a/apps/auth-server/src/app/routes/oauth/register.ts
+++ b/apps/auth-server/src/app/routes/oauth/register.ts
@@ -1,0 +1,192 @@
+import { randomBytes, randomUUID } from 'node:crypto';
+
+import type { FastifyInstance } from 'fastify';
+import { ZodTypeProvider } from 'fastify-type-provider-zod';
+
+import { env } from '../../../config/env';
+import { validateAndNormalize } from '../../helpers/dynamic-client-registration';
+import { getOrCreateDefaultRealm } from '../../helpers/realm';
+import {
+  type DynamicClientRegistrationRequest,
+  dynamicClientRegistrationRequestSchema,
+  type DynamicClientRegistrationResponse,
+  dynamicClientRegistrationResponseSchema,
+} from '../../schemas/oauth';
+
+/**
+ * POST /oauth/register
+ *
+ * OAuth 2.0 Dynamic Client Registration Protocol (RFC 7591).
+ *
+ * Policy: **open** registration. There is no `initial_access_token` gate.
+ * Defense-in-depth for this project lives at the consent screen (issue
+ * #150) — a dynamically registered client cannot harm a user without a
+ * consent-grant on the /oauth/authorize flow. That means this endpoint
+ * MUST remain tightly scope-capped and rate-limited, which is what the
+ * helper + route config below enforce.
+ *
+ * Response shape follows RFC 7591 §3.2.1. `client_secret` is omitted
+ * entirely for public clients (`token_endpoint_auth_method=none`).
+ */
+export default async function (fastify: FastifyInstance) {
+  fastify.withTypeProvider<ZodTypeProvider>().post(
+    '/register',
+    {
+      schema: {
+        description:
+          "OAuth 2.0 Dynamic Client Registration (RFC 7591). Open-mode — no initial_access_token required. Scope requests are capped to the realm's dynamic_registration_allowed_scopes list.",
+        tags: ['OAuth', 'Registration'],
+        body: dynamicClientRegistrationRequestSchema,
+        response: {
+          201: dynamicClientRegistrationResponseSchema,
+        },
+      },
+      config: {
+        // IP-scoped rate limit, at least as strict as /oauth/token.
+        // Registration is append-only and expensive (argon2id hash on
+        // confidential clients), so a burst-proof cap is mandatory.
+        rateLimit: {
+          max: env.REGISTER_CLIENT_RATE_LIMIT,
+          timeWindow: env.REGISTER_CLIENT_RATE_WINDOW * 1000,
+          keyGenerator: (req) => req.ip || 'unknown',
+        },
+      },
+    },
+    async (request, reply) => {
+      const body = request.body as DynamicClientRegistrationRequest;
+
+      const realm = await getOrCreateDefaultRealm(fastify);
+
+      // Seed realm's allowlist on first use. We *only* do this when the
+      // realm has an empty list — never overwrite an operator's choice.
+      // Defaults are intentionally tight (OIDC core scopes).
+      let allowedScopes = realm.dynamicRegistrationAllowedScopes ?? [];
+      if (allowedScopes.length === 0 && env.DEFAULT_DYNAMIC_REGISTRATION_SCOPES.length > 0) {
+        allowedScopes = [...env.DEFAULT_DYNAMIC_REGISTRATION_SCOPES];
+        try {
+          await fastify.repositories.realms.update(realm.id, {
+            dynamicRegistrationAllowedScopes: allowedScopes,
+          });
+        } catch (err) {
+          // Best-effort: if the update races another request, we still have
+          // the allowedScopes list in memory for this request.
+          fastify.log.warn(
+            { err, realmId: realm.id },
+            'Failed to persist default dynamic_registration_allowed_scopes'
+          );
+        }
+      }
+
+      // Validate + normalize against realm policy. Throws BadRequestError
+      // with RFC 7591 error codes embedded in the message on policy
+      // violations; the global error handler maps to HTTP 400.
+      const normalized = validateAndNormalize(body, allowedScopes);
+
+      // Generate client_id (UUIDv4 — opaque, guessable-resistant, URL-safe
+      // without encoding). We keep it simple rather than inventing a new
+      // format — downstream auth code already handles UUID client IDs.
+      const clientId = randomUUID();
+
+      // Confidential clients get a 32-byte secret, hashed with argon2id
+      // before persistence. Plaintext is returned exactly once in the
+      // response body and never logged.
+      let plaintextSecret: string | undefined;
+      let clientSecretHash: string;
+      if (normalized.isPublic) {
+        // Public client: no usable secret. DB column is NOT NULL, so we
+        // store a non-verifiable sentinel (a random hash of random bytes)
+        // so any accidental client_secret_post attempt fails cleanly.
+        // Length/format matches a real argon2id hash to avoid leaking
+        // client type via length-oracle.
+        clientSecretHash = await fastify.passwordHasher.hashPassword(
+          randomBytes(32).toString('hex')
+        );
+      } else {
+        plaintextSecret = randomBytes(32).toString('hex');
+        clientSecretHash = await fastify.passwordHasher.hashPassword(plaintextSecret);
+      }
+
+      const clientName = normalized.clientName ?? `dcr-${clientId.slice(0, 8)}`;
+
+      const created = await fastify.repositories.oauthClients.create({
+        realmId: realm.id,
+        clientId,
+        clientSecretHash,
+        name: clientName,
+        description: normalized.softwareId
+          ? `Dynamically registered (${normalized.softwareId})`
+          : 'Dynamically registered client',
+        redirectUris: normalized.redirectUris,
+        scopes: normalized.scopes,
+        grantTypes: normalized.grantTypes,
+        responseTypes: normalized.responseTypes,
+        tokenEndpointAuthMethod: normalized.tokenEndpointAuthMethod,
+        // Public clients MUST use PKCE (OAuth 2.1 §4.1.3 / RFC 9700).
+        // Confidential clients SHOULD also use PKCE with authorization_code;
+        // we keep the project-wide default of requirePkce=true.
+        requirePkce: true,
+        enabled: true,
+        developerId: null,
+        metadata: {
+          registrationType: 'dynamic',
+          ...(normalized.softwareId ? { softwareId: normalized.softwareId } : {}),
+          ...(normalized.softwareVersion ? { softwareVersion: normalized.softwareVersion } : {}),
+          ...(normalized.clientUri ? { clientUri: normalized.clientUri } : {}),
+          ...(normalized.logoUri ? { logoUri: normalized.logoUri } : {}),
+          ...(normalized.tosUri ? { tosUri: normalized.tosUri } : {}),
+          ...(normalized.policyUri ? { policyUri: normalized.policyUri } : {}),
+          ...(normalized.contacts ? { contacts: normalized.contacts } : {}),
+        },
+      });
+
+      await fastify.repositories.auditLogs.create({
+        userId: null,
+        oauthClientId: created.id,
+        event: 'oauth.client.registered',
+        eventType: 'client',
+        success: true,
+        ipAddress: request.ip,
+        userAgent: request.headers['user-agent'] || null,
+        metadata: {
+          registrationType: 'dynamic',
+          clientId,
+          isPublic: normalized.isPublic,
+          grantTypes: normalized.grantTypes,
+          scopes: normalized.scopes,
+        },
+      });
+
+      const issuedAtSeconds = Math.floor(created.createdAt / 1000);
+
+      const response: DynamicClientRegistrationResponse = {
+        client_id: clientId,
+        client_id_issued_at: issuedAtSeconds,
+        // RFC 7591: omit `client_secret` entirely for public clients.
+        ...(plaintextSecret
+          ? {
+              client_secret: plaintextSecret,
+              // 0 = never expires, per RFC 7591 §3.2.1.
+              client_secret_expires_at: 0,
+            }
+          : {}),
+        client_name: clientName,
+        redirect_uris: normalized.redirectUris,
+        grant_types: normalized.grantTypes,
+        response_types: normalized.responseTypes,
+        token_endpoint_auth_method: normalized.tokenEndpointAuthMethod,
+        ...(normalized.scopeString ? { scope: normalized.scopeString } : {}),
+        ...(normalized.clientUri ? { client_uri: normalized.clientUri } : {}),
+        ...(normalized.logoUri ? { logo_uri: normalized.logoUri } : {}),
+        ...(normalized.tosUri ? { tos_uri: normalized.tosUri } : {}),
+        ...(normalized.policyUri ? { policy_uri: normalized.policyUri } : {}),
+        ...(normalized.contacts ? { contacts: normalized.contacts } : {}),
+        ...(normalized.softwareId ? { software_id: normalized.softwareId } : {}),
+        ...(normalized.softwareVersion ? { software_version: normalized.softwareVersion } : {}),
+      };
+
+      // RFC 7591 §3.2.1: response MUST NOT be cached (contains secret).
+      reply.header('Cache-Control', 'no-store').header('Pragma', 'no-cache');
+      return reply.code(201).send(response);
+    }
+  );
+}

--- a/apps/auth-server/src/app/schemas/oauth.ts
+++ b/apps/auth-server/src/app/schemas/oauth.ts
@@ -117,6 +117,80 @@ export const introspectResponseSchema = z.object({
 export type IntrospectResponse = z.infer<typeof introspectResponseSchema>;
 
 /**
+ * Dynamic Client Registration request body (POST /oauth/register).
+ * RFC 7591 §2. Accepts the common subset of client metadata fields; any
+ * unknown keys are allowed and echoed back per §3.2.1 (server MAY omit,
+ * but we round-trip recognized fields only to keep DB shape bounded).
+ *
+ * Policy notes:
+ *   - `token_endpoint_auth_method=none` marks the client as public
+ *     (PKCE required).
+ *   - Grant/response type consistency is enforced in the route handler,
+ *     not in the schema, so we can surface a structured OAuth error.
+ *   - `scope` is space-separated per RFC 7591 §2 / RFC 6749 §3.3.
+ */
+export const dynamicClientRegistrationRequestSchema = z
+  .object({
+    client_name: z.string().min(1).max(255).optional(),
+    redirect_uris: z.array(z.string().min(1).max(2048)).max(20).optional(),
+    grant_types: z
+      .array(z.enum(['authorization_code', 'refresh_token', 'client_credentials']))
+      .max(8)
+      .optional(),
+    response_types: z
+      .array(z.enum(['code']))
+      .max(4)
+      .optional(),
+    token_endpoint_auth_method: z
+      .enum(['none', 'client_secret_basic', 'client_secret_post'])
+      .optional(),
+    scope: z.string().max(2048).optional(),
+    client_uri: z.url().max(2048).optional(),
+    logo_uri: z.url().max(2048).optional(),
+    tos_uri: z.url().max(2048).optional(),
+    policy_uri: z.url().max(2048).optional(),
+    contacts: z.array(z.email().max(255)).max(10).optional(),
+    software_id: z.string().max(255).optional(),
+    software_version: z.string().max(64).optional(),
+  })
+  .strict();
+
+export type DynamicClientRegistrationRequest = z.infer<
+  typeof dynamicClientRegistrationRequestSchema
+>;
+
+/**
+ * Dynamic Client Registration response body.
+ * RFC 7591 §3.2.1. `client_secret` is omitted for public clients.
+ * `client_id_issued_at` / `client_secret_expires_at` are seconds-since-epoch
+ * (not milliseconds).
+ */
+export const dynamicClientRegistrationResponseSchema = z.object({
+  client_id: z.string(),
+  client_secret: z.string().optional(),
+  client_id_issued_at: z.number().int().nonnegative(),
+  // RFC 7591: 0 means "does not expire". We emit 0 for non-expiring secrets.
+  client_secret_expires_at: z.number().int().nonnegative().optional(),
+  client_name: z.string().optional(),
+  redirect_uris: z.array(z.string()).optional(),
+  grant_types: z.array(z.string()),
+  response_types: z.array(z.string()),
+  token_endpoint_auth_method: z.string(),
+  scope: z.string().optional(),
+  client_uri: z.string().optional(),
+  logo_uri: z.string().optional(),
+  tos_uri: z.string().optional(),
+  policy_uri: z.string().optional(),
+  contacts: z.array(z.string()).optional(),
+  software_id: z.string().optional(),
+  software_version: z.string().optional(),
+});
+
+export type DynamicClientRegistrationResponse = z.infer<
+  typeof dynamicClientRegistrationResponseSchema
+>;
+
+/**
  * OIDC userinfo response schema (GET /userinfo).
  * Returns selected claims for the authenticated end-user.
  */

--- a/libs/infra/db/drizzle/0002_add_dynamic_registration_allowed_scopes.sql
+++ b/libs/infra/db/drizzle/0002_add_dynamic_registration_allowed_scopes.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "realms" ADD COLUMN "dynamic_registration_allowed_scopes" jsonb DEFAULT '[]'::jsonb NOT NULL;

--- a/libs/infra/db/drizzle/meta/0002_snapshot.json
+++ b/libs/infra/db/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,1925 @@
+{
+  "id": "7246409d-e0a3-4127-88d7-dd103a325ae5",
+  "prevId": "59c20a89-d378-4409-94e2-fb250bec7346",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_client_id": {
+          "name": "oauth_client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event": {
+          "name": "event",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "audit_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(EXTRACT(EPOCH FROM NOW())::bigint * 1000)"
+        }
+      },
+      "indexes": {
+        "idx_audit_logs_user_id": {
+          "name": "idx_audit_logs_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_logs_oauth_client_id": {
+          "name": "idx_audit_logs_oauth_client_id",
+          "columns": [
+            {
+              "expression": "oauth_client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_logs_event_type": {
+          "name": "idx_audit_logs_event_type",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_logs_event": {
+          "name": "idx_audit_logs_event",
+          "columns": [
+            {
+              "expression": "event",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_logs_created_at": {
+          "name": "idx_audit_logs_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_logs_user_event": {
+          "name": "idx_audit_logs_user_event",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_logs_failed": {
+          "name": "idx_audit_logs_failed",
+          "columns": [
+            {
+              "expression": "event",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"audit_logs\".\"success\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_logs_ip_address": {
+          "name": "idx_audit_logs_ip_address",
+          "columns": [
+            {
+              "expression": "ip_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_logs_user_id_users_id_fk": {
+          "name": "audit_logs_user_id_users_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "audit_logs_oauth_client_id_oauth_clients_id_fk": {
+          "name": "audit_logs_oauth_client_id_oauth_clients_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "oauth_clients",
+          "columnsFrom": ["oauth_client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_clients": {
+      "name": "oauth_clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "realm_id": {
+          "name": "realm_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret_hash": {
+          "name": "client_secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "audience": {
+          "name": "audience",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "require_pkce": {
+          "name": "require_pkce",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "token_endpoint_auth_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'client_secret_post'"
+        },
+        "grant_types": {
+          "name": "grant_types",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[\"authorization_code\",\"refresh_token\"]'::jsonb"
+        },
+        "response_types": {
+          "name": "response_types",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[\"code\"]'::jsonb"
+        },
+        "developer_id": {
+          "name": "developer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(EXTRACT(EPOCH FROM NOW())::bigint * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(EXTRACT(EPOCH FROM NOW())::bigint * 1000)"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_oauth_clients_realm_client_id_unique": {
+          "name": "idx_oauth_clients_realm_client_id_unique",
+          "columns": [
+            {
+              "expression": "realm_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_oauth_clients_client_id": {
+          "name": "idx_oauth_clients_client_id",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_oauth_clients_realm_id": {
+          "name": "idx_oauth_clients_realm_id",
+          "columns": [
+            {
+              "expression": "realm_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_oauth_clients_developer_id": {
+          "name": "idx_oauth_clients_developer_id",
+          "columns": [
+            {
+              "expression": "developer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_oauth_clients_enabled": {
+          "name": "idx_oauth_clients_enabled",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"oauth_clients\".\"enabled\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_oauth_clients_realm_client_id_enabled": {
+          "name": "idx_oauth_clients_realm_client_id_enabled",
+          "columns": [
+            {
+              "expression": "realm_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_clients_realm_id_realms_id_fk": {
+          "name": "oauth_clients_realm_id_realms_id_fk",
+          "tableFrom": "oauth_clients",
+          "tableTo": "realms",
+          "columnsFrom": ["realm_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_clients_developer_id_users_id_fk": {
+          "name": "oauth_clients_developer_id_users_id_fk",
+          "tableFrom": "oauth_clients",
+          "tableTo": "users",
+          "columnsFrom": ["developer_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "oauth_clients_audience_is_array": {
+          "name": "oauth_clients_audience_is_array",
+          "value": "\"oauth_clients\".\"audience\" IS NULL OR jsonb_typeof(\"oauth_clients\".\"audience\") = 'array'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.realms": {
+      "name": "realms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "access_token_lifespan": {
+          "name": "access_token_lifespan",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 900
+        },
+        "refresh_token_lifespan": {
+          "name": "refresh_token_lifespan",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 604800
+        },
+        "ssl_required": {
+          "name": "ssl_required",
+          "type": "ssl_required",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'external'"
+        },
+        "verify_email": {
+          "name": "verify_email",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "registration_allowed": {
+          "name": "registration_allowed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "login_with_email_allowed": {
+          "name": "login_with_email_allowed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "duplicate_emails_allowed": {
+          "name": "duplicate_emails_allowed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "password_policy": {
+          "name": "password_policy",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sso_idle_timeout": {
+          "name": "sso_idle_timeout",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sso_max_lifespan": {
+          "name": "sso_max_lifespan",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoke_refresh_token": {
+          "name": "revoke_refresh_token",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "refresh_token_max_reuse": {
+          "name": "refresh_token_max_reuse",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "default_locale": {
+          "name": "default_locale",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supported_locales": {
+          "name": "supported_locales",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "dynamic_registration_allowed_scopes": {
+          "name": "dynamic_registration_allowed_scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(EXTRACT(EPOCH FROM NOW())::bigint * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(EXTRACT(EPOCH FROM NOW())::bigint * 1000)"
+        }
+      },
+      "indexes": {
+        "idx_realms_enabled": {
+          "name": "idx_realms_enabled",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"realms\".\"enabled\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "realms_name_unique": {
+          "name": "realms_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "realm_id": {
+          "name": "realm_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_normalized": {
+          "name": "email_normalized",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(EXTRACT(EPOCH FROM NOW())::bigint * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(EXTRACT(EPOCH FROM NOW())::bigint * 1000)"
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_users_realm_email_normalized_unique": {
+          "name": "idx_users_realm_email_normalized_unique",
+          "columns": [
+            {
+              "expression": "realm_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email_normalized",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_email": {
+          "name": "idx_users_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_realm_id": {
+          "name": "idx_users_realm_id",
+          "columns": [
+            {
+              "expression": "realm_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_enabled": {
+          "name": "idx_users_enabled",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"users\".\"enabled\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_realm_email_enabled": {
+          "name": "idx_users_realm_email_enabled",
+          "columns": [
+            {
+              "expression": "realm_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email_normalized",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_realm_id_realms_id_fk": {
+          "name": "users_realm_id_realms_id_fk",
+          "tableFrom": "users",
+          "tableTo": "realms",
+          "columnsFrom": ["realm_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roles": {
+      "name": "roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "realm_id": {
+          "name": "realm_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_client_id": {
+          "name": "oauth_client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(EXTRACT(EPOCH FROM NOW())::bigint * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(EXTRACT(EPOCH FROM NOW())::bigint * 1000)"
+        }
+      },
+      "indexes": {
+        "idx_roles_realm_name_unique": {
+          "name": "idx_roles_realm_name_unique",
+          "columns": [
+            {
+              "expression": "realm_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "oauth_client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_roles_name": {
+          "name": "idx_roles_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_roles_realm_id": {
+          "name": "idx_roles_realm_id",
+          "columns": [
+            {
+              "expression": "realm_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_roles_oauth_client_id": {
+          "name": "idx_roles_oauth_client_id",
+          "columns": [
+            {
+              "expression": "oauth_client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "roles_realm_id_realms_id_fk": {
+          "name": "roles_realm_id_realms_id_fk",
+          "tableFrom": "roles",
+          "tableTo": "realms",
+          "columnsFrom": ["realm_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "roles_oauth_client_id_oauth_clients_id_fk": {
+          "name": "roles_oauth_client_id_oauth_clients_id_fk",
+          "tableFrom": "roles",
+          "tableTo": "oauth_clients",
+          "columnsFrom": ["oauth_client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_roles": {
+      "name": "user_roles",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigned_at": {
+          "name": "assigned_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(EXTRACT(EPOCH FROM NOW())::bigint * 1000)"
+        },
+        "assigned_by": {
+          "name": "assigned_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_user_roles_user_id": {
+          "name": "idx_user_roles_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_roles_role_id": {
+          "name": "idx_user_roles_role_id",
+          "columns": [
+            {
+              "expression": "role_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_roles_user_id_users_id_fk": {
+          "name": "user_roles_user_id_users_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_roles_role_id_roles_id_fk": {
+          "name": "user_roles_role_id_roles_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "roles",
+          "columnsFrom": ["role_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_roles_assigned_by_users_id_fk": {
+          "name": "user_roles_assigned_by_users_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "users",
+          "columnsFrom": ["assigned_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_roles_pk": {
+          "name": "user_roles_pk",
+          "columns": ["user_id", "role_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oauth_client_id": {
+          "name": "oauth_client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_hash": {
+          "name": "access_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_hash": {
+          "name": "refresh_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(EXTRACT(EPOCH FROM NOW())::bigint * 1000)"
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(EXTRACT(EPOCH FROM NOW())::bigint * 1000)"
+        }
+      },
+      "indexes": {
+        "idx_sessions_user_id": {
+          "name": "idx_sessions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sessions_active": {
+          "name": "idx_sessions_active",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"sessions\".\"revoked\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sessions_expires_at": {
+          "name": "idx_sessions_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sessions_access_token_hash": {
+          "name": "idx_sessions_access_token_hash",
+          "columns": [
+            {
+              "expression": "access_token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sessions_oauth_client_id": {
+          "name": "idx_sessions_oauth_client_id",
+          "columns": [
+            {
+              "expression": "oauth_client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sessions_oauth_client_id_oauth_clients_id_fk": {
+          "name": "sessions_oauth_client_id_oauth_clients_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "oauth_clients",
+          "columnsFrom": ["oauth_client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.authorization_codes": {
+      "name": "authorization_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oauth_client_id": {
+          "name": "oauth_client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge": {
+          "name": "code_challenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge_method": {
+          "name": "code_challenge_method",
+          "type": "code_challenge_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'S256'"
+        },
+        "nonce": {
+          "name": "nonce",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used": {
+          "name": "used",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(EXTRACT(EPOCH FROM NOW())::bigint * 1000)"
+        }
+      },
+      "indexes": {
+        "idx_authorization_codes_active": {
+          "name": "idx_authorization_codes_active",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"authorization_codes\".\"used\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_authorization_codes_expires_at": {
+          "name": "idx_authorization_codes_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_authorization_codes_user_id": {
+          "name": "idx_authorization_codes_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_authorization_codes_oauth_client_id": {
+          "name": "idx_authorization_codes_oauth_client_id",
+          "columns": [
+            {
+              "expression": "oauth_client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "authorization_codes_oauth_client_id_oauth_clients_id_fk": {
+          "name": "authorization_codes_oauth_client_id_oauth_clients_id_fk",
+          "tableFrom": "authorization_codes",
+          "tableTo": "oauth_clients",
+          "columnsFrom": ["oauth_client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "authorization_codes_user_id_users_id_fk": {
+          "name": "authorization_codes_user_id_users_id_fk",
+          "tableFrom": "authorization_codes",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "authorization_codes_code_unique": {
+          "name": "authorization_codes_code_unique",
+          "nullsNotDistinct": false,
+          "columns": ["code"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_verification_tokens": {
+      "name": "email_verification_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used": {
+          "name": "used",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(EXTRACT(EPOCH FROM NOW())::bigint * 1000)"
+        }
+      },
+      "indexes": {
+        "idx_email_verification_tokens_user_id": {
+          "name": "idx_email_verification_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_email_verification_tokens_active": {
+          "name": "idx_email_verification_tokens_active",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"email_verification_tokens\".\"used\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_email_verification_tokens_expires_at": {
+          "name": "idx_email_verification_tokens_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_verification_tokens_user_id_users_id_fk": {
+          "name": "email_verification_tokens_user_id_users_id_fk",
+          "tableFrom": "email_verification_tokens",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "email_verification_tokens_token_hash_unique": {
+          "name": "email_verification_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.refresh_tokens": {
+      "name": "refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oauth_client_id": {
+          "name": "oauth_client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_reason": {
+          "name": "revoked_reason",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_token_hash": {
+          "name": "previous_token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(EXTRACT(EPOCH FROM NOW())::bigint * 1000)"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_refresh_tokens_active": {
+          "name": "idx_refresh_tokens_active",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"refresh_tokens\".\"revoked\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_refresh_tokens_expires_at": {
+          "name": "idx_refresh_tokens_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_refresh_tokens_user_id": {
+          "name": "idx_refresh_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_refresh_tokens_oauth_client_id": {
+          "name": "idx_refresh_tokens_oauth_client_id",
+          "columns": [
+            {
+              "expression": "oauth_client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_refresh_tokens_user_active": {
+          "name": "idx_refresh_tokens_user_active",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"refresh_tokens\".\"revoked\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "refresh_tokens_user_id_users_id_fk": {
+          "name": "refresh_tokens_user_id_users_id_fk",
+          "tableFrom": "refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "refresh_tokens_oauth_client_id_oauth_clients_id_fk": {
+          "name": "refresh_tokens_oauth_client_id_oauth_clients_id_fk",
+          "tableFrom": "refresh_tokens",
+          "tableTo": "oauth_clients",
+          "columnsFrom": ["oauth_client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "refresh_tokens_token_hash_unique": {
+          "name": "refresh_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.audit_event_type": {
+      "name": "audit_event_type",
+      "schema": "public",
+      "values": ["auth", "token", "client", "security", "user", "realm"]
+    },
+    "public.code_challenge_method": {
+      "name": "code_challenge_method",
+      "schema": "public",
+      "values": ["S256"]
+    },
+    "public.grant_type": {
+      "name": "grant_type",
+      "schema": "public",
+      "values": ["authorization_code", "refresh_token", "client_credentials"]
+    },
+    "public.response_type": {
+      "name": "response_type",
+      "schema": "public",
+      "values": ["code"]
+    },
+    "public.ssl_required": {
+      "name": "ssl_required",
+      "schema": "public",
+      "values": ["none", "external", "all"]
+    },
+    "public.token_endpoint_auth_method": {
+      "name": "token_endpoint_auth_method",
+      "schema": "public",
+      "values": ["client_secret_post", "client_secret_basic", "private_key_jwt", "none"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/libs/infra/db/drizzle/meta/_journal.json
+++ b/libs/infra/db/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1776371685401,
       "tag": "0001_add_oauth_clients_audience",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1777018691381,
+      "tag": "0002_add_dynamic_registration_allowed_scopes",
+      "breakpoints": true
     }
   ]
 }

--- a/libs/infra/db/src/lib/schema/core.ts
+++ b/libs/infra/db/src/lib/schema/core.ts
@@ -52,6 +52,17 @@ export const realms = pgTable(
     refreshTokenMaxReuse: bigint('refresh_token_max_reuse', { mode: 'number' }).default(0),
     defaultLocale: varchar('default_locale', { length: 10 }),
     supportedLocales: jsonb('supported_locales').default(JSONB_EMPTY_ARRAY).$type<unknown[]>(),
+    /**
+     * Scopes that may be requested by clients created via Dynamic Client
+     * Registration (RFC 7591). This is the hard cap enforced by the
+     * `/oauth/register` endpoint: any scope outside this list is rejected
+     * with `invalid_client_metadata`. Admin-level scopes (e.g. `memory:admin`)
+     * and tenant-scoped grants (e.g. `akinon:*`) MUST NOT appear here.
+     */
+    dynamicRegistrationAllowedScopes: jsonb('dynamic_registration_allowed_scopes')
+      .notNull()
+      .default(JSONB_EMPTY_ARRAY)
+      .$type<string[]>(),
     metadata: jsonb('metadata').$type<Record<string, unknown> | null>(),
     createdAt: bigint('created_at', { mode: 'number' }).notNull().default(EPOCH_MS_NOW),
     updatedAt: bigint('updated_at', { mode: 'number' }).notNull().default(EPOCH_MS_NOW),

--- a/libs/server/config/src/lib/schemas/auth.ts
+++ b/libs/server/config/src/lib/schemas/auth.ts
@@ -136,6 +136,37 @@ export const authEnvSchema = z.object({
    * Userinfo rate limit window in seconds (default: 60 = 1 minute)
    */
   USERINFO_RATE_WINDOW: z.coerce.number().int().min(1).default(60),
+
+  /**
+   * Maximum Dynamic Client Registration attempts per window per-IP
+   * (RFC 7591). Matches /oauth/token's default (30) as a conservative
+   * starting point — registration is higher-impact than a token exchange,
+   * so this should never be looser than the token endpoint.
+   */
+  REGISTER_CLIENT_RATE_LIMIT: z.coerce.number().int().min(1).default(30),
+  /**
+   * Dynamic Client Registration rate limit window in seconds.
+   */
+  REGISTER_CLIENT_RATE_WINDOW: z.coerce.number().int().min(1).default(60),
+
+  /**
+   * Comma-separated scopes allowed by default for dynamically registered
+   * clients when a realm's `dynamic_registration_allowed_scopes` column is
+   * empty. Used at /oauth/register time to seed the realm on first use.
+   *
+   * Intentionally tight: only OIDC core scopes. Admin / tenant-scoped
+   * grants (e.g. `memory:admin`, `akinon:*`) MUST be added explicitly by
+   * an operator and MUST NOT live in this default.
+   */
+  DEFAULT_DYNAMIC_REGISTRATION_SCOPES: z
+    .string()
+    .default('openid profile email offline_access')
+    .transform((s) =>
+      s
+        .split(/[\s,]+/)
+        .map((x) => x.trim())
+        .filter((x) => x.length > 0)
+    ),
 });
 
 /**


### PR DESCRIPTION
Closes #149.

## Summary
- Adds `POST /oauth/register` per RFC 7591 in open mode (no `initial_access_token`). Validator/normalizer helpers in `apps/auth-server/src/app/helpers/dynamic-client-registration.ts`, request/response Zod schemas in `apps/auth-server/src/app/schemas/oauth.ts`.
- Scope cap: each realm carries a `dynamic_registration_allowed_scopes` list (new jsonb column). Empty realms seeded on first `/oauth/register` with a tight default (`openid profile email offline_access`) — never overwrites an operator list. No admin/tenant scopes in defaults.
- `token_endpoint_auth_method` defaults to `none` (OAuth 2.1 / MCP posture), not RFC 7591's `client_secret_basic`. `require_pkce: true` forced on every dyn-reg client.
- Public clients get no `client_secret`; `oauth_clients.client_secret_hash` is stored as a sentinel argon2id hash of random bytes (column is NOT NULL — see follow-up below).
- Rate limit: per-IP, 30/60s matching `/oauth/token`. Knob: `REGISTER_CLIENT_RATE_LIMIT`.

## Caveats for reviewers
- **Merge-time migration collision**: three parallel PRs number their migration `0002`. Suggest landing order `#151 (0002 tokens) → #150 (0003 consents) → this (0004)`; renumber this migration + snapshot + journal entry on rebase.
- **Cross-branch dependency on #150**: once #150 lands, `oauth_clients.dynamic_registered_at` exists and the DCR handler should write `now()` on INSERT so the consent screen's dynamic-client badge is accurate. Not wired in this PR (column doesn't exist on this branch); add on rebase.
- **Public-client secret-hash sentinel**: kept the column NOT NULL to minimise schema churn. Cleaner alternative is a follow-up migration to make `client_secret_hash` nullable and represent public clients as `NULL`.
- **Registration endpoint advertisement** in `/.well-known/*` is handled by #148; this PR does not touch well-known.
- RFC 7592 (`registration_access_token`, `registration_client_uri`) intentionally out of scope for MVP.

## Safety story
Open DCR is only safe because #150 (consent screen) gates scope issuance. Prefer landing this last in the sequence so the defense-in-depth is in place before a dynamically-registered client can reach `/oauth/authorize` unchaperoned.

## Test plan
- [x] `pnpm nx affected -t test` — auth-server 103 passing (21 new across 2 files)
- [x] `pnpm nx affected -t lint typecheck` — clean
- [x] `pnpm nx build auth-server` / `drizzle-kit check`
- [ ] Manual: `POST /oauth/register` happy path — public client, PKCE flow end-to-end
- [ ] Manual: request a disallowed scope (e.g. `memory:admin`) — expect rejection
- [ ] Manual: exceed rate limit — expect 429