### PR TITLE
fix(oauth): accept public-client authorization_code exchange (PKCE, no secret)

### DIFF
--- a/apps/auth-server/src/app/helpers/client-auth.ts
+++ b/apps/auth-server/src/app/helpers/client-auth.ts
@@ -134,18 +134,19 @@ export async function authenticateClient(
 }
 
 /**
- * Authenticate a client for the refresh_token grant.
+ * Authenticate a client for grant types that permit public clients:
+ * `authorization_code` (PKCE-bound) and `refresh_token` (ownership-bound).
  *
- * OAuth 2.1 §4.3.1 / RFC 6749 §6: confidential clients present full
- * credentials (same rules as `authenticateClient`); public clients
- * (`token_endpoint_auth_method: 'none'`) present only `client_id` and
- * are bound to the presented refresh token by ownership + rotation.
+ * OAuth 2.1 §4.1.3 / §4.3.1 / RFC 6749 §6: confidential clients present
+ * full credentials (same rules as `authenticateClient`); public clients
+ * (`token_endpoint_auth_method: 'none'`) present only `client_id`.
  *
  * Returns the client row regardless of confidential-vs-public
- * classification. The caller MUST still enforce refresh-token ownership
- * (`refreshToken.oauthClientId === client.id`).
+ * classification. The caller MUST still enforce the grant-specific
+ * binding — PKCE `code_verifier` for authorization_code, refresh-token
+ * ownership + rotation for refresh_token.
  */
-export async function authenticateClientForRefresh(
+export async function authenticateClientPublicOrConfidential(
   fastify: FastifyInstance,
   realmId: string,
   request: FastifyRequest,

--- a/apps/auth-server/src/app/routes/oauth/token.test.ts
+++ b/apps/auth-server/src/app/routes/oauth/token.test.ts
@@ -846,6 +846,37 @@ describe('POST /oauth/token route — authorization_code grant', () => {
     const reply = createReply();
     await expect(handler(baseRequest(), reply)).rejects.toThrow(UnauthorizedClientError);
   });
+
+  it('authenticates a public client (token_endpoint_auth_method=none) by client_id alone', async () => {
+    // PKCE-capable public client — OAuth 2.1 §4.1.3. No client_secret sent;
+    // PKCE code_verifier + client_id is sufficient to bind the code to the
+    // client. Previously failed with invalid_client because the token route
+    // only accepted the public-client path for refresh_token.
+    const { fastify, ctx } = setupAuthCodeStub();
+    (fastify.repositories.oauthClients.findByClientId as unknown as Mock).mockResolvedValue({
+      id: 'client-uuid-ac-1',
+      clientId: 'test-client-1',
+      clientSecretHash: null,
+      enabled: true,
+      grantTypes: ['authorization_code', 'refresh_token'],
+      scopes: ['read:foo'],
+      audience: null,
+      tokenEndpointAuthMethod: 'none',
+    });
+    await tokenRoute(fastify);
+    const handler = ctx.handler;
+    if (!handler) throw new Error('Handler missing');
+
+    const request = baseRequest({ client_secret: undefined });
+    // No Authorization header, no client_secret — just client_id + PKCE verifier.
+    const reply = createReply();
+    const result = (await handler(request, reply)) as Record<string, unknown>;
+
+    expect(result.access_token).toBe('signed.jwt.token');
+    expect(result.refresh_token).toBe('refresh-token-plain');
+    // Password hasher MUST NOT have been called — public client, no secret to verify.
+    expect(fastify.passwordHasher.verifyPassword as unknown as Mock).not.toHaveBeenCalled();
+  });
 });
 
 describe('POST /oauth/token route — refresh_token grant', () => {

--- a/apps/auth-server/src/app/routes/oauth/token.ts
+++ b/apps/auth-server/src/app/routes/oauth/token.ts
@@ -15,7 +15,7 @@ import { env } from '../../../config/env';
 import { MIN_RESPONSE_TIME_MS } from '../../constants';
 import {
   authenticateClient,
-  authenticateClientForRefresh,
+  authenticateClientPublicOrConfidential,
   extractClientCredentials,
   type OAuthClientLike,
   resolveAudience,
@@ -81,15 +81,16 @@ export default async function (fastify: FastifyInstance) {
       try {
         const realm = await getOrCreateDefaultRealm(fastify);
 
-        // Authenticate the client. refresh_token supports public clients
-        // (RFC 6749 §6 / OAuth 2.1 §4.3.1) — `authenticateClientForRefresh`
-        // accepts the `client_id`-only path for `token_endpoint_auth_method
-        // = 'none'` clients. Confidential clients in every grant (including
-        // refresh_token) continue to present full credentials.
+        // Authenticate the client. authorization_code (PKCE) and
+        // refresh_token both support public clients
+        // (OAuth 2.1 §4.1.3 / §4.3.1 / RFC 6749 §6). The PKCE verifier /
+        // refresh-token ownership binds the grant to the client; no
+        // `client_secret` is required when `token_endpoint_auth_method:
+        // 'none'`. client_credentials is confidential-only by definition.
         let client: OAuthClientLike;
         try {
-          if (body.grant_type === 'refresh_token') {
-            client = await authenticateClientForRefresh(
+          if (body.grant_type === 'authorization_code' || body.grant_type === 'refresh_token') {
+            client = await authenticateClientPublicOrConfidential(
               fastify,
               realm.id,
               request as FastifyRequest,


### PR DESCRIPTION
## Summary

- Every `POST /oauth/token` with `grant_type=authorization_code` from a public client (dyn-reg, `token_endpoint_auth_method=none`) was being rejected with `invalid_client` — the handler only routed `refresh_token` through the public-client-capable authenticator
- OAuth 2.1 §4.1.3: for public clients, the PKCE `code_verifier` + `client_id` binds the code to the client; no `client_secret` is required
- Rename `authenticateClientForRefresh` → `authenticateClientPublicOrConfidential` (logic was already grant-agnostic; name was misleading) and use it for `authorization_code` too
- `client_credentials` stays confidential-only by definition

Hit in production when Claude Code's dyn-reg flow completed the browser step and the callback exchange blew up silently. Every real MCP 2025-06-18 client that uses dyn-reg + PKCE was broken by this.

## Test plan

- [ ] New test: public client with `token_endpoint_auth_method=none` gets tokens from `/oauth/token` with `client_id` alone (no `client_secret`, no Basic header); `passwordHasher.verifyPassword` never called
- [ ] Existing confidential-client authorization_code tests still pass (body `client_secret` path + Basic auth path)
- [ ] End-to-end: Claude Code's browser flow now completes the token exchange and the MCP session unblocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)