### PR TITLE
fix(oauth): drop .strict() from dyn-reg schema per RFC 7591 §3.2

### DIFF
--- a/apps/auth-server/src/app/routes/oauth/register.test.ts
+++ b/apps/auth-server/src/app/routes/oauth/register.test.ts
@@ -266,6 +266,34 @@ describe('POST /oauth/register — Dynamic Client Registration (RFC 7591)', () =
     ).rejects.toThrow(/invalid_client_metadata/);
   });
 
+  it('strips unrecognized fields (application_type, custom_ext) without error (RFC 7591 §3.2)', async () => {
+    const { fastify, ctx } = createFastifyStub();
+    await registerRoute(fastify);
+
+    const { reply } = createReply();
+    const result = (await ctx.handler!(
+      {
+        body: {
+          client_name: 'test-native-client',
+          redirect_uris: ['http://localhost:54545/callback'],
+          grant_types: ['authorization_code', 'refresh_token'],
+          response_types: ['code'],
+          token_endpoint_auth_method: 'none',
+          scope: 'openid',
+          application_type: 'native',
+          'x-custom-extension': 'value',
+        },
+        ip: '127.0.0.1',
+        headers: {},
+      },
+      reply
+    )) as Record<string, unknown>;
+
+    expect(result.client_id).toBeDefined();
+    expect('client_secret' in result).toBe(false);
+    expect('application_type' in result).toBe(false);
+  });
+
   it('seeds the realm default allowlist on first use when empty', async () => {
     const { fastify, ctx, state } = createFastifyStub({
       dynamicRegistrationAllowedScopes: [],

--- a/apps/auth-server/src/app/schemas/oauth.ts
+++ b/apps/auth-server/src/app/schemas/oauth.ts
@@ -154,32 +154,32 @@ export type IntrospectResponse = z.infer<typeof introspectResponseSchema>;
  *   - Grant/response type consistency is enforced in the route handler,
  *     not in the schema, so we can surface a structured OAuth error.
  *   - `scope` is space-separated per RFC 7591 §2 / RFC 6749 §3.3.
+ *   - RFC 7591 §3.2 requires servers to ignore unrecognized metadata fields,
+ *     so this schema uses Zod's default strip behaviour (no `.strict()`).
  */
-export const dynamicClientRegistrationRequestSchema = z
-  .object({
-    client_name: z.string().min(1).max(255).optional(),
-    redirect_uris: z.array(z.string().min(1).max(2048)).max(20).optional(),
-    grant_types: z
-      .array(z.enum(['authorization_code', 'refresh_token', 'client_credentials']))
-      .max(8)
-      .optional(),
-    response_types: z
-      .array(z.enum(['code']))
-      .max(4)
-      .optional(),
-    token_endpoint_auth_method: z
-      .enum(['none', 'client_secret_basic', 'client_secret_post'])
-      .optional(),
-    scope: z.string().max(2048).optional(),
-    client_uri: z.url().max(2048).optional(),
-    logo_uri: z.url().max(2048).optional(),
-    tos_uri: z.url().max(2048).optional(),
-    policy_uri: z.url().max(2048).optional(),
-    contacts: z.array(z.email().max(255)).max(10).optional(),
-    software_id: z.string().max(255).optional(),
-    software_version: z.string().max(64).optional(),
-  })
-  .strict();
+export const dynamicClientRegistrationRequestSchema = z.object({
+  client_name: z.string().min(1).max(255).optional(),
+  redirect_uris: z.array(z.string().min(1).max(2048)).max(20).optional(),
+  grant_types: z
+    .array(z.enum(['authorization_code', 'refresh_token', 'client_credentials']))
+    .max(8)
+    .optional(),
+  response_types: z
+    .array(z.enum(['code']))
+    .max(4)
+    .optional(),
+  token_endpoint_auth_method: z
+    .enum(['none', 'client_secret_basic', 'client_secret_post'])
+    .optional(),
+  scope: z.string().max(2048).optional(),
+  client_uri: z.url().max(2048).optional(),
+  logo_uri: z.url().max(2048).optional(),
+  tos_uri: z.url().max(2048).optional(),
+  policy_uri: z.url().max(2048).optional(),
+  contacts: z.array(z.email().max(255)).max(10).optional(),
+  software_id: z.string().max(255).optional(),
+  software_version: z.string().max(64).optional(),
+});
 
 export type DynamicClientRegistrationRequest = z.infer<
   typeof dynamicClientRegistrationRequestSchema


### PR DESCRIPTION
## Summary

- RFC 7591 §3.2 says servers MUST ignore unrecognised client metadata fields — `.strict()` violated this by returning a 400 for any unknown key
- Claude Code (and other OAuth 2.1 clients) send `application_type: "native"` — a valid IANA-registered field absent from our explicit allow-list, which triggered the failure
- Fix: remove `.strict()`; Zod's default strip mode accepts and silently discards unrecognised fields, matching the RFC

Caught by the end-to-end smoke test in majordomo scripts/smoke-oauth-chain.sh (section 2 was the only remaining failure after the full OAuth 2.1 stack landed in #156).

## Test plan

- [ ] Existing `register.test.ts` suite still passes (no regressions)
- [ ] New test: POST with `application_type: "native"` + custom extension returns `201` with `client_id`, no `client_secret`, no echoed unknown fields
- [ ] `scripts/smoke-oauth-chain.sh --tailscale` section 2 passes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)