### PR TITLE
feat(oauth): implement RFC 8707 Resource Indicators

### DIFF
--- a/apps/auth-server/src/app/helpers/client-auth.ts
+++ b/apps/auth-server/src/app/helpers/client-auth.ts
@@ -205,18 +205,27 @@ export function validateScopes(
 
 /**
  * Resolve the `aud` JWT claim for a client.
- * Returns the client's configured audience (string[] from DB) when set,
- * otherwise falls back to the client_id per RFC 8707 light-mode.
  *
- * Validates the stored JSONB shape at read time — element type, non-empty,
- * per-entry length, and array size — and falls back to `client_id` when the
- * stored value is malformed (belt-and-braces beside the DB CHECK constraint).
+ * Precedence (RFC 8707 §2 then RFC 8707 light-mode fallback):
+ *   1. `resource` — resource indicators bound to the grant (auth code /
+ *      refresh token) or sent with a client_credentials request. When
+ *      present, overrides the pre-configured client audience so tokens
+ *      are always scoped to the caller-requested resource.
+ *   2. `client.audience` — configured per-client in the DB (machine
+ *      clients that don't send `resource`).
+ *   3. `client.clientId` — last-resort light-mode default.
+ *
+ * Validates the stored JSONB shape at read time for (2); falls back to
+ * (3) when the stored value is malformed (belt-and-braces beside the DB
+ * CHECK constraint).
  */
-export function resolveAudience(client: OAuthClientLike): string | string[] {
+export function resolveAudience(client: OAuthClientLike, resource?: string[]): string | string[] {
+  if (resource && resource.length > 0) {
+    return resource.length === 1 ? resource[0] : resource;
+  }
   const parsed = audienceSchema.safeParse(client.audience);
   if (!parsed.success || parsed.data.length === 0) {
     return client.clientId;
   }
-  // Collapse single-item arrays to string for compact JWTs.
   return parsed.data.length === 1 ? parsed.data[0] : parsed.data;
 }

--- a/apps/auth-server/src/app/helpers/discovery.ts
+++ b/apps/auth-server/src/app/helpers/discovery.ts
@@ -69,6 +69,9 @@ export function buildAuthorizationServerMetadata(
     // Public subject identifiers — no pairwise salts today.
     subject_types_supported: ['public'],
     id_token_signing_alg_values_supported: ['EdDSA'],
+    // RFC 8707 §3: advertise Resource Indicator support. Clients that want
+    // audience-scoped tokens can rely on this metadata flag.
+    resource_indicators_supported: true,
   };
 }
 

--- a/apps/auth-server/src/app/plugins/error-handler.ts
+++ b/apps/auth-server/src/app/plugins/error-handler.ts
@@ -6,6 +6,7 @@ import {
   InvalidCredentialsError,
   InvalidGrantError,
   InvalidScopeError,
+  InvalidTargetError,
   InvalidTokenError,
   JWTExpiredError,
   JWTInvalidError,
@@ -63,8 +64,13 @@ export default fp(async function (fastify: FastifyInstance) {
         'Error occurred'
       );
 
-      // OAuth errors that carry an optional `error_description` (RFC 6749 §5.2)
-      if (error instanceof InvalidScopeError || error instanceof InvalidGrantError) {
+      // OAuth errors that carry an optional `error_description` (RFC 6749 §5.2,
+      // RFC 8707 §2.2 for `invalid_target`)
+      if (
+        error instanceof InvalidScopeError ||
+        error instanceof InvalidGrantError ||
+        error instanceof InvalidTargetError
+      ) {
         const response: ErrorResponse = {
           error: error.message,
           statusCode: error.statusCode,

--- a/apps/auth-server/src/app/routes/oauth/authorize.test.ts
+++ b/apps/auth-server/src/app/routes/oauth/authorize.test.ts
@@ -203,4 +203,40 @@ describe('GET /oauth/authorize — session-cookie integration', () => {
     expect(state.redirected).toContain('code=');
     expect(state.redirected).toContain('state=xyz');
   });
+
+  it('persists RFC 8707 resource indicator(s) onto the authorization code', async () => {
+    // RFC 8707 clients sends `resource` with /oauth/authorize;
+    // the code row MUST carry it so /oauth/token can set `aud` correctly.
+    const { fastify, ctx } = makeFastify();
+    await authorizeRoute(fastify);
+    (fastify.repositories.oauthClients.findByClientId as unknown as Mock).mockResolvedValue(CLIENT);
+    (fastify.repositories.oauthConsents.findActive as unknown as Mock).mockResolvedValue({
+      scopes: ['email'],
+      revokedAt: null,
+    });
+    const { signSessionId } = await import('../../helpers/session-cookie');
+    const signed = signSessionId('sid-3');
+    (fastify.sessionUtils.getSession as unknown as Mock).mockResolvedValue({
+      userId: 'user-1',
+      email: 'a@b.com',
+      sessionId: 'sid-3',
+      createdAt: Date.now(),
+    });
+
+    const { reply } = createReply();
+    await ctx.handler!(
+      {
+        query: { ...BASE_QUERY, resource: ['https://api.example.com/v1'] },
+        url: '/oauth/authorize?response_type=code&client_id=app-123&scope=email&resource=https%3A%2F%2Fapi.example.com%2Fv1',
+        headers: { cookie: `__Host-qauth_session=${signed}` },
+        ip: '127.0.0.1',
+      },
+      reply
+    );
+
+    expect(fastify.repositories.authorizationCodes.create).toHaveBeenCalledOnce();
+    const createArg = (fastify.repositories.authorizationCodes.create as unknown as Mock).mock
+      .calls[0][0];
+    expect(createArg.resource).toEqual(['https://api.example.com/v1']);
+  });
 });

--- a/apps/auth-server/src/app/routes/oauth/authorize.ts
+++ b/apps/auth-server/src/app/routes/oauth/authorize.ts
@@ -230,6 +230,10 @@ export default async function (fastify: FastifyInstance) {
           codeChallengeMethod: 'S256',
           nonce: query.nonce ?? null,
           scopes,
+          // RFC 8707: bind the resource indicator(s) to the authorization
+          // code so /oauth/token can set the access token's `aud` claim to
+          // exactly what the client requested.
+          resource: query.resource ?? [],
           state: query.state ?? null,
           expiresAt,
         });

--- a/apps/auth-server/src/app/routes/oauth/token.test.ts
+++ b/apps/auth-server/src/app/routes/oauth/token.test.ts
@@ -2,6 +2,7 @@ import {
   InvalidClientError,
   InvalidGrantError,
   InvalidScopeError,
+  InvalidTargetError,
   NotFoundError,
   UnauthorizedClientError,
 } from '@qauth-labs/shared-errors';
@@ -177,6 +178,86 @@ describe('POST /oauth/token route — client_credentials grant', () => {
 
     // No refresh token persisted
     expect(fastify.repositories.refreshTokens.create).not.toHaveBeenCalled();
+  });
+
+  it('issues a client_credentials token with aud = requested resource when inside audience allowlist (RFC 8707)', async () => {
+    const { fastify, ctx } = createFastifyStub();
+    await tokenRoute(fastify);
+    const handler = ctx.handler;
+
+    const client = {
+      id: 'client-uuid-ccr-1',
+      clientId: 'machine-client',
+      clientSecretHash: 'hash',
+      enabled: true,
+      grantTypes: ['client_credentials'],
+      scopes: ['read:foo'],
+      audience: ['https://api.example.com/v1', 'https://api2.example.com/v1'],
+    };
+
+    (fastify.repositories.oauthClients.findByClientId as unknown as Mock).mockResolvedValue(client);
+    (fastify.passwordHasher.verifyPassword as unknown as Mock).mockResolvedValue(true);
+    (fastify.jwtUtils.signAccessToken as unknown as Mock).mockResolvedValue('cc.jwt');
+
+    const request = {
+      body: {
+        grant_type: 'client_credentials',
+        client_id: client.clientId,
+        client_secret: 'secret',
+        scope: 'read:foo',
+        resource: ['https://api.example.com/v1'],
+      },
+      ip: '127.0.0.1',
+      headers: { 'user-agent': 'vitest' },
+    };
+
+    const reply = createReply();
+    if (!handler) throw new Error('Handler missing');
+    await handler(request, reply);
+
+    // aud must be the requested resource, narrowing from the allowlist.
+    expect(fastify.jwtUtils.signAccessToken).toHaveBeenCalledWith(
+      expect.objectContaining({ aud: 'https://api.example.com/v1' })
+    );
+  });
+
+  it('rejects client_credentials with resource outside the client audience allowlist (RFC 8707 §2.2)', async () => {
+    // Security: without this check, a compromised machine credential could
+    // mint tokens for arbitrary resource servers it was never configured to reach.
+    const { fastify, ctx } = createFastifyStub();
+    await tokenRoute(fastify);
+    const handler = ctx.handler;
+
+    const client = {
+      id: 'client-uuid-ccr-2',
+      clientId: 'machine-client-2',
+      clientSecretHash: 'hash',
+      enabled: true,
+      grantTypes: ['client_credentials'],
+      scopes: ['read:foo'],
+      audience: ['https://api.example.com/v1'],
+    };
+
+    (fastify.repositories.oauthClients.findByClientId as unknown as Mock).mockResolvedValue(client);
+    (fastify.passwordHasher.verifyPassword as unknown as Mock).mockResolvedValue(true);
+
+    const request = {
+      body: {
+        grant_type: 'client_credentials',
+        client_id: client.clientId,
+        client_secret: 'secret',
+        scope: 'read:foo',
+        // Client asks for a resource NOT in its audience allowlist.
+        resource: ['https://unauthorized.example.com/v1'],
+      },
+      ip: '127.0.0.1',
+      headers: { 'user-agent': 'vitest' },
+    };
+
+    const reply = createReply();
+    if (!handler) throw new Error('Handler missing');
+    await expect(handler(request, reply)).rejects.toThrow(InvalidTargetError);
+    expect(fastify.jwtUtils.signAccessToken).not.toHaveBeenCalled();
   });
 
   it('authenticates client via Authorization: Basic header', async () => {
@@ -847,6 +928,44 @@ describe('POST /oauth/token route — authorization_code grant', () => {
     await expect(handler(baseRequest(), reply)).rejects.toThrow(UnauthorizedClientError);
   });
 
+  it('issues access token with aud = resource bound to the auth code (RFC 8707)', async () => {
+    const { fastify, ctx, authCode } = setupAuthCodeStub();
+    // Simulate the authorize step having stored `resource` on the auth code.
+    (fastify.repositories.authorizationCodes.findByCode as unknown as Mock).mockResolvedValue({
+      ...authCode,
+      resource: ['https://api.example.com/v1'],
+    });
+    await tokenRoute(fastify);
+    const handler = ctx.handler;
+    if (!handler) throw new Error('Handler missing');
+
+    const reply = createReply();
+    await handler(baseRequest(), reply);
+
+    const signArg = (fastify.jwtUtils.signAccessToken as unknown as Mock).mock.calls[0][0];
+    expect(signArg.aud).toBe('https://api.example.com/v1');
+    const rtArg = (fastify.repositories.refreshTokens.create as unknown as Mock).mock.calls[0][0];
+    expect(rtArg.resource).toEqual(['https://api.example.com/v1']);
+  });
+
+  it('rejects authorization_code exchange when request resource is outside code binding', async () => {
+    const { fastify, ctx, authCode } = setupAuthCodeStub();
+    (fastify.repositories.authorizationCodes.findByCode as unknown as Mock).mockResolvedValue({
+      ...authCode,
+      resource: ['https://api.example.com/v1'],
+    });
+    await tokenRoute(fastify);
+    const handler = ctx.handler;
+    if (!handler) throw new Error('Handler missing');
+
+    const reply = createReply();
+    // Client tries to request a different resource at token time — must fail
+    // with RFC 8707 §2.2 `invalid_target` (not invalid_grant).
+    await expect(
+      handler(baseRequest({ resource: ['https://api2.example.com/v1'] }), reply)
+    ).rejects.toThrow(InvalidTargetError);
+  });
+
   it('authenticates a public client (token_endpoint_auth_method=none) by client_id alone', async () => {
     // PKCE-capable public client — OAuth 2.1 §4.1.3. No client_secret sent;
     // PKCE code_verifier + client_id is sufficient to bind the code to the
@@ -1045,6 +1164,50 @@ describe('POST /oauth/token route — refresh_token grant', () => {
     // the other client's family.
     expect(fastify.repositories.refreshTokens.revokeFamily).not.toHaveBeenCalled();
     expect(fastify.repositories.refreshTokens.revoke).not.toHaveBeenCalled();
+  });
+
+  it('carries RFC 8707 resource binding across a refresh rotation', async () => {
+    const { fastify, ctx, confidentialClient, storedToken } = setupRefreshStub();
+    (fastify.repositories.oauthClients.findByClientId as unknown as Mock).mockResolvedValue(
+      confidentialClient
+    );
+    (
+      fastify.repositories.refreshTokens.findByTokenHashIncludingRevoked as unknown as Mock
+    ).mockResolvedValue({ ...storedToken, resource: ['https://api.example.com/v1'] });
+
+    await tokenRoute(fastify);
+    const handler = ctx.handler;
+    if (!handler) throw new Error('Handler missing');
+
+    const reply = createReply();
+    await handler(refreshRequest(), reply);
+
+    expect(fastify.jwtUtils.signAccessToken).toHaveBeenCalledWith(
+      expect.objectContaining({ aud: 'https://api.example.com/v1' })
+    );
+    expect(fastify.repositories.refreshTokens.create).toHaveBeenCalledWith(
+      expect.objectContaining({ resource: ['https://api.example.com/v1'] }),
+      expect.anything()
+    );
+  });
+
+  it('rejects refresh with resource outside the refresh-token binding (RFC 8707)', async () => {
+    const { fastify, ctx, confidentialClient, storedToken } = setupRefreshStub();
+    (fastify.repositories.oauthClients.findByClientId as unknown as Mock).mockResolvedValue(
+      confidentialClient
+    );
+    (
+      fastify.repositories.refreshTokens.findByTokenHashIncludingRevoked as unknown as Mock
+    ).mockResolvedValue({ ...storedToken, resource: ['https://api.example.com/v1'] });
+
+    await tokenRoute(fastify);
+    const handler = ctx.handler;
+    if (!handler) throw new Error('Handler missing');
+
+    const reply = createReply();
+    await expect(
+      handler(refreshRequest({ resource: ['https://api2.example.com/v1'] }), reply)
+    ).rejects.toThrow(InvalidTargetError);
   });
 
   it('honours scope down-scoping when a subset is requested', async () => {

--- a/apps/auth-server/src/app/routes/oauth/token.ts
+++ b/apps/auth-server/src/app/routes/oauth/token.ts
@@ -5,6 +5,7 @@ import {
   InvalidClientError,
   InvalidGrantError,
   InvalidScopeError,
+  InvalidTargetError,
   NotFoundError,
   UnauthorizedClientError,
 } from '@qauth-labs/shared-errors';
@@ -158,6 +159,7 @@ export default async function (fastify: FastifyInstance) {
       } catch (error) {
         if (
           error instanceof InvalidGrantError ||
+          error instanceof InvalidTargetError ||
           error instanceof InvalidClientError ||
           error instanceof InvalidScopeError ||
           error instanceof NotFoundError ||
@@ -281,6 +283,32 @@ async function handleAuthorizationCode(
     throw new InvalidGrantError('Invalid or expired authorization code');
   }
 
+  // RFC 8707 §2.2: if the token request also includes `resource`, it MUST
+  // be a subset of the one bound to the auth code. Empty request resource
+  // carries forward the code's resource unchanged.
+  const codeResource = authCode.resource ?? [];
+  const requestedResource = body.resource ?? [];
+  if (requestedResource.length > 0) {
+    const extra = requestedResource.filter((r) => !codeResource.includes(r));
+    if (extra.length > 0) {
+      await fastify.repositories.auditLogs.create({
+        userId: authCode.userId,
+        oauthClientId: client.id,
+        event: 'oauth.token.exchange.failure',
+        eventType: 'token',
+        success: false,
+        ipAddress: request.ip,
+        userAgent: request.headers['user-agent'] || null,
+        metadata: {
+          error: 'invalid_target: resource outside the authorization-code binding',
+          extra,
+        },
+      });
+      throw new InvalidTargetError('requested resource is outside the authorization-code binding');
+    }
+  }
+  const effectiveResource = requestedResource.length > 0 ? requestedResource : codeResource;
+
   await fastify.repositories.authorizationCodes.markUsed(authCode.id);
 
   const user = await fastify.repositories.users.findById(authCode.userId);
@@ -306,7 +334,7 @@ async function handleAuthorizationCode(
     email_verified: user.emailVerified,
     clientId: client.clientId,
     scope: scopeString,
-    aud: resolveAudience(client),
+    aud: resolveAudience(client, effectiveResource),
   });
 
   const { token: refreshToken, tokenHash } = fastify.jwtUtils.generateRefreshToken();
@@ -326,6 +354,9 @@ async function handleAuthorizationCode(
     familyId,
     expiresAt: refreshTokenExpiresAt,
     scopes: authCode.scopes,
+    // RFC 8707: carry the resource set onto the refresh token so subsequent
+    // refreshes produce access tokens with the same `aud`.
+    resource: effectiveResource,
   });
 
   let sessionId: string | undefined;
@@ -436,11 +467,42 @@ async function handleClientCredentials(
 
   const scopeString = grantedScopes.join(' ');
 
+  // RFC 8707 §2.2: machine clients MAY include `resource` to scope the
+  // minted token to a specific resource server, but only WITHIN the
+  // client's pre-configured audience allowlist. Without this check, a
+  // compromised machine-client credential could mint tokens for arbitrary
+  // resource URIs — including resource servers it was never configured
+  // to reach. Falls back to `[client.clientId]` when the client has no
+  // explicit audience, matching resolveAudience's light-mode default.
+  const requestedResource = body.resource ?? [];
+  if (requestedResource.length > 0) {
+    const allowedAudience =
+      client.audience && client.audience.length > 0 ? client.audience : [client.clientId];
+    const extra = requestedResource.filter((r) => !allowedAudience.includes(r));
+    if (extra.length > 0) {
+      await fastify.repositories.auditLogs.create({
+        userId: null,
+        oauthClientId: client.id,
+        event: 'oauth.token.exchange.failure',
+        eventType: 'token',
+        success: false,
+        ipAddress: request.ip,
+        userAgent: request.headers['user-agent'] || null,
+        metadata: {
+          error: 'invalid_target: resource outside the client audience allowlist',
+          extra,
+          allowedAudience,
+        },
+      });
+      throw new InvalidTargetError('requested resource is outside the client audience allowlist');
+    }
+  }
+
   const accessToken = await fastify.jwtUtils.signAccessToken({
     sub: client.clientId,
     clientId: client.clientId,
     scope: scopeString,
-    aud: resolveAudience(client),
+    aud: resolveAudience(client, requestedResource),
   });
 
   const accessTokenExpiresIn = fastify.jwtUtils.getAccessTokenLifespan();
@@ -456,6 +518,7 @@ async function handleClientCredentials(
     metadata: {
       grantType: 'client_credentials',
       scope: scopeString,
+      resource: requestedResource,
     },
   });
 
@@ -644,6 +707,34 @@ async function handleRefreshToken(
     grantedScopes = storedToken.scopes;
   }
 
+  // RFC 8707 §2.2: refresh requests MAY include `resource` to narrow the
+  // audience of the minted access token, but MUST NOT request a resource
+  // outside the set bound to the refresh token (which itself descends
+  // from the auth code). Empty request resource carries the stored set
+  // forward unchanged.
+  const storedResource = storedToken.resource ?? [];
+  const requestedResource = body.resource ?? [];
+  if (requestedResource.length > 0) {
+    const extra = requestedResource.filter((r) => !storedResource.includes(r));
+    if (extra.length > 0) {
+      await fastify.repositories.auditLogs.create({
+        userId: user.id,
+        oauthClientId: client.id,
+        event: 'oauth.token.exchange.failure',
+        eventType: 'token',
+        success: false,
+        ipAddress: request.ip,
+        userAgent: request.headers['user-agent'] || null,
+        metadata: {
+          error: 'invalid_target: resource outside the refresh-token binding',
+          extra,
+        },
+      });
+      throw new InvalidTargetError('requested resource is outside the refresh-token binding');
+    }
+  }
+  const effectiveResource = requestedResource.length > 0 ? requestedResource : storedResource;
+
   // Rotate atomically: revoke the presented token and insert the new one
   // inside a single transaction so a crash/failure between the two steps
   // can never leave the user with a revoked token and no replacement.
@@ -666,6 +757,10 @@ async function handleRefreshToken(
         previousTokenHash: presentedHash,
         expiresAt: refreshTokenExpiresAt,
         scopes: grantedScopes,
+        // RFC 8707: the rotated refresh token carries the (possibly
+        // narrowed) resource binding — NOT the request's — so we never
+        // widen the binding across a rotation.
+        resource: effectiveResource,
       },
       tx
     );
@@ -679,7 +774,7 @@ async function handleRefreshToken(
     email_verified: user.emailVerified,
     clientId: client.clientId,
     scope: scopeString,
-    aud: resolveAudience(client),
+    aud: resolveAudience(client, effectiveResource),
   });
 
   const accessTokenExpiresIn = fastify.jwtUtils.getAccessTokenLifespan();

--- a/apps/auth-server/src/app/schemas/oauth.ts
+++ b/apps/auth-server/src/app/schemas/oauth.ts
@@ -1,8 +1,27 @@
 import { z } from 'zod';
 
 /**
+ * RFC 8707 §2: `resource` is an absolute URI without fragment, identifying
+ * the protected resource the access token is intended for. Clients MAY
+ * include multiple values (one per resource). We accept either a single
+ * string or an array; the route normalizes to an array.
+ *
+ * Coerced to string[] so downstream code (authorize/token routes, DB
+ * repositories, `resolveAudience`) can treat all cases uniformly.
+ */
+const resourceEntrySchema = z
+  .url()
+  .max(2048)
+  .refine((v) => !v.includes('#'), { message: 'resource must not contain a fragment' });
+
+export const resourceParamSchema = z
+  .union([resourceEntrySchema, z.array(resourceEntrySchema).max(10)])
+  .optional()
+  .transform((v) => (v === undefined ? undefined : Array.isArray(v) ? v : [v]));
+
+/**
  * OAuth 2.1 authorize query parameters (GET /oauth/authorize).
- * RFC 6749 4.1.1, RFC 7636 PKCE.
+ * RFC 6749 4.1.1, RFC 7636 PKCE, RFC 8707 Resource Indicators.
  */
 export const authorizeQuerySchema = z.object({
   response_type: z.literal('code'),
@@ -17,6 +36,7 @@ export const authorizeQuerySchema = z.object({
   state: z.string().max(255).optional(),
   scope: z.string().optional(),
   nonce: z.string().max(255).optional(),
+  resource: resourceParamSchema,
 });
 
 export type AuthorizeQuery = z.infer<typeof authorizeQuerySchema>;
@@ -40,6 +60,9 @@ export const tokenExchangeAuthCodeBodySchema = z.object({
     .max(128)
     .regex(/^[A-Za-z0-9._~-]+$/),
   client_secret: z.string().min(1).optional(),
+  // RFC 8707 §2: when present, MUST match the resource set bound to the
+  // authorization code. Enforced in the handler, not the schema.
+  resource: resourceParamSchema,
 });
 
 /**
@@ -52,6 +75,9 @@ export const tokenExchangeClientCredsBodySchema = z.object({
   client_id: z.string().min(1).optional(),
   client_secret: z.string().min(1).optional(),
   scope: z.string().optional(),
+  // RFC 8707 §2: machine clients request a resource at mint time; handler
+  // uses it as the token `aud` (overrides client.audience when present).
+  resource: resourceParamSchema,
 });
 
 /**
@@ -76,6 +102,9 @@ export const tokenExchangeRefreshBodySchema = z.object({
   client_id: z.string().min(1).optional(),
   client_secret: z.string().min(1).optional(),
   scope: z.string().optional(),
+  // RFC 8707 §2: on refresh, resource MUST be a subset of the one bound
+  // to the original authorization code. Enforced in the handler.
+  resource: resourceParamSchema,
 });
 
 /**

--- a/libs/infra/db/drizzle/0003_rfc8707_resource_indicators.sql
+++ b/libs/infra/db/drizzle/0003_rfc8707_resource_indicators.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "authorization_codes" ADD COLUMN "resource" jsonb DEFAULT '[]'::jsonb NOT NULL;--> statement-breakpoint
+ALTER TABLE "refresh_tokens" ADD COLUMN "resource" jsonb DEFAULT '[]'::jsonb NOT NULL;

--- a/libs/infra/db/drizzle/meta/0003_snapshot.json
+++ b/libs/infra/db/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,2121 @@
+{
+  "id": "2d8e303d-29d8-40a5-99a3-7c7ab66840f8",
+  "prevId": "6f10760b-e599-4596-a225-c335e0c11431",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_client_id": {
+          "name": "oauth_client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event": {
+          "name": "event",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "audit_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(EXTRACT(EPOCH FROM NOW())::bigint * 1000)"
+        }
+      },
+      "indexes": {
+        "idx_audit_logs_user_id": {
+          "name": "idx_audit_logs_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_logs_oauth_client_id": {
+          "name": "idx_audit_logs_oauth_client_id",
+          "columns": [
+            {
+              "expression": "oauth_client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_logs_event_type": {
+          "name": "idx_audit_logs_event_type",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_logs_event": {
+          "name": "idx_audit_logs_event",
+          "columns": [
+            {
+              "expression": "event",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_logs_created_at": {
+          "name": "idx_audit_logs_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_logs_user_event": {
+          "name": "idx_audit_logs_user_event",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_logs_failed": {
+          "name": "idx_audit_logs_failed",
+          "columns": [
+            {
+              "expression": "event",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"audit_logs\".\"success\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_logs_ip_address": {
+          "name": "idx_audit_logs_ip_address",
+          "columns": [
+            {
+              "expression": "ip_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_logs_user_id_users_id_fk": {
+          "name": "audit_logs_user_id_users_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "audit_logs_oauth_client_id_oauth_clients_id_fk": {
+          "name": "audit_logs_oauth_client_id_oauth_clients_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "oauth_clients",
+          "columnsFrom": ["oauth_client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_consents": {
+      "name": "oauth_consents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oauth_client_id": {
+          "name": "oauth_client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "realm_id": {
+          "name": "realm_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(EXTRACT(EPOCH FROM NOW())::bigint * 1000)"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_oauth_consents_user_client_active": {
+          "name": "idx_oauth_consents_user_client_active",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "oauth_client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"oauth_consents\".\"revoked_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_oauth_consents_user_id": {
+          "name": "idx_oauth_consents_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_oauth_consents_client_id": {
+          "name": "idx_oauth_consents_client_id",
+          "columns": [
+            {
+              "expression": "oauth_client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_oauth_consents_realm_id": {
+          "name": "idx_oauth_consents_realm_id",
+          "columns": [
+            {
+              "expression": "realm_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_consents_user_id_users_id_fk": {
+          "name": "oauth_consents_user_id_users_id_fk",
+          "tableFrom": "oauth_consents",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_consents_oauth_client_id_oauth_clients_id_fk": {
+          "name": "oauth_consents_oauth_client_id_oauth_clients_id_fk",
+          "tableFrom": "oauth_consents",
+          "tableTo": "oauth_clients",
+          "columnsFrom": ["oauth_client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_consents_realm_id_realms_id_fk": {
+          "name": "oauth_consents_realm_id_realms_id_fk",
+          "tableFrom": "oauth_consents",
+          "tableTo": "realms",
+          "columnsFrom": ["realm_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_clients": {
+      "name": "oauth_clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "realm_id": {
+          "name": "realm_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret_hash": {
+          "name": "client_secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "audience": {
+          "name": "audience",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "require_pkce": {
+          "name": "require_pkce",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "token_endpoint_auth_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'client_secret_post'"
+        },
+        "grant_types": {
+          "name": "grant_types",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[\"authorization_code\",\"refresh_token\"]'::jsonb"
+        },
+        "response_types": {
+          "name": "response_types",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[\"code\"]'::jsonb"
+        },
+        "developer_id": {
+          "name": "developer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dynamic_registered_at": {
+          "name": "dynamic_registered_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(EXTRACT(EPOCH FROM NOW())::bigint * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(EXTRACT(EPOCH FROM NOW())::bigint * 1000)"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_oauth_clients_realm_client_id_unique": {
+          "name": "idx_oauth_clients_realm_client_id_unique",
+          "columns": [
+            {
+              "expression": "realm_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_oauth_clients_client_id": {
+          "name": "idx_oauth_clients_client_id",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_oauth_clients_realm_id": {
+          "name": "idx_oauth_clients_realm_id",
+          "columns": [
+            {
+              "expression": "realm_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_oauth_clients_developer_id": {
+          "name": "idx_oauth_clients_developer_id",
+          "columns": [
+            {
+              "expression": "developer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_oauth_clients_enabled": {
+          "name": "idx_oauth_clients_enabled",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"oauth_clients\".\"enabled\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_oauth_clients_realm_client_id_enabled": {
+          "name": "idx_oauth_clients_realm_client_id_enabled",
+          "columns": [
+            {
+              "expression": "realm_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_clients_realm_id_realms_id_fk": {
+          "name": "oauth_clients_realm_id_realms_id_fk",
+          "tableFrom": "oauth_clients",
+          "tableTo": "realms",
+          "columnsFrom": ["realm_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_clients_developer_id_users_id_fk": {
+          "name": "oauth_clients_developer_id_users_id_fk",
+          "tableFrom": "oauth_clients",
+          "tableTo": "users",
+          "columnsFrom": ["developer_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "oauth_clients_audience_is_array": {
+          "name": "oauth_clients_audience_is_array",
+          "value": "\"oauth_clients\".\"audience\" IS NULL OR jsonb_typeof(\"oauth_clients\".\"audience\") = 'array'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.realms": {
+      "name": "realms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "access_token_lifespan": {
+          "name": "access_token_lifespan",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 900
+        },
+        "refresh_token_lifespan": {
+          "name": "refresh_token_lifespan",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 604800
+        },
+        "ssl_required": {
+          "name": "ssl_required",
+          "type": "ssl_required",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'external'"
+        },
+        "verify_email": {
+          "name": "verify_email",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "registration_allowed": {
+          "name": "registration_allowed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "login_with_email_allowed": {
+          "name": "login_with_email_allowed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "duplicate_emails_allowed": {
+          "name": "duplicate_emails_allowed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "password_policy": {
+          "name": "password_policy",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sso_idle_timeout": {
+          "name": "sso_idle_timeout",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sso_max_lifespan": {
+          "name": "sso_max_lifespan",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoke_refresh_token": {
+          "name": "revoke_refresh_token",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "refresh_token_max_reuse": {
+          "name": "refresh_token_max_reuse",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "default_locale": {
+          "name": "default_locale",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supported_locales": {
+          "name": "supported_locales",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "dynamic_registration_allowed_scopes": {
+          "name": "dynamic_registration_allowed_scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(EXTRACT(EPOCH FROM NOW())::bigint * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(EXTRACT(EPOCH FROM NOW())::bigint * 1000)"
+        }
+      },
+      "indexes": {
+        "idx_realms_enabled": {
+          "name": "idx_realms_enabled",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"realms\".\"enabled\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "realms_name_unique": {
+          "name": "realms_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "realm_id": {
+          "name": "realm_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_normalized": {
+          "name": "email_normalized",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(EXTRACT(EPOCH FROM NOW())::bigint * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(EXTRACT(EPOCH FROM NOW())::bigint * 1000)"
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_users_realm_email_normalized_unique": {
+          "name": "idx_users_realm_email_normalized_unique",
+          "columns": [
+            {
+              "expression": "realm_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email_normalized",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_email": {
+          "name": "idx_users_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_realm_id": {
+          "name": "idx_users_realm_id",
+          "columns": [
+            {
+              "expression": "realm_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_enabled": {
+          "name": "idx_users_enabled",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"users\".\"enabled\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_realm_email_enabled": {
+          "name": "idx_users_realm_email_enabled",
+          "columns": [
+            {
+              "expression": "realm_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email_normalized",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_realm_id_realms_id_fk": {
+          "name": "users_realm_id_realms_id_fk",
+          "tableFrom": "users",
+          "tableTo": "realms",
+          "columnsFrom": ["realm_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roles": {
+      "name": "roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "realm_id": {
+          "name": "realm_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_client_id": {
+          "name": "oauth_client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(EXTRACT(EPOCH FROM NOW())::bigint * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(EXTRACT(EPOCH FROM NOW())::bigint * 1000)"
+        }
+      },
+      "indexes": {
+        "idx_roles_realm_name_unique": {
+          "name": "idx_roles_realm_name_unique",
+          "columns": [
+            {
+              "expression": "realm_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "oauth_client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_roles_name": {
+          "name": "idx_roles_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_roles_realm_id": {
+          "name": "idx_roles_realm_id",
+          "columns": [
+            {
+              "expression": "realm_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_roles_oauth_client_id": {
+          "name": "idx_roles_oauth_client_id",
+          "columns": [
+            {
+              "expression": "oauth_client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "roles_realm_id_realms_id_fk": {
+          "name": "roles_realm_id_realms_id_fk",
+          "tableFrom": "roles",
+          "tableTo": "realms",
+          "columnsFrom": ["realm_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "roles_oauth_client_id_oauth_clients_id_fk": {
+          "name": "roles_oauth_client_id_oauth_clients_id_fk",
+          "tableFrom": "roles",
+          "tableTo": "oauth_clients",
+          "columnsFrom": ["oauth_client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_roles": {
+      "name": "user_roles",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigned_at": {
+          "name": "assigned_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(EXTRACT(EPOCH FROM NOW())::bigint * 1000)"
+        },
+        "assigned_by": {
+          "name": "assigned_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_user_roles_user_id": {
+          "name": "idx_user_roles_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_roles_role_id": {
+          "name": "idx_user_roles_role_id",
+          "columns": [
+            {
+              "expression": "role_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_roles_user_id_users_id_fk": {
+          "name": "user_roles_user_id_users_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_roles_role_id_roles_id_fk": {
+          "name": "user_roles_role_id_roles_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "roles",
+          "columnsFrom": ["role_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_roles_assigned_by_users_id_fk": {
+          "name": "user_roles_assigned_by_users_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "users",
+          "columnsFrom": ["assigned_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_roles_pk": {
+          "name": "user_roles_pk",
+          "columns": ["user_id", "role_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oauth_client_id": {
+          "name": "oauth_client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_hash": {
+          "name": "access_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_hash": {
+          "name": "refresh_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(EXTRACT(EPOCH FROM NOW())::bigint * 1000)"
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(EXTRACT(EPOCH FROM NOW())::bigint * 1000)"
+        }
+      },
+      "indexes": {
+        "idx_sessions_user_id": {
+          "name": "idx_sessions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sessions_active": {
+          "name": "idx_sessions_active",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"sessions\".\"revoked\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sessions_expires_at": {
+          "name": "idx_sessions_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sessions_access_token_hash": {
+          "name": "idx_sessions_access_token_hash",
+          "columns": [
+            {
+              "expression": "access_token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sessions_oauth_client_id": {
+          "name": "idx_sessions_oauth_client_id",
+          "columns": [
+            {
+              "expression": "oauth_client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sessions_oauth_client_id_oauth_clients_id_fk": {
+          "name": "sessions_oauth_client_id_oauth_clients_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "oauth_clients",
+          "columnsFrom": ["oauth_client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.authorization_codes": {
+      "name": "authorization_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oauth_client_id": {
+          "name": "oauth_client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge": {
+          "name": "code_challenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge_method": {
+          "name": "code_challenge_method",
+          "type": "code_challenge_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'S256'"
+        },
+        "nonce": {
+          "name": "nonce",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "resource": {
+          "name": "resource",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used": {
+          "name": "used",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(EXTRACT(EPOCH FROM NOW())::bigint * 1000)"
+        }
+      },
+      "indexes": {
+        "idx_authorization_codes_active": {
+          "name": "idx_authorization_codes_active",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"authorization_codes\".\"used\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_authorization_codes_expires_at": {
+          "name": "idx_authorization_codes_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_authorization_codes_user_id": {
+          "name": "idx_authorization_codes_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_authorization_codes_oauth_client_id": {
+          "name": "idx_authorization_codes_oauth_client_id",
+          "columns": [
+            {
+              "expression": "oauth_client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "authorization_codes_oauth_client_id_oauth_clients_id_fk": {
+          "name": "authorization_codes_oauth_client_id_oauth_clients_id_fk",
+          "tableFrom": "authorization_codes",
+          "tableTo": "oauth_clients",
+          "columnsFrom": ["oauth_client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "authorization_codes_user_id_users_id_fk": {
+          "name": "authorization_codes_user_id_users_id_fk",
+          "tableFrom": "authorization_codes",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "authorization_codes_code_unique": {
+          "name": "authorization_codes_code_unique",
+          "nullsNotDistinct": false,
+          "columns": ["code"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_verification_tokens": {
+      "name": "email_verification_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used": {
+          "name": "used",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(EXTRACT(EPOCH FROM NOW())::bigint * 1000)"
+        }
+      },
+      "indexes": {
+        "idx_email_verification_tokens_user_id": {
+          "name": "idx_email_verification_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_email_verification_tokens_active": {
+          "name": "idx_email_verification_tokens_active",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"email_verification_tokens\".\"used\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_email_verification_tokens_expires_at": {
+          "name": "idx_email_verification_tokens_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_verification_tokens_user_id_users_id_fk": {
+          "name": "email_verification_tokens_user_id_users_id_fk",
+          "tableFrom": "email_verification_tokens",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "email_verification_tokens_token_hash_unique": {
+          "name": "email_verification_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.refresh_tokens": {
+      "name": "refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oauth_client_id": {
+          "name": "oauth_client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "family_id": {
+          "name": "family_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "resource": {
+          "name": "resource",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_reason": {
+          "name": "revoked_reason",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_token_hash": {
+          "name": "previous_token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(EXTRACT(EPOCH FROM NOW())::bigint * 1000)"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_refresh_tokens_active": {
+          "name": "idx_refresh_tokens_active",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"refresh_tokens\".\"revoked\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_refresh_tokens_expires_at": {
+          "name": "idx_refresh_tokens_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_refresh_tokens_user_id": {
+          "name": "idx_refresh_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_refresh_tokens_oauth_client_id": {
+          "name": "idx_refresh_tokens_oauth_client_id",
+          "columns": [
+            {
+              "expression": "oauth_client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_refresh_tokens_user_active": {
+          "name": "idx_refresh_tokens_user_active",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"refresh_tokens\".\"revoked\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_refresh_tokens_family_id": {
+          "name": "idx_refresh_tokens_family_id",
+          "columns": [
+            {
+              "expression": "family_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "refresh_tokens_user_id_users_id_fk": {
+          "name": "refresh_tokens_user_id_users_id_fk",
+          "tableFrom": "refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "refresh_tokens_oauth_client_id_oauth_clients_id_fk": {
+          "name": "refresh_tokens_oauth_client_id_oauth_clients_id_fk",
+          "tableFrom": "refresh_tokens",
+          "tableTo": "oauth_clients",
+          "columnsFrom": ["oauth_client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "refresh_tokens_token_hash_unique": {
+          "name": "refresh_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.audit_event_type": {
+      "name": "audit_event_type",
+      "schema": "public",
+      "values": ["auth", "token", "client", "security", "user", "realm"]
+    },
+    "public.code_challenge_method": {
+      "name": "code_challenge_method",
+      "schema": "public",
+      "values": ["S256"]
+    },
+    "public.grant_type": {
+      "name": "grant_type",
+      "schema": "public",
+      "values": ["authorization_code", "refresh_token", "client_credentials"]
+    },
+    "public.response_type": {
+      "name": "response_type",
+      "schema": "public",
+      "values": ["code"]
+    },
+    "public.ssl_required": {
+      "name": "ssl_required",
+      "schema": "public",
+      "values": ["none", "external", "all"]
+    },
+    "public.token_endpoint_auth_method": {
+      "name": "token_endpoint_auth_method",
+      "schema": "public",
+      "values": ["client_secret_post", "client_secret_basic", "private_key_jwt", "none"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/libs/infra/db/drizzle/meta/_journal.json
+++ b/libs/infra/db/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1777020661667,
       "tag": "0002_oauth_mcp_stack",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1777054812718,
+      "tag": "0003_rfc8707_resource_indicators",
+      "breakpoints": true
     }
   ]
 }

--- a/libs/infra/db/src/lib/schema/tokens.ts
+++ b/libs/infra/db/src/lib/schema/tokens.ts
@@ -48,6 +48,14 @@ export const authorizationCodes = pgTable(
     codeChallengeMethod: codeChallengeMethodEnum('code_challenge_method').notNull().default('S256'),
     nonce: varchar('nonce', { length: 255 }),
     scopes: jsonb('scopes').notNull().default(JSONB_EMPTY_ARRAY).$type<string[]>(),
+    /**
+     * RFC 8707 `resource` parameter(s) from /oauth/authorize. Absolute URIs
+     * identifying the protected resource(s) the issued access token is
+     * intended for. Becomes the token's `aud` claim at /oauth/token time.
+     * Empty array means "no resource indicated; fall back to
+     * client.audience / light-mode default" (backward-compatible path).
+     */
+    resource: jsonb('resource').notNull().default(JSONB_EMPTY_ARRAY).$type<string[]>(),
     state: varchar('state', { length: 255 }),
     expiresAt: bigint('expires_at', { mode: 'number' }).notNull(),
     used: boolean('used').notNull().default(false),
@@ -90,6 +98,13 @@ export const refreshTokens = pgTable(
       .notNull()
       .default(sql`uuidv7()`),
     scopes: jsonb('scopes').notNull().default(JSONB_EMPTY_ARRAY).$type<string[]>(),
+    /**
+     * RFC 8707 resource indicator(s) carried from the originating
+     * authorization code. All access tokens minted from this refresh
+     * token MUST have `aud` equal to (or a subset of) this list. Empty
+     * array means "no resource bound; use light-mode default".
+     */
+    resource: jsonb('resource').notNull().default(JSONB_EMPTY_ARRAY).$type<string[]>(),
     expiresAt: bigint('expires_at', { mode: 'number' }).notNull(),
     revoked: boolean('revoked').notNull().default(false),
     revokedAt: bigint('revoked_at', { mode: 'number' }),

--- a/libs/shared/errors/src/lib/auth/index.ts
+++ b/libs/shared/errors/src/lib/auth/index.ts
@@ -4,6 +4,7 @@ export * from './invalid-client.error';
 export * from './invalid-credentials.error';
 export * from './invalid-grant.error';
 export * from './invalid-scope.error';
+export * from './invalid-target.error';
 export * from './invalid-token.error';
 export * from './jwt-expired.error';
 export * from './jwt-invalid.error';

--- a/libs/shared/errors/src/lib/auth/invalid-target.error.ts
+++ b/libs/shared/errors/src/lib/auth/invalid-target.error.ts
@@ -1,0 +1,25 @@
+/**
+ * Error thrown when an OAuth resource indicator is invalid or unauthorized
+ * (RFC 8707 §2.2 `invalid_target`) — the client requested a `resource` that
+ * is outside the binding of its grant (authorization code / refresh token /
+ * client's configured audience allowlist).
+ *
+ * Wire format mirrors RFC 6749 §5.2 OAuth error responses: `error`
+ * carries the bare `invalid_target` token, with optional
+ * `error_description` for human-readable detail.
+ */
+export class InvalidTargetError extends Error {
+  readonly statusCode = 400;
+  readonly code = 'INVALID_TARGET';
+  readonly errorDescription?: string;
+
+  constructor(errorDescription?: string) {
+    super('invalid_target');
+    this.name = 'InvalidTargetError';
+    this.errorDescription = errorDescription;
+    Object.setPrototypeOf(this, InvalidTargetError.prototype);
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, InvalidTargetError);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds `resource` parameter support to `/oauth/authorize` and `/oauth/token` (all three grants), with persistence through the authorization code → refresh token → access token's `aud` claim.

Without this, dynamically-registered public clients (`audience=null`) were minting tokens with `aud=<client_id>` (a random UUID), which resource servers correctly rejected. RFC 8707 is the spec-compliant fix: the client names the resource, the AS binds the grant to it, and the issued access token's `aud` is the resource URI.

## Changes

- **Schemas**: add optional `resource` (single URI or array, ≤10 entries, absolute URI, no fragment, ≤2048 chars) to `authorizeQuerySchema`, all three token grant body schemas
- **DB migration** `0003_rfc8707_resource_indicators.sql`: adds `resource jsonb NOT NULL DEFAULT '[]'` to `authorization_codes` and `refresh_tokens`. Drizzle schema + snapshot regenerated
- **authorize.ts**: persist `resource` onto the auth code
- **token.ts (authorization_code)**: read `code.resource`; request narrowing must be a subset (else `invalid_target`); use as `aud`; carry onto issued refresh token
- **token.ts (client_credentials)**: accept `body.resource`; use as `aud` (overrides `client.audience` when present)
- **token.ts (refresh_token)**: read `storedToken.resource`; request narrowing must be a subset; rotated refresh token inherits the **effective** (not requested) binding — we never widen across a rotation
- **resolveAudience**: new optional `resource` param precedence: `resource > client.audience > clientId`
- **well-known**: advertise `resource_indicators_supported: true` per RFC 8707 §3

## Backward compatibility

Clients that don't send `resource` are unaffected — empty array falls back to `client.audience` / `clientId` as before. Pre-seeded machine clients (config/qauth/clients.json) keep working without any change.

## Test plan

- [x] `authorize.test`: persists `resource` onto the auth code row
- [x] `token.test` (authorization_code): `aud` = resource; narrowing outside the code's binding → `InvalidGrantError`
- [x] `token.test` (refresh_token): resource carries across rotation; narrowing outside stored binding → `InvalidGrantError`
- [x] All 169 auth-server tests pass locally
- [ ] End-to-end: Claude Code's dyn-reg browser flow issues a token with `aud=https://mcp.example.com/mcp`; a downstream MCP resource server accepts it once its expected audience is set to the resource URI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
