### PR TITLE
fix(oauth): normalize authorize `resource` querystring to string[]

### DIFF
--- a/apps/auth-server/src/app/routes/oauth/authorize.test.ts
+++ b/apps/auth-server/src/app/routes/oauth/authorize.test.ts
@@ -239,4 +239,44 @@ describe('GET /oauth/authorize — session-cookie integration', () => {
       .calls[0][0];
     expect(createArg.resource).toEqual(['https://api.example.com/v1']);
   });
+
+  it('normalizes a single-value resource querystring (bare string) to an array', async () => {
+    // Fastify querystring parsing + fastify-type-provider-zod@6 does not apply
+    // Zod `.transform()` outputs to `request.query` for GET routes the way it
+    // does for POST bodies. A single `resource=X` arrives as a bare string,
+    // not an array. The route normalizes before persistence so the auth code
+    // carries the correct shape for the /oauth/token binding check.
+    const { fastify, ctx } = makeFastify();
+    await authorizeRoute(fastify);
+    (fastify.repositories.oauthClients.findByClientId as unknown as Mock).mockResolvedValue(CLIENT);
+    (fastify.repositories.oauthConsents.findActive as unknown as Mock).mockResolvedValue({
+      scopes: ['email'],
+      revokedAt: null,
+    });
+    const { signSessionId } = await import('../../helpers/session-cookie');
+    const signed = signSessionId('sid-4');
+    (fastify.sessionUtils.getSession as unknown as Mock).mockResolvedValue({
+      userId: 'user-1',
+      email: 'a@b.com',
+      sessionId: 'sid-4',
+      createdAt: Date.now(),
+    });
+
+    const { reply } = createReply();
+    await ctx.handler!(
+      {
+        // Note: `resource` is a bare string here (not wrapped in an array),
+        // simulating Fastify's raw querystring parsing for `?resource=X`.
+        query: { ...BASE_QUERY, resource: 'https://api.example.com/v1' },
+        url: '/oauth/authorize?response_type=code&client_id=app-123&scope=email&resource=https%3A%2F%2Fapi.example.com%2Fv1',
+        headers: { cookie: `__Host-qauth_session=${signed}` },
+        ip: '127.0.0.1',
+      },
+      reply
+    );
+
+    const createArg = (fastify.repositories.authorizationCodes.create as unknown as Mock).mock
+      .calls[0][0];
+    expect(createArg.resource).toEqual(['https://api.example.com/v1']);
+  });
 });

--- a/apps/auth-server/src/app/routes/oauth/authorize.ts
+++ b/apps/auth-server/src/app/routes/oauth/authorize.ts
@@ -15,6 +15,20 @@ import { getOrCreateDefaultRealm } from '../../helpers/realm';
 import { type AuthorizeQuery, authorizeQuerySchema } from '../../schemas/oauth';
 
 /**
+ * RFC 8707: normalize the `resource` querystring param to a string[].
+ * See `resourceParamSchema` note — Fastify querystring transforms don't
+ * always reach the handler, so a single `resource=X` may arrive as a bare
+ * string. Zod has already validated shape (single URI or array of URIs);
+ * all we need is the shape coercion.
+ */
+function normalizeResource(v: unknown): string[] {
+  if (v === undefined || v === null) return [];
+  if (Array.isArray(v)) return v.filter((x): x is string => typeof x === 'string');
+  if (typeof v === 'string') return [v];
+  return [];
+}
+
+/**
  * GET /oauth/authorize
  * OAuth 2.1 Authorization Code Flow with PKCE.
  *
@@ -233,7 +247,12 @@ export default async function (fastify: FastifyInstance) {
           // RFC 8707: bind the resource indicator(s) to the authorization
           // code so /oauth/token can set the access token's `aud` claim to
           // exactly what the client requested.
-          resource: query.resource ?? [],
+          //
+          // fastify-type-provider-zod@6.1.0 does not apply Zod `.transform()`
+          // outputs to `request.query` on GET routes the way it does for
+          // POST bodies, so a single `resource=X` query param arrives as
+          // the raw string — normalize manually here.
+          resource: normalizeResource(query.resource as unknown),
           state: query.state ?? null,
           expiresAt,
         });


### PR DESCRIPTION
## Summary

End-to-end bug caught after deploying #160: every browser-driven PKCE flow with a single `resource` query param got `invalid_target: requested resource is outside the authorization-code binding` at `/oauth/token` time. Production traffic showed dozens of failed exchanges despite clients correctly sending `?resource=https://mcp.example.com`.

Root cause: `fastify-type-provider-zod@6.1.0` does not apply Zod `.transform()` outputs to `request.query` on GET routes the way it does for POST bodies. `resourceParamSchema` transforms `string → string[]`, so the schema test (which hands it an array) passed, but real browser traffic (single value → raw string) landed in the handler as a bare string and was dropped when written to the `jsonb NOT NULL DEFAULT '[]'::jsonb` column.

Token-side binding check then rejected the exchange because `authCode.resource` was `[]` while `body.resource` (POST body transform does work) carried the requested URI.

## Fix

Tiny `normalizeResource(v: unknown): string[]` helper at the top of `authorize.ts`, called on `query.resource` before persistence. Schema-level validation (URI shape, no fragment, length caps) still runs — only the array coercion is duplicated.

## Test plan

- [x] New test: `query.resource: 'bare-string'` (not an array) → code row persisted with `resource: ['bare-string']`
- [x] Existing test (array input) still passes — 172/172 auth-server tests
- [ ] Live Claude Code flow: fresh OAuth round-trip produces a token with `aud=<resource URI>` and memory-mcp accepts it

🤖 Generated with [Claude Code](https://claude.com/claude-code)