### PR TITLE
fix(ui): drop redundant /ui/ prefix from login/consent route paths

### DIFF
--- a/apps/auth-server/src/app/routes/ui/consent.ts
+++ b/apps/auth-server/src/app/routes/ui/consent.ts
@@ -232,7 +232,7 @@ export default async function (fastify: FastifyInstance) {
    * re-issue the authorize call on Allow.
    */
   fastify.withTypeProvider<ZodTypeProvider>().get(
-    '/ui/consent',
+    '/consent',
     {
       schema: {
         description:
@@ -318,7 +318,7 @@ export default async function (fastify: FastifyInstance) {
    * client's redirect_uri in both cases.
    */
   fastify.withTypeProvider<ZodTypeProvider>().post(
-    '/ui/consent',
+    '/consent',
     {
       schema: {
         description:

--- a/apps/auth-server/src/app/routes/ui/login.ts
+++ b/apps/auth-server/src/app/routes/ui/login.ts
@@ -148,7 +148,7 @@ type LoginForm = z.infer<typeof loginFormSchema>;
 
 export default async function (fastify: FastifyInstance) {
   fastify.withTypeProvider<ZodTypeProvider>().get(
-    '/ui/login',
+    '/login',
     {
       schema: {
         description:
@@ -170,7 +170,7 @@ export default async function (fastify: FastifyInstance) {
   );
 
   fastify.withTypeProvider<ZodTypeProvider>().post(
-    '/ui/login',
+    '/login',
     {
       schema: {
         description: 'Submit the session-cookie login form. Sets __Host-qauth_session on success.',


### PR DESCRIPTION
## Summary

- `GET /ui/login` was returning **404** in production because the route was actually registered at `/ui/ui/login`
- `routes/ui/login.ts` declared `.get('/ui/login', ...)` but fastify-autoload adds the directory name as a route prefix by default (`dirNameRoutePrefix: true`), so the `/ui/` part got duplicated
- Same bug in `routes/ui/consent.ts`
- Fix: declare `'/login'` and `'/consent'` inside the handlers; autoload's directory prefix produces the final `/ui/login` and `/ui/consent` paths that every caller expects (HTML form `action=`, redirect targets, OIDC discovery, smoke test)

Matches the existing pattern in `routes/oauth/authorize.ts` which declares `'/authorize'` and is reachable at `/oauth/authorize`.

## Test plan

- [ ] `curl https://auth.example.com/ui/login` returns 200 (currently 404)
- [ ] `curl https://auth.example.com/ui/consent?...` returns the consent page (currently 404)
- [ ] `GET /oauth/authorize` still redirects to `/ui/login?return_to=...` and that redirect resolves (currently dead-ends at 404)
- [ ] Existing route tests pass unchanged — the test stubs ignore the URL string and capture handlers directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
