### PR TITLE
fix(oauth): parse RFC 8707 resource from request.url on authorize + consent paths

### DIFF
--- a/apps/auth-server/src/app/routes/oauth/authorize.test.ts
+++ b/apps/auth-server/src/app/routes/oauth/authorize.test.ts
@@ -240,12 +240,11 @@ describe('GET /oauth/authorize — session-cookie integration', () => {
     expect(createArg.resource).toEqual(['https://api.example.com/v1']);
   });
 
-  it('normalizes a single-value resource querystring (bare string) to an array', async () => {
-    // Fastify querystring parsing + fastify-type-provider-zod@6 does not apply
-    // Zod `.transform()` outputs to `request.query` for GET routes the way it
-    // does for POST bodies. A single `resource=X` arrives as a bare string,
-    // not an array. The route normalizes before persistence so the auth code
-    // carries the correct shape for the /oauth/token binding check.
+  it('parses RFC 8707 resource from request.url even when the validator does not populate request.query', async () => {
+    // Regression: fastify-type-provider-zod@6.1.0 does NOT put the Zod-parsed
+    // `resource` back onto `request.query` for GET routes, so a real auth
+    // flow had `query.resource === undefined` despite the URL carrying
+    // `?resource=X`. We now parse the URL directly — testing that path.
     const { fastify, ctx } = makeFastify();
     await authorizeRoute(fastify);
     (fastify.repositories.oauthClients.findByClientId as unknown as Mock).mockResolvedValue(CLIENT);
@@ -265,9 +264,9 @@ describe('GET /oauth/authorize — session-cookie integration', () => {
     const { reply } = createReply();
     await ctx.handler!(
       {
-        // Note: `resource` is a bare string here (not wrapped in an array),
-        // simulating Fastify's raw querystring parsing for `?resource=X`.
-        query: { ...BASE_QUERY, resource: 'https://api.example.com/v1' },
+        // `request.query` intentionally DOES NOT include `resource` — mirrors
+        // what we see in production when the Zod validator strips it.
+        query: BASE_QUERY,
         url: '/oauth/authorize?response_type=code&client_id=app-123&scope=email&resource=https%3A%2F%2Fapi.example.com%2Fv1',
         headers: { cookie: `__Host-qauth_session=${signed}` },
         ip: '127.0.0.1',
@@ -278,5 +277,44 @@ describe('GET /oauth/authorize — session-cookie integration', () => {
     const createArg = (fastify.repositories.authorizationCodes.create as unknown as Mock).mock
       .calls[0][0];
     expect(createArg.resource).toEqual(['https://api.example.com/v1']);
+  });
+
+  it('parses multiple `resource=` params from request.url into an array', async () => {
+    const { fastify, ctx } = makeFastify();
+    await authorizeRoute(fastify);
+    (fastify.repositories.oauthClients.findByClientId as unknown as Mock).mockResolvedValue(CLIENT);
+    (fastify.repositories.oauthConsents.findActive as unknown as Mock).mockResolvedValue({
+      scopes: ['email'],
+      revokedAt: null,
+    });
+    const { signSessionId } = await import('../../helpers/session-cookie');
+    const signed = signSessionId('sid-5');
+    (fastify.sessionUtils.getSession as unknown as Mock).mockResolvedValue({
+      userId: 'user-1',
+      email: 'a@b.com',
+      sessionId: 'sid-5',
+      createdAt: Date.now(),
+    });
+
+    const { reply } = createReply();
+    await ctx.handler!(
+      {
+        query: BASE_QUERY,
+        url:
+          '/oauth/authorize?response_type=code&client_id=app-123&scope=email' +
+          '&resource=https%3A%2F%2Fapi.example.com%2Fv1' +
+          '&resource=https%3A%2F%2Fapi2.example.com%2Fv1',
+        headers: { cookie: `__Host-qauth_session=${signed}` },
+        ip: '127.0.0.1',
+      },
+      reply
+    );
+
+    const createArg = (fastify.repositories.authorizationCodes.create as unknown as Mock).mock
+      .calls[0][0];
+    expect(createArg.resource).toEqual([
+      'https://api.example.com/v1',
+      'https://api2.example.com/v1',
+    ]);
   });
 });

--- a/apps/auth-server/src/app/routes/oauth/authorize.ts
+++ b/apps/auth-server/src/app/routes/oauth/authorize.ts
@@ -15,17 +15,25 @@ import { getOrCreateDefaultRealm } from '../../helpers/realm';
 import { type AuthorizeQuery, authorizeQuerySchema } from '../../schemas/oauth';
 
 /**
- * RFC 8707: normalize the `resource` querystring param to a string[].
- * See `resourceParamSchema` note — Fastify querystring transforms don't
- * always reach the handler, so a single `resource=X` may arrive as a bare
- * string. Zod has already validated shape (single URI or array of URIs);
- * all we need is the shape coercion.
+ * RFC 8707: parse every `resource=` query param directly from the request
+ * URL instead of relying on `request.query.resource`.
+ *
+ * Why: fastify-type-provider-zod@6.1.0 drops the `resource` field from the
+ * parsed query when its Zod schema is a union + transform (e.g.
+ * `z.union([z.url(), z.array(z.url())]).transform(...)`) — the raw-string
+ * variant from Fastify's querystring parser does not survive the validator.
+ * The field IS validated (invalid URIs fail the whole request), but the
+ * validator does not write the parsed array back into request.query.
+ *
+ * Reading from `request.url` sidesteps the validator entirely. Zod has
+ * already rejected invalid inputs at schema time, so whatever reaches this
+ * code point is already shape-safe.
  */
-function normalizeResource(v: unknown): string[] {
-  if (v === undefined || v === null) return [];
-  if (Array.isArray(v)) return v.filter((x): x is string => typeof x === 'string');
-  if (typeof v === 'string') return [v];
-  return [];
+function parseResourceFromUrl(url: string): string[] {
+  const q = url.indexOf('?');
+  if (q < 0) return [];
+  const params = new URLSearchParams(url.slice(q + 1));
+  return params.getAll('resource');
 }
 
 /**
@@ -246,13 +254,10 @@ export default async function (fastify: FastifyInstance) {
           scopes,
           // RFC 8707: bind the resource indicator(s) to the authorization
           // code so /oauth/token can set the access token's `aud` claim to
-          // exactly what the client requested.
-          //
-          // fastify-type-provider-zod@6.1.0 does not apply Zod `.transform()`
-          // outputs to `request.query` on GET routes the way it does for
-          // POST bodies, so a single `resource=X` query param arrives as
-          // the raw string — normalize manually here.
-          resource: normalizeResource(query.resource as unknown),
+          // exactly what the client requested. Reached on the consent-skip
+          // path (returning user, prior consent covers requested scopes);
+          // the consent-screen path creates codes in ui/consent.ts.
+          resource: parseResourceFromUrl(request.url),
           state: query.state ?? null,
           expiresAt,
         });

--- a/apps/auth-server/src/app/routes/ui/consent.test.ts
+++ b/apps/auth-server/src/app/routes/ui/consent.test.ts
@@ -298,6 +298,50 @@ describe('UI /ui/consent POST — allow/deny', () => {
     expect(state.redirected).toContain('state=xyz');
   });
 
+  it('persists RFC 8707 resource on the code when POST body carries resource field(s)', async () => {
+    const { fastify, ctx } = makeFastify();
+    await consentRoute(fastify);
+    const { signSessionId } = await import('../../helpers/session-cookie');
+    const signed = signSessionId('sid-res');
+    const csrf = 'csrf-res';
+    (fastify.sessionUtils.getSession as unknown as Mock).mockResolvedValue({
+      userId: 'user-1',
+      email: 'a@b.com',
+      sessionId: 'sid-res',
+      csrfToken: csrf,
+      createdAt: Date.now(),
+    });
+    (fastify.repositories.oauthClients.findByClientId as unknown as Mock).mockResolvedValue(CLIENT);
+
+    const { reply } = createReply();
+    await ctx.post!(
+      {
+        body: {
+          decision: 'allow',
+          allow_forever: '1',
+          csrf_token: csrf,
+          client_id: 'app-123',
+          redirect_uri: 'https://example.com/cb',
+          state: 'xyz',
+          scope: 'email',
+          code_challenge: 'A'.repeat(43),
+          code_challenge_method: 'S256',
+          response_type: 'code',
+          // Hidden form inputs from the consent page — one or more values
+          // (Fastify parses multi-value form bodies as an array).
+          resource: ['https://api.example.com/v1'],
+        },
+        headers: { cookie: `__Host-qauth_session=${signed}` },
+        ip: '127.0.0.1',
+      },
+      reply
+    );
+
+    const createArg = (fastify.repositories.authorizationCodes.create as unknown as Mock).mock
+      .calls[0][0];
+    expect(createArg.resource).toEqual(['https://api.example.com/v1']);
+  });
+
   it('allow without allow_forever issues code but does NOT persist consent', async () => {
     const { fastify, ctx } = makeFastify();
     await consentRoute(fastify);

--- a/apps/auth-server/src/app/routes/ui/consent.ts
+++ b/apps/auth-server/src/app/routes/ui/consent.ts
@@ -22,7 +22,19 @@ import {
   csrfTokensEqual,
   generateCsrfToken,
 } from '../../helpers/session-cookie';
-import { authorizeQuerySchema } from '../../schemas/oauth';
+import { authorizeQuerySchema, resourceParamSchema } from '../../schemas/oauth';
+
+/**
+ * RFC 8707: parse every `resource=` entry from a URL query string.
+ * See authorize.ts's parseResourceFromUrl — fastify-type-provider-zod@6.1.0
+ * drops the parsed `resource` from request.query for GET routes when the
+ * schema is a union + transform. Reading request.url sidesteps that.
+ */
+function parseResourceFromUrl(url: string): string[] {
+  const q = url.indexOf('?');
+  if (q < 0) return [];
+  return new URLSearchParams(url.slice(q + 1)).getAll('resource');
+}
 
 /**
  * Consent screen & Allow/Deny POST handler (issue #150).
@@ -52,6 +64,10 @@ const consentFormSchema = z.object({
   code_challenge: z.string().min(43).max(128),
   code_challenge_method: z.literal('S256'),
   response_type: z.literal('code'),
+  // RFC 8707: carried through as hidden form field(s). POST body transforms
+  // work (unlike GET querystrings), so `resourceParamSchema` populates an
+  // array on `body.resource`.
+  resource: resourceParamSchema,
 });
 
 type ConsentForm = z.infer<typeof consentFormSchema>;
@@ -73,15 +89,20 @@ function consentPage(opts: {
   badgeDynamic: boolean;
   csrfToken: string;
   authorizeParams: Record<string, string | undefined>;
+  /** RFC 8707 resource indicators — emitted as one hidden input per URI. */
+  resources: string[];
   userEmail: string;
 }): string {
   const scopeRows = opts.scopes.length
     ? opts.scopes.map((s) => html`<li><code>${s}</code> — ${describeScope(s)}</li>`)
     : [html`<li><em>No scopes requested.</em></li>`];
 
-  const hidden = Object.entries(opts.authorizeParams)
-    .filter(([, v]) => v != null && v !== '')
-    .map(([k, v]) => html`<input type="hidden" name="${k}" value="${String(v)}" />`);
+  const hidden = [
+    ...Object.entries(opts.authorizeParams)
+      .filter(([, v]) => v != null && v !== '')
+      .map(([k, v]) => html`<input type="hidden" name="${k}" value="${String(v)}" />`),
+    ...opts.resources.map((r) => html`<input type="hidden" name="resource" value="${r}" />`),
+  ];
 
   const audienceBlock = opts.audience.length
     ? html`<p><strong>Tokens will be valid for:</strong> ${opts.audience.join(', ')}</p>`
@@ -307,6 +328,11 @@ export default async function (fastify: FastifyInstance) {
             code_challenge_method: query.code_challenge_method,
             response_type: query.response_type,
           },
+          // RFC 8707: parsed directly from request.url (see
+          // parseResourceFromUrl). Rendered as one hidden <input
+          // name="resource" value="<uri>" /> per entry so the POST body
+          // carries every requested resource URI back to the handler.
+          resources: parseResourceFromUrl(request.url),
           userEmail: session.email,
         })
       );
@@ -441,6 +467,9 @@ export default async function (fastify: FastifyInstance) {
             codeChallengeMethod: 'S256',
             nonce: body.nonce ?? null,
             scopes,
+            // RFC 8707: bind the requested resource(s) to this code so
+            // /oauth/token can set the issued access token's `aud` claim.
+            resource: body.resource ?? [],
             state: body.state ?? null,
             expiresAt,
           });


### PR DESCRIPTION
## Problem

`fastify-type-provider-zod@6.1.0` does not write Zod-transformed fields back onto `request.query` for GET routes. This meant `query.resource` was always `undefined` even when the URL contained `resource=` params — so authorization codes were minted with an empty `resource` array, causing downstream `/oauth/token` to produce tokens with `aud` set to the client UUID instead of the requested resource URI. The `resource` param IS validated by Zod at schema time (invalid URIs still fail the request), but the parsed value is never surfaced on `request.query`.

The same bug affected both code-creation paths:

1. **authorize.ts** — the consent-skip path (returning user, prior grant covers scopes), which creates the code directly in `GET /oauth/authorize`.
2. **consent.ts** — the first-time browser flow, which creates the code in `POST /ui/consent`. This is the path taken by every new client authorization.

## Fix

Parse `resource` indicators directly from `request.url` via `URLSearchParams` instead of relying on `request.query.resource`:

- **`authorize.ts`** — `parseResourceFromUrl(request.url)` on the `authorizationCodes.create()` call (consent-skip path)
- **`consent.ts` GET** — parses resource URIs from the URL and renders one `<input type="hidden" name="resource" value="..." />` per URI so values survive the POST
- **`consent.ts` POST** — reads `body.resource` and passes it to `authorizationCodes.create()`

## Tests

- URL-parse regression: `query.resource` absent but URL carries `resource=` → code gets correct array
- Multi-value `resource=` params parsed into array
- Consent POST `allow_forever` path: `resource` field persisted onto the authorization code

🤖 Generated with [Claude Code](https://claude.com/claude-code)