### PR TITLE
feat(portal): Phase 2.1 — developer registration & dashboard shell

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -237,3 +237,16 @@ EMAIL_BASE_URL=https://example.com
 # Test Configuration (optional, for test environments)
 # TEST_DATABASE_URL=postgresql://qauth:password@localhost:5432/qauth_test
 # TEST_REDIS_URL=redis://localhost:6379/1
+
+# Developer Portal Configuration (apps/developer-portal)
+# Base URL of the auth-server this portal will call for authentication.
+# Must be reachable from the Node.js server process (not the browser).
+AUTH_SERVER_URL=http://localhost:3001
+
+# Secret used to sign the portal session cookie (__Host-qauth_portal_session).
+# Must be at least 32 characters of random data. Generate with:
+#   node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+PORTAL_SESSION_SECRET=change-me-to-a-random-hex-string-at-least-32-chars
+
+# Lifetime of the portal session cookie in seconds (default: 900 = 15 minutes)
+PORTAL_SESSION_TTL=900

--- a/.prettierignore
+++ b/.prettierignore
@@ -4,4 +4,5 @@ dist
 coverage
 *.log
 pnpm-lock.yaml
+**/routeTree.gen.ts
 

--- a/apps/developer-portal/README.md
+++ b/apps/developer-portal/README.md
@@ -1,0 +1,32 @@
+# Developer Portal
+
+TanStack Start application that lets QAuth users register, verify their email, log in, and manage OAuth consent grants.
+
+## Architecture
+
+The portal owns its own session via an HttpOnly signed cookie `__Host-qauth_portal_session`. The cookie carries `{ accessToken, refreshToken, expiresAt }` signed with HMAC-SHA256. TanStack Start server functions are the only callers of auth-server endpoints — tokens never enter the browser.
+
+## Environment variables
+
+| Variable                | Required | Default | Description                                                |
+| ----------------------- | -------- | ------- | ---------------------------------------------------------- |
+| `AUTH_SERVER_URL`       | Yes      | —       | Base URL of the auth-server (e.g. `http://localhost:3001`) |
+| `PORTAL_SESSION_SECRET` | Yes      | —       | 32+ char random secret for signing the session cookie      |
+| `PORTAL_SESSION_TTL`    | No       | `900`   | Session cookie lifetime in seconds                         |
+
+See `.env.example` at the repo root for sample values.
+
+## Server layer
+
+All server-only code lives under `src/server/`:
+
+- `config.ts` — env var validation (throws at startup if required vars are missing)
+- `session-cookie.ts` — HMAC-SHA256 sign/verify helpers for the portal session cookie
+- `auth-server-client.ts` — typed `fetch` wrappers for each auth-server endpoint, always returning `Result<T>` (never throws)
+- `actions/` — TanStack Start server functions (`createServerFn`) consumed by route files
+
+## Running tests
+
+```bash
+pnpm nx test developer-portal
+```

--- a/apps/developer-portal/project.json
+++ b/apps/developer-portal/project.json
@@ -3,5 +3,15 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "apps/developer-portal/src",
   "projectType": "application",
-  "tags": ["scope:app"]
+  "tags": ["scope:app"],
+  "targets": {
+    "test": {
+      "executor": "@nx/vitest:test",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "passWithNoTests": true,
+        "reportsDirectory": "{workspaceRoot}/coverage/{projectRoot}"
+      }
+    }
+  }
 }

--- a/apps/developer-portal/src/routeTree.gen.ts
+++ b/apps/developer-portal/src/routeTree.gen.ts
@@ -8,81 +8,87 @@
 // You should NOT make any changes in this file as it will be overwritten.
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
-import { Route as rootRouteImport } from './routes/__root';
-import { Route as VerifyRouteImport } from './routes/verify';
-import { Route as RegisterRouteImport } from './routes/register';
-import { Route as LoginRouteImport } from './routes/login';
-import { Route as ConsentsRouteImport } from './routes/consents';
-import { Route as AuthedRouteImport } from './routes/_authed';
-import { Route as IndexRouteImport } from './routes/index';
-import { Route as AuthedDashboardRouteImport } from './routes/_authed/dashboard';
+import { Route as rootRouteImport } from './routes/__root'
+import { Route as VerifyRouteImport } from './routes/verify'
+import { Route as RegisterRouteImport } from './routes/register'
+import { Route as LoginRouteImport } from './routes/login'
+import { Route as ConsentsRouteImport } from './routes/consents'
+import { Route as AuthedRouteImport } from './routes/_authed'
+import { Route as IndexRouteImport } from './routes/index'
+import { Route as AuthedDashboardRouteImport } from './routes/_authed/dashboard'
 
 const VerifyRoute = VerifyRouteImport.update({
   id: '/verify',
   path: '/verify',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const RegisterRoute = RegisterRouteImport.update({
   id: '/register',
   path: '/register',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const LoginRoute = LoginRouteImport.update({
   id: '/login',
   path: '/login',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const ConsentsRoute = ConsentsRouteImport.update({
   id: '/consents',
   path: '/consents',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const AuthedRoute = AuthedRouteImport.update({
   id: '/_authed',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const AuthedDashboardRoute = AuthedDashboardRouteImport.update({
   id: '/dashboard',
   path: '/dashboard',
   getParentRoute: () => AuthedRoute,
-} as any);
+} as any)
 
 export interface FileRoutesByFullPath {
-  '/': typeof IndexRoute;
-  '/consents': typeof ConsentsRoute;
-  '/login': typeof LoginRoute;
-  '/register': typeof RegisterRoute;
-  '/verify': typeof VerifyRoute;
-  '/dashboard': typeof AuthedDashboardRoute;
+  '/': typeof IndexRoute
+  '/consents': typeof ConsentsRoute
+  '/login': typeof LoginRoute
+  '/register': typeof RegisterRoute
+  '/verify': typeof VerifyRoute
+  '/dashboard': typeof AuthedDashboardRoute
 }
 export interface FileRoutesByTo {
-  '/': typeof IndexRoute;
-  '/consents': typeof ConsentsRoute;
-  '/login': typeof LoginRoute;
-  '/register': typeof RegisterRoute;
-  '/verify': typeof VerifyRoute;
-  '/dashboard': typeof AuthedDashboardRoute;
+  '/': typeof IndexRoute
+  '/consents': typeof ConsentsRoute
+  '/login': typeof LoginRoute
+  '/register': typeof RegisterRoute
+  '/verify': typeof VerifyRoute
+  '/dashboard': typeof AuthedDashboardRoute
 }
 export interface FileRoutesById {
-  __root__: typeof rootRouteImport;
-  '/': typeof IndexRoute;
-  '/_authed': typeof AuthedRouteWithChildren;
-  '/consents': typeof ConsentsRoute;
-  '/login': typeof LoginRoute;
-  '/register': typeof RegisterRoute;
-  '/verify': typeof VerifyRoute;
-  '/_authed/dashboard': typeof AuthedDashboardRoute;
+  __root__: typeof rootRouteImport
+  '/': typeof IndexRoute
+  '/_authed': typeof AuthedRouteWithChildren
+  '/consents': typeof ConsentsRoute
+  '/login': typeof LoginRoute
+  '/register': typeof RegisterRoute
+  '/verify': typeof VerifyRoute
+  '/_authed/dashboard': typeof AuthedDashboardRoute
 }
 export interface FileRouteTypes {
-  fileRoutesByFullPath: FileRoutesByFullPath;
-  fullPaths: '/' | '/consents' | '/login' | '/register' | '/verify' | '/dashboard';
-  fileRoutesByTo: FileRoutesByTo;
-  to: '/' | '/consents' | '/login' | '/register' | '/verify' | '/dashboard';
+  fileRoutesByFullPath: FileRoutesByFullPath
+  fullPaths:
+    | '/'
+    | '/consents'
+    | '/login'
+    | '/register'
+    | '/verify'
+    | '/dashboard'
+  fileRoutesByTo: FileRoutesByTo
+  to: '/' | '/consents' | '/login' | '/register' | '/verify' | '/dashboard'
   id:
     | '__root__'
     | '/'
@@ -91,81 +97,82 @@ export interface FileRouteTypes {
     | '/login'
     | '/register'
     | '/verify'
-    | '/_authed/dashboard';
-  fileRoutesById: FileRoutesById;
+    | '/_authed/dashboard'
+  fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
-  IndexRoute: typeof IndexRoute;
-  AuthedRoute: typeof AuthedRouteWithChildren;
-  ConsentsRoute: typeof ConsentsRoute;
-  LoginRoute: typeof LoginRoute;
-  RegisterRoute: typeof RegisterRoute;
-  VerifyRoute: typeof VerifyRoute;
+  IndexRoute: typeof IndexRoute
+  AuthedRoute: typeof AuthedRouteWithChildren
+  ConsentsRoute: typeof ConsentsRoute
+  LoginRoute: typeof LoginRoute
+  RegisterRoute: typeof RegisterRoute
+  VerifyRoute: typeof VerifyRoute
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
     '/verify': {
-      id: '/verify';
-      path: '/verify';
-      fullPath: '/verify';
-      preLoaderRoute: typeof VerifyRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
+      id: '/verify'
+      path: '/verify'
+      fullPath: '/verify'
+      preLoaderRoute: typeof VerifyRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/register': {
-      id: '/register';
-      path: '/register';
-      fullPath: '/register';
-      preLoaderRoute: typeof RegisterRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
+      id: '/register'
+      path: '/register'
+      fullPath: '/register'
+      preLoaderRoute: typeof RegisterRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/login': {
-      id: '/login';
-      path: '/login';
-      fullPath: '/login';
-      preLoaderRoute: typeof LoginRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
+      id: '/login'
+      path: '/login'
+      fullPath: '/login'
+      preLoaderRoute: typeof LoginRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/consents': {
-      id: '/consents';
-      path: '/consents';
-      fullPath: '/consents';
-      preLoaderRoute: typeof ConsentsRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
+      id: '/consents'
+      path: '/consents'
+      fullPath: '/consents'
+      preLoaderRoute: typeof ConsentsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/_authed': {
-      id: '/_authed';
-      path: '';
-      fullPath: '/';
-      preLoaderRoute: typeof AuthedRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
+      id: '/_authed'
+      path: ''
+      fullPath: '/'
+      preLoaderRoute: typeof AuthedRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/': {
-      id: '/';
-      path: '/';
-      fullPath: '/';
-      preLoaderRoute: typeof IndexRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
+      id: '/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/_authed/dashboard': {
-      id: '/_authed/dashboard';
-      path: '/dashboard';
-      fullPath: '/dashboard';
-      preLoaderRoute: typeof AuthedDashboardRouteImport;
-      parentRoute: typeof AuthedRoute;
-    };
+      id: '/_authed/dashboard'
+      path: '/dashboard'
+      fullPath: '/dashboard'
+      preLoaderRoute: typeof AuthedDashboardRouteImport
+      parentRoute: typeof AuthedRoute
+    }
   }
 }
 
 interface AuthedRouteChildren {
-  AuthedDashboardRoute: typeof AuthedDashboardRoute;
+  AuthedDashboardRoute: typeof AuthedDashboardRoute
 }
 
 const AuthedRouteChildren: AuthedRouteChildren = {
   AuthedDashboardRoute: AuthedDashboardRoute,
-};
+}
 
-const AuthedRouteWithChildren = AuthedRoute._addFileChildren(AuthedRouteChildren);
+const AuthedRouteWithChildren =
+  AuthedRoute._addFileChildren(AuthedRouteChildren)
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
@@ -174,16 +181,16 @@ const rootRouteChildren: RootRouteChildren = {
   LoginRoute: LoginRoute,
   RegisterRoute: RegisterRoute,
   VerifyRoute: VerifyRoute,
-};
+}
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)
-  ._addFileTypes<FileRouteTypes>();
+  ._addFileTypes<FileRouteTypes>()
 
-import type { getRouter } from './router.tsx';
-import type { createStart } from '@tanstack/react-start';
+import type { getRouter } from './router.tsx'
+import type { createStart } from '@tanstack/react-start'
 declare module '@tanstack/react-start' {
   interface Register {
-    ssr: true;
-    router: Awaited<ReturnType<typeof getRouter>>;
+    ssr: true
+    router: Awaited<ReturnType<typeof getRouter>>
   }
 }

--- a/apps/developer-portal/src/routeTree.gen.ts
+++ b/apps/developer-portal/src/routeTree.gen.ts
@@ -8,79 +8,182 @@
 // You should NOT make any changes in this file as it will be overwritten.
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
-import { Route as rootRouteImport } from './routes/__root'
-import { Route as ConsentsRouteImport } from './routes/consents'
-import { Route as IndexRouteImport } from './routes/index'
+import { Route as rootRouteImport } from './routes/__root';
+import { Route as VerifyRouteImport } from './routes/verify';
+import { Route as RegisterRouteImport } from './routes/register';
+import { Route as LoginRouteImport } from './routes/login';
+import { Route as ConsentsRouteImport } from './routes/consents';
+import { Route as AuthedRouteImport } from './routes/_authed';
+import { Route as IndexRouteImport } from './routes/index';
+import { Route as AuthedDashboardRouteImport } from './routes/_authed/dashboard';
 
+const VerifyRoute = VerifyRouteImport.update({
+  id: '/verify',
+  path: '/verify',
+  getParentRoute: () => rootRouteImport,
+} as any);
+const RegisterRoute = RegisterRouteImport.update({
+  id: '/register',
+  path: '/register',
+  getParentRoute: () => rootRouteImport,
+} as any);
+const LoginRoute = LoginRouteImport.update({
+  id: '/login',
+  path: '/login',
+  getParentRoute: () => rootRouteImport,
+} as any);
 const ConsentsRoute = ConsentsRouteImport.update({
   id: '/consents',
   path: '/consents',
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
+const AuthedRoute = AuthedRouteImport.update({
+  id: '/_authed',
+  getParentRoute: () => rootRouteImport,
+} as any);
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
+const AuthedDashboardRoute = AuthedDashboardRouteImport.update({
+  id: '/dashboard',
+  path: '/dashboard',
+  getParentRoute: () => AuthedRoute,
+} as any);
 
 export interface FileRoutesByFullPath {
-  '/': typeof IndexRoute
-  '/consents': typeof ConsentsRoute
+  '/': typeof IndexRoute;
+  '/consents': typeof ConsentsRoute;
+  '/login': typeof LoginRoute;
+  '/register': typeof RegisterRoute;
+  '/verify': typeof VerifyRoute;
+  '/dashboard': typeof AuthedDashboardRoute;
 }
 export interface FileRoutesByTo {
-  '/': typeof IndexRoute
-  '/consents': typeof ConsentsRoute
+  '/': typeof IndexRoute;
+  '/consents': typeof ConsentsRoute;
+  '/login': typeof LoginRoute;
+  '/register': typeof RegisterRoute;
+  '/verify': typeof VerifyRoute;
+  '/dashboard': typeof AuthedDashboardRoute;
 }
 export interface FileRoutesById {
-  __root__: typeof rootRouteImport
-  '/': typeof IndexRoute
-  '/consents': typeof ConsentsRoute
+  __root__: typeof rootRouteImport;
+  '/': typeof IndexRoute;
+  '/_authed': typeof AuthedRouteWithChildren;
+  '/consents': typeof ConsentsRoute;
+  '/login': typeof LoginRoute;
+  '/register': typeof RegisterRoute;
+  '/verify': typeof VerifyRoute;
+  '/_authed/dashboard': typeof AuthedDashboardRoute;
 }
 export interface FileRouteTypes {
-  fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/consents'
-  fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/consents'
-  id: '__root__' | '/' | '/consents'
-  fileRoutesById: FileRoutesById
+  fileRoutesByFullPath: FileRoutesByFullPath;
+  fullPaths: '/' | '/consents' | '/login' | '/register' | '/verify' | '/dashboard';
+  fileRoutesByTo: FileRoutesByTo;
+  to: '/' | '/consents' | '/login' | '/register' | '/verify' | '/dashboard';
+  id:
+    | '__root__'
+    | '/'
+    | '/_authed'
+    | '/consents'
+    | '/login'
+    | '/register'
+    | '/verify'
+    | '/_authed/dashboard';
+  fileRoutesById: FileRoutesById;
 }
 export interface RootRouteChildren {
-  IndexRoute: typeof IndexRoute
-  ConsentsRoute: typeof ConsentsRoute
+  IndexRoute: typeof IndexRoute;
+  AuthedRoute: typeof AuthedRouteWithChildren;
+  ConsentsRoute: typeof ConsentsRoute;
+  LoginRoute: typeof LoginRoute;
+  RegisterRoute: typeof RegisterRoute;
+  VerifyRoute: typeof VerifyRoute;
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/verify': {
+      id: '/verify';
+      path: '/verify';
+      fullPath: '/verify';
+      preLoaderRoute: typeof VerifyRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    '/register': {
+      id: '/register';
+      path: '/register';
+      fullPath: '/register';
+      preLoaderRoute: typeof RegisterRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    '/login': {
+      id: '/login';
+      path: '/login';
+      fullPath: '/login';
+      preLoaderRoute: typeof LoginRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
     '/consents': {
-      id: '/consents'
-      path: '/consents'
-      fullPath: '/consents'
-      preLoaderRoute: typeof ConsentsRouteImport
-      parentRoute: typeof rootRouteImport
-    }
+      id: '/consents';
+      path: '/consents';
+      fullPath: '/consents';
+      preLoaderRoute: typeof ConsentsRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    '/_authed': {
+      id: '/_authed';
+      path: '';
+      fullPath: '/';
+      preLoaderRoute: typeof AuthedRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
     '/': {
-      id: '/'
-      path: '/'
-      fullPath: '/'
-      preLoaderRoute: typeof IndexRouteImport
-      parentRoute: typeof rootRouteImport
-    }
+      id: '/';
+      path: '/';
+      fullPath: '/';
+      preLoaderRoute: typeof IndexRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    '/_authed/dashboard': {
+      id: '/_authed/dashboard';
+      path: '/dashboard';
+      fullPath: '/dashboard';
+      preLoaderRoute: typeof AuthedDashboardRouteImport;
+      parentRoute: typeof AuthedRoute;
+    };
   }
 }
 
+interface AuthedRouteChildren {
+  AuthedDashboardRoute: typeof AuthedDashboardRoute;
+}
+
+const AuthedRouteChildren: AuthedRouteChildren = {
+  AuthedDashboardRoute: AuthedDashboardRoute,
+};
+
+const AuthedRouteWithChildren = AuthedRoute._addFileChildren(AuthedRouteChildren);
+
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  AuthedRoute: AuthedRouteWithChildren,
   ConsentsRoute: ConsentsRoute,
-}
+  LoginRoute: LoginRoute,
+  RegisterRoute: RegisterRoute,
+  VerifyRoute: VerifyRoute,
+};
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)
-  ._addFileTypes<FileRouteTypes>()
+  ._addFileTypes<FileRouteTypes>();
 
-import type { getRouter } from './router.tsx'
-import type { createStart } from '@tanstack/react-start'
+import type { getRouter } from './router.tsx';
+import type { createStart } from '@tanstack/react-start';
 declare module '@tanstack/react-start' {
   interface Register {
-    ssr: true
-    router: Awaited<ReturnType<typeof getRouter>>
+    ssr: true;
+    router: Awaited<ReturnType<typeof getRouter>>;
   }
 }

--- a/apps/developer-portal/src/routes/_authed.test.tsx
+++ b/apps/developer-portal/src/routes/_authed.test.tsx
@@ -1,0 +1,85 @@
+import { RouterContextProvider } from '@tanstack/react-router';
+import { renderToString } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+
+const { mockRedirect } = vi.hoisted(() => ({
+  mockRedirect: vi.fn((opts: { to: string }) => {
+    const err = new Error(`Redirect to ${opts.to}`) as Error & { to: string };
+    err.to = opts.to;
+    throw err;
+  }),
+}));
+
+vi.mock('../server/actions/current-user', () => ({
+  currentUserFn: vi.fn(),
+}));
+
+vi.mock('../server/actions/logout', () => ({
+  logoutFn: vi.fn(),
+}));
+
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tanstack/react-router')>();
+  return {
+    ...actual,
+    redirect: mockRedirect,
+    // useRouter is mocked for the component's direct useRouter() call (navigate).
+    // Route.useRouteContext() goes through the internal ./useRouter.js which reads React context
+    // — that is provided by RouterContextProvider below.
+    useRouter: vi.fn(() => ({ navigate: vi.fn() })),
+    Outlet: () => null,
+  };
+});
+
+import { currentUserFn } from '../server/actions/current-user';
+import { Route } from './_authed';
+
+// Route.id is a getter backed by Route._id, which is normally populated by the
+// route tree generator via Route.init(). Set _id directly so that
+// Route.useRouteContext() passes from: '/_authed' to useMatch in tests.
+(Route as unknown as { _id: string })._id = '/_authed';
+
+const testUser = { sub: 'u1', email: 'dev@example.com', email_verified: true };
+
+// Minimal fake router for SSR-mode rendering via RouterContextProvider.
+// Route.useRouteContext() → useMatch({ from: '/_authed' }) → useRouterState() →
+// the internal useRouter.js reads React context → returns this fakeRouter.
+const fakeRouter = {
+  isServer: true,
+  options: {},
+  state: {
+    matches: [{ id: '/_authed', routeId: '/_authed', search: {}, context: { user: testUser } }],
+  },
+} as unknown as Parameters<typeof RouterContextProvider>[0]['router'];
+
+describe('_authed beforeLoad guard', () => {
+  it('throws a redirect to /login when currentUserFn returns null', async () => {
+    vi.mocked(currentUserFn).mockResolvedValue(null);
+
+    const beforeLoad = Route.options.beforeLoad as (ctx: unknown) => Promise<unknown>;
+    await expect(beforeLoad({})).rejects.toMatchObject({ to: '/login' });
+    expect(mockRedirect).toHaveBeenCalledWith({ to: '/login' });
+  });
+
+  it('returns the user context when currentUserFn returns a user', async () => {
+    vi.mocked(currentUserFn).mockResolvedValue({ user: testUser });
+
+    const beforeLoad = Route.options.beforeLoad as (ctx: unknown) => Promise<unknown>;
+    const result = (await beforeLoad({})) as { user: typeof testUser };
+
+    expect(result).toEqual({ user: testUser });
+  });
+});
+
+describe('AuthedLayout component', () => {
+  it('renders the portal header with user email and logout button', () => {
+    const html = renderToString(
+      <RouterContextProvider router={fakeRouter}>
+        <Route.options.component />
+      </RouterContextProvider>
+    );
+    expect(html).toContain('QAuth Developer Portal');
+    expect(html).toContain('dev@example.com');
+    expect(html).toContain('Log out');
+  });
+});

--- a/apps/developer-portal/src/routes/_authed.tsx
+++ b/apps/developer-portal/src/routes/_authed.tsx
@@ -1,0 +1,49 @@
+import { createFileRoute, Outlet, redirect, useRouter } from '@tanstack/react-router';
+
+import { currentUserFn } from '../server/actions/current-user';
+import { logoutFn } from '../server/actions/logout';
+import type { UserInfoData } from '../server/auth-server-client';
+
+export const Route = createFileRoute('/_authed')({
+  beforeLoad: async () => {
+    const result = await currentUserFn();
+    if (result === null) {
+      throw redirect({ to: '/login' });
+    }
+    return { user: result.user };
+  },
+  component: AuthedLayout,
+});
+
+function AuthedLayout() {
+  const { user } = Route.useRouteContext() as { user: UserInfoData };
+  const router = useRouter();
+
+  async function handleLogout() {
+    await logoutFn();
+    await router.navigate({ to: '/login' });
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <header className="border-b border-gray-200 bg-white px-6 py-3">
+        <div className="mx-auto flex max-w-5xl items-center justify-between">
+          <span className="text-sm font-medium text-gray-700">QAuth Developer Portal</span>
+          <div className="flex items-center gap-4">
+            <span className="text-sm text-gray-500">{user.email ?? user.sub}</span>
+            {/* Button primitive drops onClick — use native button here */}
+            <button
+              type="button"
+              onClick={() => void handleLogout()}
+              className="rounded-md border border-gray-300 bg-white px-3 py-1 text-sm text-gray-800 hover:bg-gray-100"
+            >
+              Log out
+            </button>
+          </div>
+        </div>
+      </header>
+
+      <Outlet />
+    </div>
+  );
+}

--- a/apps/developer-portal/src/routes/_authed.tsx
+++ b/apps/developer-portal/src/routes/_authed.tsx
@@ -1,3 +1,4 @@
+import { Button } from '@qauth-labs/ui';
 import { createFileRoute, Outlet, redirect, useRouter } from '@tanstack/react-router';
 
 import { currentUserFn } from '../server/actions/current-user';
@@ -31,14 +32,9 @@ function AuthedLayout() {
           <span className="text-sm font-medium text-gray-700">QAuth Developer Portal</span>
           <div className="flex items-center gap-4">
             <span className="text-sm text-gray-500">{user.email ?? user.sub}</span>
-            {/* Button primitive drops onClick — use native button here */}
-            <button
-              type="button"
-              onClick={() => void handleLogout()}
-              className="rounded-md border border-gray-300 bg-white px-3 py-1 text-sm text-gray-800 hover:bg-gray-100"
-            >
+            <Button variant="ghost" size="sm" type="button" onClick={() => void handleLogout()}>
               Log out
-            </button>
+            </Button>
           </div>
         </div>
       </header>

--- a/apps/developer-portal/src/routes/_authed/dashboard.test.tsx
+++ b/apps/developer-portal/src/routes/_authed/dashboard.test.tsx
@@ -1,0 +1,62 @@
+import { RouterContextProvider } from '@tanstack/react-router';
+import { renderToString } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+
+import { Route } from './dashboard';
+
+// Route.id is a getter backed by Route._id, which is normally populated by the
+// route tree generator via Route.init(). Set _id directly so that
+// Route.useRouteContext() passes from: '/_authed/dashboard' to useMatch in tests.
+(Route as unknown as { _id: string })._id = '/_authed/dashboard';
+
+const testUser = { sub: 'u1', email: 'dev@example.com', email_verified: true };
+
+// Minimal fake router for SSR-mode rendering via RouterContextProvider.
+// Route.useRouteContext() → useMatch({ from: '/_authed/dashboard' }) → useRouterState() →
+// reads router.state.matches when router.isServer === true.
+const fakeRouter = {
+  isServer: true,
+  options: {},
+  state: {
+    matches: [
+      {
+        id: '/_authed/dashboard',
+        routeId: '/_authed/dashboard',
+        search: {},
+        context: { user: testUser },
+      },
+    ],
+  },
+} as unknown as Parameters<typeof RouterContextProvider>[0]['router'];
+
+describe('DashboardPage component', () => {
+  it('greets the user by email', () => {
+    const html = renderToString(
+      <RouterContextProvider router={fakeRouter}>
+        <Route.options.component />
+      </RouterContextProvider>
+    );
+    expect(html).toContain('dev@example.com');
+    expect(html).toContain('Welcome');
+  });
+
+  it('renders the OAuth Clients placeholder card', () => {
+    const html = renderToString(
+      <RouterContextProvider router={fakeRouter}>
+        <Route.options.component />
+      </RouterContextProvider>
+    );
+    expect(html).toContain('OAuth Clients');
+    expect(html).toContain('Coming soon');
+  });
+
+  it('renders the API Keys placeholder card', () => {
+    const html = renderToString(
+      <RouterContextProvider router={fakeRouter}>
+        <Route.options.component />
+      </RouterContextProvider>
+    );
+    expect(html).toContain('API Keys');
+    expect(html).toContain('Coming soon');
+  });
+});

--- a/apps/developer-portal/src/routes/_authed/dashboard.tsx
+++ b/apps/developer-portal/src/routes/_authed/dashboard.tsx
@@ -1,0 +1,44 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@qauth-labs/ui';
+import { createFileRoute } from '@tanstack/react-router';
+
+import type { UserInfoData } from '../../server/auth-server-client';
+
+export const Route = createFileRoute('/_authed/dashboard')({
+  component: DashboardPage,
+});
+
+function DashboardPage() {
+  const { user } = Route.useRouteContext() as { user: UserInfoData };
+
+  return (
+    <main className="mx-auto max-w-5xl px-6 py-10">
+      <h1 className="mb-8 text-2xl font-semibold text-gray-900">
+        Welcome, {user.email ?? user.sub}
+      </h1>
+
+      <div className="grid gap-6 sm:grid-cols-2">
+        <Card>
+          <CardHeader>
+            <CardTitle>OAuth Clients</CardTitle>
+            <CardDescription>
+              Manage applications that use QAuth for authentication.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <p className="text-sm text-gray-400">Coming soon in Phase 2.2.</p>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>API Keys</CardTitle>
+            <CardDescription>Generate and revoke keys for direct API access.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <p className="text-sm text-gray-400">Coming soon in Phase 2.3.</p>
+          </CardContent>
+        </Card>
+      </div>
+    </main>
+  );
+}

--- a/apps/developer-portal/src/routes/login.test.tsx
+++ b/apps/developer-portal/src/routes/login.test.tsx
@@ -1,0 +1,73 @@
+import { renderToString } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../server/actions/current-user', () => ({
+  currentUserFn: vi.fn(),
+}));
+
+vi.mock('../server/actions/login', () => ({
+  loginFn: vi.fn(),
+}));
+
+const { mockRedirect } = vi.hoisted(() => ({
+  mockRedirect: vi.fn((opts: { to: string }) => {
+    const err = new Error(`Redirect to ${opts.to}`) as Error & { to: string };
+    err.to = opts.to;
+    throw err;
+  }),
+}));
+
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tanstack/react-router')>();
+  return {
+    ...actual,
+    redirect: mockRedirect,
+    useRouter: vi.fn(() => ({ navigate: vi.fn() })),
+    Link: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+  };
+});
+
+import { currentUserFn } from '../server/actions/current-user';
+import { Route } from './login';
+
+describe('login beforeLoad guard', () => {
+  it('throws a redirect to /dashboard when user is already authenticated', async () => {
+    vi.mocked(currentUserFn).mockResolvedValue({
+      user: { sub: 'u1', email: 'dev@example.com', email_verified: true },
+    });
+
+    const beforeLoad = Route.options.beforeLoad as (ctx: unknown) => Promise<unknown>;
+    await expect(beforeLoad({})).rejects.toMatchObject({ to: '/dashboard' });
+    expect(mockRedirect).toHaveBeenCalledWith({ to: '/dashboard' });
+  });
+
+  it('does not redirect when user is not authenticated', async () => {
+    vi.mocked(currentUserFn).mockResolvedValue(null);
+
+    const beforeLoad = Route.options.beforeLoad as (ctx: unknown) => Promise<unknown>;
+    await expect(beforeLoad({})).resolves.toBeUndefined();
+  });
+});
+
+describe('LoginPage component', () => {
+  it('renders email and password fields', () => {
+    const html = renderToString(<Route.options.component />);
+    expect(html).toContain('type="email"');
+    expect(html).toContain('type="password"');
+  });
+
+  it('renders the submit button', () => {
+    const html = renderToString(<Route.options.component />);
+    expect(html).toContain('Log in');
+  });
+
+  it('renders a link to the register page', () => {
+    const html = renderToString(<Route.options.component />);
+    expect(html).toContain('Register');
+  });
+
+  it('renders the forgot password placeholder text', () => {
+    const html = renderToString(<Route.options.component />);
+    expect(html).toContain('Coming soon');
+  });
+});

--- a/apps/developer-portal/src/routes/login.tsx
+++ b/apps/developer-portal/src/routes/login.tsx
@@ -1,0 +1,93 @@
+import { FormField, Input } from '@qauth-labs/ui';
+import { createFileRoute, Link, redirect, useRouter } from '@tanstack/react-router';
+import { useState } from 'react';
+
+import { currentUserFn } from '../server/actions/current-user';
+import { loginFn } from '../server/actions/login';
+
+export const Route = createFileRoute('/login')({
+  beforeLoad: async () => {
+    const result = await currentUserFn();
+    if (result !== null) {
+      throw redirect({ to: '/dashboard' });
+    }
+  },
+  component: LoginPage,
+});
+
+type FormState = { stage: 'idle' } | { stage: 'submitting' } | { stage: 'error'; message: string };
+
+function LoginPage() {
+  const router = useRouter();
+  const [formState, setFormState] = useState<FormState>({ stage: 'idle' });
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const fd = new FormData(e.currentTarget);
+    const email = (fd.get('email') as string).trim();
+    const password = fd.get('password') as string;
+
+    setFormState({ stage: 'submitting' });
+
+    const result = await loginFn({ data: { email, password } });
+
+    if (result.ok) {
+      await router.navigate({ to: '/dashboard' });
+      return;
+    }
+
+    // Generic message regardless of error code — anti-enumeration.
+    setFormState({ stage: 'error', message: 'Invalid email or password.' });
+  }
+
+  const errorMessage = formState.stage === 'error' ? formState.message : undefined;
+  const isSubmitting = formState.stage === 'submitting';
+
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-gray-50 px-4">
+      <div className="w-full max-w-md space-y-6 rounded-lg border border-gray-200 bg-white p-8 shadow-sm">
+        <h1 className="text-xl font-semibold">Log in to your account</h1>
+
+        {errorMessage ? (
+          <p role="alert" className="text-sm text-red-600">
+            {errorMessage}
+          </p>
+        ) : null}
+
+        <form onSubmit={(e) => void handleSubmit(e)} noValidate className="space-y-4">
+          <FormField label="Email" htmlFor="email">
+            <Input id="email" name="email" type="email" autoComplete="email" required />
+          </FormField>
+
+          <FormField label="Password" htmlFor="password">
+            <Input
+              id="password"
+              name="password"
+              type="password"
+              autoComplete="current-password"
+              required
+            />
+          </FormField>
+
+          <p className="text-sm text-gray-400">Forgot password? Coming soon.</p>
+
+          {/* Button primitive drops type/disabled — use native button for form submission */}
+          <button
+            type="submit"
+            disabled={isSubmitting}
+            className="w-full rounded-md bg-blue-500 px-4 py-2 text-sm text-white hover:bg-blue-600 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {isSubmitting ? 'Logging in...' : 'Log in'}
+          </button>
+        </form>
+
+        <p className="text-center text-sm text-gray-500">
+          Don&apos;t have an account?{' '}
+          <Link to="/register" className="text-blue-600 hover:underline">
+            Register
+          </Link>
+        </p>
+      </div>
+    </main>
+  );
+}

--- a/apps/developer-portal/src/routes/login.tsx
+++ b/apps/developer-portal/src/routes/login.tsx
@@ -1,4 +1,4 @@
-import { FormField, Input } from '@qauth-labs/ui';
+import { Button, FormField, Input } from '@qauth-labs/ui';
 import { createFileRoute, Link, redirect, useRouter } from '@tanstack/react-router';
 import { useState } from 'react';
 
@@ -71,14 +71,9 @@ function LoginPage() {
 
           <p className="text-sm text-gray-400">Forgot password? Coming soon.</p>
 
-          {/* Button primitive drops type/disabled — use native button for form submission */}
-          <button
-            type="submit"
-            disabled={isSubmitting}
-            className="w-full rounded-md bg-blue-500 px-4 py-2 text-sm text-white hover:bg-blue-600 disabled:cursor-not-allowed disabled:opacity-50"
-          >
+          <Button type="submit" disabled={isSubmitting} className="w-full">
             {isSubmitting ? 'Logging in...' : 'Log in'}
-          </button>
+          </Button>
         </form>
 
         <p className="text-center text-sm text-gray-500">

--- a/apps/developer-portal/src/routes/register.test.tsx
+++ b/apps/developer-portal/src/routes/register.test.tsx
@@ -1,0 +1,77 @@
+import { renderToString } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../server/actions/current-user', () => ({
+  currentUserFn: vi.fn(),
+}));
+
+vi.mock('../server/actions/register', () => ({
+  registerFn: vi.fn(),
+}));
+
+vi.mock('../server/actions/resend-verification', () => ({
+  resendVerificationFn: vi.fn(),
+}));
+
+const { mockRedirect } = vi.hoisted(() => ({
+  mockRedirect: vi.fn((opts: { to: string }) => {
+    const err = new Error(`Redirect to ${opts.to}`) as Error & { to: string };
+    err.to = opts.to;
+    throw err;
+  }),
+}));
+
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tanstack/react-router')>();
+  return {
+    ...actual,
+    redirect: mockRedirect,
+    Link: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+  };
+});
+
+import { currentUserFn } from '../server/actions/current-user';
+import { Route } from './register';
+
+describe('register beforeLoad guard', () => {
+  it('throws a redirect to /dashboard when user is already authenticated', async () => {
+    vi.mocked(currentUserFn).mockResolvedValue({
+      user: { sub: 'u1', email: 'dev@example.com', email_verified: true },
+    });
+
+    const beforeLoad = Route.options.beforeLoad as (ctx: unknown) => Promise<unknown>;
+    await expect(beforeLoad({})).rejects.toMatchObject({ to: '/dashboard' });
+    expect(mockRedirect).toHaveBeenCalledWith({ to: '/dashboard' });
+  });
+
+  it('does not redirect when user is not authenticated', async () => {
+    vi.mocked(currentUserFn).mockResolvedValue(null);
+
+    const beforeLoad = Route.options.beforeLoad as (ctx: unknown) => Promise<unknown>;
+    await expect(beforeLoad({})).resolves.toBeUndefined();
+  });
+});
+
+describe('RegisterPage component', () => {
+  it('renders email and password fields in idle state', () => {
+    const html = renderToString(<Route.options.component />);
+    expect(html).toContain('type="email"');
+    expect(html).toContain('type="password"');
+  });
+
+  it('renders the submit button', () => {
+    const html = renderToString(<Route.options.component />);
+    expect(html).toContain('Create account');
+  });
+
+  it('renders a link to the login page', () => {
+    const html = renderToString(<Route.options.component />);
+    expect(html).toContain('Log in');
+  });
+
+  it('renders the email field with autocomplete attribute', () => {
+    // React 19 preserves camelCase attribute names in renderToString output.
+    const html = renderToString(<Route.options.component />);
+    expect(html).toContain('autoComplete="email"');
+  });
+});

--- a/apps/developer-portal/src/routes/register.tsx
+++ b/apps/developer-portal/src/routes/register.tsx
@@ -1,0 +1,165 @@
+import { FormField, Input } from '@qauth-labs/ui';
+import { createFileRoute, Link, redirect } from '@tanstack/react-router';
+import { useState } from 'react';
+
+import { currentUserFn } from '../server/actions/current-user';
+import { registerFn } from '../server/actions/register';
+import { resendVerificationFn } from '../server/actions/resend-verification';
+
+export const Route = createFileRoute('/register')({
+  beforeLoad: async () => {
+    const result = await currentUserFn();
+    if (result !== null) {
+      throw redirect({ to: '/dashboard' });
+    }
+  },
+  component: RegisterPage,
+});
+
+type FormState =
+  | { stage: 'idle' }
+  | { stage: 'submitting' }
+  | { stage: 'success'; email: string }
+  | { stage: 'error'; fieldErrors: { email?: string; password?: string }; formError?: string };
+
+type ResendState = 'idle' | 'sending' | 'sent' | { error: string };
+
+function RegisterPage() {
+  const [formState, setFormState] = useState<FormState>({ stage: 'idle' });
+  const [resendState, setResendState] = useState<ResendState>('idle');
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const fd = new FormData(e.currentTarget);
+    const email = (fd.get('email') as string).trim();
+    const password = fd.get('password') as string;
+
+    setFormState({ stage: 'submitting' });
+
+    const result = await registerFn({ data: { email, password } });
+
+    if (result.ok) {
+      setFormState({ stage: 'success', email: result.data.email });
+      return;
+    }
+
+    const { code, message, details } = result.error;
+
+    if (code === 'EMAIL_TAKEN') {
+      setFormState({
+        stage: 'error',
+        fieldErrors: { email: 'Email already registered.' },
+      });
+      return;
+    }
+
+    if (code === 'WEAK_PASSWORD') {
+      const feedback = Array.isArray(details) ? (details as string[]).join(' ') : message;
+      setFormState({
+        stage: 'error',
+        fieldErrors: { password: feedback },
+      });
+      return;
+    }
+
+    setFormState({ stage: 'error', fieldErrors: {}, formError: message });
+  }
+
+  async function handleResend(email: string) {
+    setResendState('sending');
+    const result = await resendVerificationFn({ data: { email } });
+    if (result.ok) {
+      setResendState('sent');
+    } else {
+      setResendState({ error: result.error.message });
+    }
+  }
+
+  if (formState.stage === 'success') {
+    return (
+      <main className="flex min-h-screen items-center justify-center bg-gray-50 px-4">
+        <div className="w-full max-w-md space-y-4 rounded-lg border border-gray-200 bg-white p-8 shadow-sm">
+          <h1 className="text-xl font-semibold">Check your inbox</h1>
+          <p className="text-sm text-gray-600">
+            We sent a verification link to <span className="font-medium">{formState.email}</span>.
+            Open it to activate your account.
+          </p>
+
+          {resendState === 'sent' ? (
+            <p className="text-sm text-green-700">Verification email resent.</p>
+          ) : typeof resendState === 'object' ? (
+            <p className="text-sm text-red-600">{resendState.error}</p>
+          ) : (
+            /* Button primitive drops onClick/disabled — use native button here */
+            <button
+              type="button"
+              disabled={resendState === 'sending'}
+              onClick={() => void handleResend(formState.email)}
+              className="rounded-md border border-gray-300 bg-white px-4 py-2 text-sm text-gray-800 hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {resendState === 'sending' ? 'Sending...' : 'Resend verification email'}
+            </button>
+          )}
+        </div>
+      </main>
+    );
+  }
+
+  const fieldErrors = formState.stage === 'error' ? formState.fieldErrors : {};
+  const formError = formState.stage === 'error' ? formState.formError : undefined;
+  const isSubmitting = formState.stage === 'submitting';
+
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-gray-50 px-4">
+      <div className="w-full max-w-md space-y-6 rounded-lg border border-gray-200 bg-white p-8 shadow-sm">
+        <h1 className="text-xl font-semibold">Create your account</h1>
+
+        {formError ? (
+          <p role="alert" className="text-sm text-red-600">
+            {formError}
+          </p>
+        ) : null}
+
+        <form onSubmit={(e) => void handleSubmit(e)} noValidate className="space-y-4">
+          <FormField label="Email" htmlFor="email" error={fieldErrors.email}>
+            <Input
+              id="email"
+              name="email"
+              type="email"
+              autoComplete="email"
+              required
+              aria-invalid={fieldErrors.email ? 'true' : undefined}
+            />
+          </FormField>
+
+          <FormField label="Password" htmlFor="password" error={fieldErrors.password}>
+            <Input
+              id="password"
+              name="password"
+              type="password"
+              autoComplete="new-password"
+              required
+              aria-invalid={fieldErrors.password ? 'true' : undefined}
+            />
+          </FormField>
+
+          {/* Button primitive drops type/disabled — use native button for form submission */}
+          <button
+            type="submit"
+            disabled={isSubmitting}
+            className="w-full rounded-md bg-blue-500 px-4 py-2 text-sm text-white hover:bg-blue-600 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {isSubmitting ? 'Creating account...' : 'Create account'}
+          </button>
+        </form>
+
+        <p className="text-center text-sm text-gray-500">
+          Already have an account?{' '}
+          <Link to="/login" className="text-blue-600 hover:underline">
+            Log in
+          </Link>
+        </p>
+      </div>
+    </main>
+  );
+}

--- a/apps/developer-portal/src/routes/register.tsx
+++ b/apps/developer-portal/src/routes/register.tsx
@@ -1,4 +1,4 @@
-import { FormField, Input } from '@qauth-labs/ui';
+import { Button, FormField, Input } from '@qauth-labs/ui';
 import { createFileRoute, Link, redirect } from '@tanstack/react-router';
 import { useState } from 'react';
 
@@ -90,15 +90,14 @@ function RegisterPage() {
           ) : typeof resendState === 'object' ? (
             <p className="text-sm text-red-600">{resendState.error}</p>
           ) : (
-            /* Button primitive drops onClick/disabled — use native button here */
-            <button
+            <Button
+              variant="outline"
               type="button"
               disabled={resendState === 'sending'}
               onClick={() => void handleResend(formState.email)}
-              className="rounded-md border border-gray-300 bg-white px-4 py-2 text-sm text-gray-800 hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-50"
             >
               {resendState === 'sending' ? 'Sending...' : 'Resend verification email'}
-            </button>
+            </Button>
           )}
         </div>
       </main>
@@ -143,14 +142,9 @@ function RegisterPage() {
             />
           </FormField>
 
-          {/* Button primitive drops type/disabled — use native button for form submission */}
-          <button
-            type="submit"
-            disabled={isSubmitting}
-            className="w-full rounded-md bg-blue-500 px-4 py-2 text-sm text-white hover:bg-blue-600 disabled:cursor-not-allowed disabled:opacity-50"
-          >
+          <Button type="submit" disabled={isSubmitting} className="w-full">
             {isSubmitting ? 'Creating account...' : 'Create account'}
-          </button>
+          </Button>
         </form>
 
         <p className="text-center text-sm text-gray-500">

--- a/apps/developer-portal/src/routes/verify.test.tsx
+++ b/apps/developer-portal/src/routes/verify.test.tsx
@@ -1,0 +1,78 @@
+import { RouterContextProvider } from '@tanstack/react-router';
+import { renderToString } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../server/actions/verify', () => ({
+  verifyFn: vi.fn(),
+}));
+
+vi.mock('../server/actions/resend-verification', () => ({
+  resendVerificationFn: vi.fn(),
+}));
+
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tanstack/react-router')>();
+  return {
+    ...actual,
+    Link: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+  };
+});
+
+import { Route } from './verify';
+
+const VALID_TOKEN = 'a'.repeat(64);
+
+// Route.id is a getter backed by Route._id, which is normally populated by the
+// route tree generator via Route.init(). Set _id directly so that
+// Route.useSearch() passes from: '/verify' to useMatch in tests.
+(Route as unknown as { _id: string })._id = '/verify';
+
+// Minimal fake router for SSR-mode rendering.
+// useRouterState reads router.state.matches when router.isServer === true.
+const fakeRouter = {
+  isServer: true,
+  options: {},
+  state: {
+    matches: [{ id: '/verify', routeId: '/verify', search: { token: VALID_TOKEN }, context: {} }],
+  },
+} as unknown as Parameters<typeof RouterContextProvider>[0]['router'];
+
+describe('verify validateSearch', () => {
+  const validateSearch = Route.options.validateSearch as (raw: Record<string, unknown>) => {
+    token: string;
+  };
+
+  it('accepts a valid 64-char lowercase hex token', () => {
+    expect(validateSearch({ token: VALID_TOKEN })).toEqual({ token: VALID_TOKEN });
+  });
+
+  it('throws when token is missing', () => {
+    expect(() => validateSearch({})).toThrow();
+  });
+
+  it('throws when token is too short', () => {
+    expect(() => validateSearch({ token: 'abc123' })).toThrow();
+  });
+
+  it('throws when token contains non-hex characters (uppercase)', () => {
+    // Auth-server issues lowercase hex only — uppercase is invalid.
+    expect(() => validateSearch({ token: 'A'.repeat(64) })).toThrow();
+  });
+
+  it('throws when token is not a string', () => {
+    expect(() => validateSearch({ token: 12345 })).toThrow();
+  });
+});
+
+describe('VerifyPage component', () => {
+  it('renders the pending state on initial render (useEffect not called in SSR)', () => {
+    // useEffect is not invoked by renderToString, so the component always
+    // starts in the "pending" stage.
+    const html = renderToString(
+      <RouterContextProvider router={fakeRouter}>
+        <Route.options.component />
+      </RouterContextProvider>
+    );
+    expect(html).toContain('Verifying your email');
+  });
+});

--- a/apps/developer-portal/src/routes/verify.tsx
+++ b/apps/developer-portal/src/routes/verify.tsx
@@ -57,8 +57,7 @@ function VerifyPage() {
     return () => {
       cancelled = true;
     };
-    // token is stable for the lifetime of this page load — empty deps is intentional
-  }, []);
+  }, [token]);
 
   async function handleResend(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();

--- a/apps/developer-portal/src/routes/verify.tsx
+++ b/apps/developer-portal/src/routes/verify.tsx
@@ -1,0 +1,152 @@
+import { FormField, Input } from '@qauth-labs/ui';
+import { createFileRoute, Link } from '@tanstack/react-router';
+import { useEffect, useState } from 'react';
+
+import { resendVerificationFn } from '../server/actions/resend-verification';
+import { verifyFn } from '../server/actions/verify';
+
+// Auth-server enforces 64-char hex tokens — reject early to skip the round-trip.
+const TOKEN_RE = /^[0-9a-f]{64}$/;
+
+export const Route = createFileRoute('/verify')({
+  validateSearch: (raw: Record<string, unknown>): { token: string } => {
+    const token = raw['token'];
+    if (typeof token !== 'string' || !TOKEN_RE.test(token)) {
+      throw new Error('Invalid or missing verification token');
+    }
+    return { token };
+  },
+  component: VerifyPage,
+});
+
+type VerifyState =
+  | { stage: 'pending' }
+  | { stage: 'success'; email: string }
+  | { stage: 'already-verified' }
+  | { stage: 'error'; message: string };
+
+type ResendState = 'idle' | 'sending' | 'sent' | { error: string };
+
+function VerifyPage() {
+  const { token } = Route.useSearch();
+  const [state, setState] = useState<VerifyState>({ stage: 'pending' });
+  const [resendEmail, setResendEmail] = useState('');
+  const [resendState, setResendState] = useState<ResendState>('idle');
+
+  useEffect(() => {
+    let cancelled = false;
+
+    verifyFn({ data: { token } }).then((result) => {
+      if (cancelled) return;
+
+      if (result.ok) {
+        setState({ stage: 'success', email: result.data.email });
+        return;
+      }
+
+      const { code, message } = result.error;
+
+      if (code === 'EMAIL_ALREADY_VERIFIED') {
+        setState({ stage: 'already-verified' });
+        return;
+      }
+
+      setState({ stage: 'error', message });
+    });
+
+    return () => {
+      cancelled = true;
+    };
+    // token is stable for the lifetime of this page load — empty deps is intentional
+  }, []);
+
+  async function handleResend(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setResendState('sending');
+    const result = await resendVerificationFn({ data: { email: resendEmail } });
+    if (result.ok) {
+      setResendState('sent');
+    } else {
+      setResendState({ error: result.error.message });
+    }
+  }
+
+  if (state.stage === 'pending') {
+    return (
+      <main className="flex min-h-screen items-center justify-center bg-gray-50 px-4">
+        <p className="text-sm text-gray-500">Verifying your email...</p>
+      </main>
+    );
+  }
+
+  if (state.stage === 'success' || state.stage === 'already-verified') {
+    return (
+      <main className="flex min-h-screen items-center justify-center bg-gray-50 px-4">
+        <div className="w-full max-w-md space-y-4 rounded-lg border border-gray-200 bg-white p-8 shadow-sm">
+          <h1 className="text-xl font-semibold">Email verified</h1>
+          {state.stage === 'success' ? (
+            <p className="text-sm text-gray-600">
+              <span className="font-medium">{state.email}</span> has been verified. You can now log
+              in.
+            </p>
+          ) : (
+            <p className="text-sm text-gray-600">This email is already verified.</p>
+          )}
+          <Link
+            to="/login"
+            className="inline-block rounded-md bg-blue-500 px-4 py-2 text-sm text-white hover:bg-blue-600"
+          >
+            Continue to login
+          </Link>
+        </div>
+      </main>
+    );
+  }
+
+  // Error state.
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-gray-50 px-4">
+      <div className="w-full max-w-md space-y-4 rounded-lg border border-gray-200 bg-white p-8 shadow-sm">
+        <h1 className="text-xl font-semibold">Verification failed</h1>
+        <p role="alert" className="text-sm text-red-600">
+          {state.message}
+        </p>
+
+        <p className="text-sm text-gray-600">
+          Enter your email below to request a new verification link.
+        </p>
+
+        {resendState === 'sent' ? (
+          <p className="text-sm text-green-700">Verification email sent. Check your inbox.</p>
+        ) : (
+          <form onSubmit={(e) => void handleResend(e)} className="space-y-3">
+            <FormField label="Email" htmlFor="resend-email">
+              <Input
+                id="resend-email"
+                name="email"
+                type="email"
+                autoComplete="email"
+                required
+                value={resendEmail}
+                onChange={(e) => setResendEmail(e.target.value)}
+              />
+            </FormField>
+
+            {typeof resendState === 'object' ? (
+              <p className="text-sm text-red-600">{resendState.error}</p>
+            ) : null}
+
+            {/* Button primitive drops type/disabled — use native button for form submission */}
+            <button
+              type="submit"
+              disabled={resendState === 'sending'}
+              className="rounded-md bg-blue-500 px-4 py-2 text-sm text-white hover:bg-blue-600 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {resendState === 'sending' ? 'Sending...' : 'Resend verification email'}
+            </button>
+          </form>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/apps/developer-portal/src/routes/verify.tsx
+++ b/apps/developer-portal/src/routes/verify.tsx
@@ -1,4 +1,4 @@
-import { FormField, Input } from '@qauth-labs/ui';
+import { Button, FormField, Input } from '@qauth-labs/ui';
 import { createFileRoute, Link } from '@tanstack/react-router';
 import { useEffect, useState } from 'react';
 
@@ -92,11 +92,8 @@ function VerifyPage() {
           ) : (
             <p className="text-sm text-gray-600">This email is already verified.</p>
           )}
-          <Link
-            to="/login"
-            className="inline-block rounded-md bg-blue-500 px-4 py-2 text-sm text-white hover:bg-blue-600"
-          >
-            Continue to login
+          <Link to="/login">
+            <Button type="button">Continue to login</Button>
           </Link>
         </div>
       </main>
@@ -136,14 +133,9 @@ function VerifyPage() {
               <p className="text-sm text-red-600">{resendState.error}</p>
             ) : null}
 
-            {/* Button primitive drops type/disabled — use native button for form submission */}
-            <button
-              type="submit"
-              disabled={resendState === 'sending'}
-              className="rounded-md bg-blue-500 px-4 py-2 text-sm text-white hover:bg-blue-600 disabled:cursor-not-allowed disabled:opacity-50"
-            >
+            <Button type="submit" disabled={resendState === 'sending'}>
               {resendState === 'sending' ? 'Sending...' : 'Resend verification email'}
-            </button>
+            </Button>
           </form>
         )}
       </div>

--- a/apps/developer-portal/src/server/actions/current-user.test.ts
+++ b/apps/developer-portal/src/server/actions/current-user.test.ts
@@ -64,8 +64,18 @@ describe('currentUserHandler', () => {
     expect(authServerClient.userinfo).not.toHaveBeenCalled();
   });
 
-  it('returns null when userinfo call fails', async () => {
+  it('returns null without hitting userinfo when expiresAt is in the past', async () => {
     const session = { accessToken: 'expired-at', refreshToken: 'rt', expiresAt: Date.now() - 1000 };
+    vi.mocked(readSessionCookie).mockReturnValue(session);
+    mockGetRequestHeader.mockReturnValue('some-cookie-header');
+
+    const result = await currentUserHandler();
+    expect(result).toBeNull();
+    expect(authServerClient.userinfo).not.toHaveBeenCalled();
+  });
+
+  it('returns null when userinfo call fails for a non-expired session', async () => {
+    const session = { accessToken: 'at', refreshToken: 'rt', expiresAt: Date.now() + 60_000 };
     vi.mocked(readSessionCookie).mockReturnValue(session);
     vi.mocked(authServerClient.userinfo).mockResolvedValue({
       ok: false,
@@ -75,5 +85,6 @@ describe('currentUserHandler', () => {
 
     const result = await currentUserHandler();
     expect(result).toBeNull();
+    expect(authServerClient.userinfo).toHaveBeenCalledOnce();
   });
 });

--- a/apps/developer-portal/src/server/actions/current-user.test.ts
+++ b/apps/developer-portal/src/server/actions/current-user.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../config', () => ({
+  env: {
+    AUTH_SERVER_URL: 'http://localhost:3001',
+    PORTAL_SESSION_SECRET: 'test-secret-minimum-32-chars-long!!',
+    PORTAL_SESSION_TTL: 900,
+  },
+}));
+
+vi.mock('../auth-server-client', () => ({
+  authServerClient: {
+    userinfo: vi.fn(),
+  },
+}));
+
+vi.mock('../session-cookie', () => ({
+  SESSION_COOKIE_NAME: '__Host-qauth_portal_session',
+  readSessionCookie: vi.fn(),
+  signSession: vi.fn(),
+  verifySession: vi.fn(),
+  setSessionCookieHeader: vi.fn(),
+  clearSessionCookieHeader: vi.fn(),
+}));
+
+const { mockGetRequestHeader } = vi.hoisted(() => ({
+  mockGetRequestHeader: vi.fn(),
+}));
+
+vi.mock('@tanstack/react-start/server', () => ({
+  getRequestHeader: mockGetRequestHeader,
+  setResponseHeader: vi.fn(),
+}));
+
+import { authServerClient } from '../auth-server-client';
+import { readSessionCookie } from '../session-cookie';
+import { currentUserHandler } from './current-user';
+
+describe('currentUserHandler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+  it('returns user data when session is valid and userinfo succeeds', async () => {
+    const session = { accessToken: 'at', refreshToken: 'rt', expiresAt: Date.now() + 1000 };
+    vi.mocked(readSessionCookie).mockReturnValue(session);
+    vi.mocked(authServerClient.userinfo).mockResolvedValue({
+      ok: true,
+      data: { sub: 'user-id', email: 'test@example.com', email_verified: true },
+    });
+    mockGetRequestHeader.mockReturnValue('cookie-header-value');
+
+    const result = await currentUserHandler();
+    expect(result).not.toBeNull();
+    expect(result?.user.sub).toBe('user-id');
+    expect(result?.user.email).toBe('test@example.com');
+  });
+
+  it('returns null when no session cookie is present', async () => {
+    vi.mocked(readSessionCookie).mockReturnValue(null);
+    mockGetRequestHeader.mockReturnValue(undefined);
+
+    const result = await currentUserHandler();
+    expect(result).toBeNull();
+    expect(authServerClient.userinfo).not.toHaveBeenCalled();
+  });
+
+  it('returns null when userinfo call fails', async () => {
+    const session = { accessToken: 'expired-at', refreshToken: 'rt', expiresAt: Date.now() - 1000 };
+    vi.mocked(readSessionCookie).mockReturnValue(session);
+    vi.mocked(authServerClient.userinfo).mockResolvedValue({
+      ok: false,
+      error: { code: 'UNKNOWN', message: 'Unauthorized', status: 401 },
+    });
+    mockGetRequestHeader.mockReturnValue('some-cookie-header');
+
+    const result = await currentUserHandler();
+    expect(result).toBeNull();
+  });
+});

--- a/apps/developer-portal/src/server/actions/current-user.ts
+++ b/apps/developer-portal/src/server/actions/current-user.ts
@@ -1,0 +1,20 @@
+import { createServerFn } from '@tanstack/react-start';
+import { getRequestHeader } from '@tanstack/react-start/server';
+
+import { authServerClient, type UserInfoData } from '../auth-server-client';
+import { readSessionCookie } from '../session-cookie';
+
+export type CurrentUserResult = { user: UserInfoData } | null;
+
+export async function currentUserHandler(): Promise<CurrentUserResult> {
+  const cookieHeader = getRequestHeader('cookie');
+  const session = readSessionCookie(cookieHeader);
+  if (!session) return null;
+
+  const result = await authServerClient.userinfo(session.accessToken);
+  if (!result.ok) return null;
+
+  return { user: result.data };
+}
+
+export const currentUserFn = createServerFn({ method: 'GET' }).handler(currentUserHandler);

--- a/apps/developer-portal/src/server/actions/current-user.ts
+++ b/apps/developer-portal/src/server/actions/current-user.ts
@@ -9,7 +9,10 @@ export type CurrentUserResult = { user: UserInfoData } | null;
 export async function currentUserHandler(): Promise<CurrentUserResult> {
   const cookieHeader = getRequestHeader('cookie');
   const session = readSessionCookie(cookieHeader);
-  if (!session) return null;
+  // Skip the network round-trip when we already know the access token is past
+  // its issued lifetime. (Refresh-token rotation lives in Phase 2.x; for now
+  // an expired session bounces the user to /login.)
+  if (!session || Date.now() >= session.expiresAt) return null;
 
   const result = await authServerClient.userinfo(session.accessToken);
   if (!result.ok) return null;

--- a/apps/developer-portal/src/server/actions/login.test.ts
+++ b/apps/developer-portal/src/server/actions/login.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../config', () => ({
+  env: {
+    AUTH_SERVER_URL: 'http://localhost:3001',
+    PORTAL_SESSION_SECRET: 'test-secret-minimum-32-chars-long!!',
+    PORTAL_SESSION_TTL: 900,
+  },
+}));
+
+vi.mock('../auth-server-client', () => ({
+  authServerClient: {
+    login: vi.fn(),
+  },
+}));
+
+vi.mock('../session-cookie', () => ({
+  SESSION_COOKIE_NAME: '__Host-qauth_portal_session',
+  signSession: vi.fn((payload: unknown) => `signed:${JSON.stringify(payload)}`),
+  setSessionCookieHeader: vi.fn(() => '__Host-qauth_portal_session=signed-value; Path=/; HttpOnly'),
+  readSessionCookie: vi.fn(),
+  clearSessionCookieHeader: vi.fn(),
+  verifySession: vi.fn(),
+}));
+
+const { mockSetResponseHeader } = vi.hoisted(() => ({
+  mockSetResponseHeader: vi.fn(),
+}));
+
+vi.mock('@tanstack/react-start/server', () => ({
+  setResponseHeader: mockSetResponseHeader,
+  getRequestHeader: vi.fn(),
+}));
+
+import { authServerClient } from '../auth-server-client';
+import { setSessionCookieHeader } from '../session-cookie';
+import { loginHandler } from './login';
+
+describe('loginHandler', () => {
+  it('sets session cookie and returns expiresAt on success', async () => {
+    vi.mocked(authServerClient.login).mockResolvedValue({
+      ok: true,
+      data: {
+        access_token: 'at-value',
+        refresh_token: 'rt-value',
+        expires_in: 900,
+        token_type: 'Bearer',
+      },
+    });
+
+    const before = Date.now();
+    const result = await loginHandler({
+      data: { email: 'test@example.com', password: 'Password1!' },
+    });
+    const after = Date.now();
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.expiresAt).toBeGreaterThanOrEqual(before + 900_000);
+      expect(result.data.expiresAt).toBeLessThanOrEqual(after + 900_000);
+    }
+
+    expect(setSessionCookieHeader).toHaveBeenCalledWith(
+      expect.objectContaining({ accessToken: 'at-value', refreshToken: 'rt-value' })
+    );
+    expect(mockSetResponseHeader).toHaveBeenCalledWith('set-cookie', expect.any(String));
+  });
+
+  it('does not set cookie and returns error on login failure', async () => {
+    vi.mocked(authServerClient.login).mockResolvedValue({
+      ok: false,
+      error: { code: 'INVALID_CREDENTIALS', message: 'Invalid email or password', status: 401 },
+    });
+    mockSetResponseHeader.mockClear();
+
+    const result = await loginHandler({ data: { email: 'bad@example.com', password: 'wrong' } });
+
+    expect(result.ok).toBe(false);
+    expect(mockSetResponseHeader).not.toHaveBeenCalled();
+  });
+
+  it('preserves the error code from the client', async () => {
+    vi.mocked(authServerClient.login).mockResolvedValue({
+      ok: false,
+      error: { code: 'RATE_LIMITED', message: 'Too many requests', status: 429 },
+    });
+
+    const result = await loginHandler({
+      data: { email: 'test@example.com', password: 'Password1!' },
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe('RATE_LIMITED');
+  });
+});

--- a/apps/developer-portal/src/server/actions/login.ts
+++ b/apps/developer-portal/src/server/actions/login.ts
@@ -1,0 +1,31 @@
+import { createServerFn } from '@tanstack/react-start';
+import { setResponseHeader } from '@tanstack/react-start/server';
+
+import { authServerClient, type Result } from '../auth-server-client';
+import { setSessionCookieHeader } from '../session-cookie';
+
+export type LoginResult = Result<{ expiresAt: number }>;
+
+export async function loginHandler({
+  data,
+}: {
+  data: { email: string; password: string };
+}): Promise<LoginResult> {
+  const result = await authServerClient.login(data.email, data.password);
+  if (!result.ok) return result;
+
+  const expiresAt = Date.now() + result.data.expires_in * 1000;
+
+  setResponseHeader(
+    'set-cookie',
+    setSessionCookieHeader({
+      accessToken: result.data.access_token,
+      refreshToken: result.data.refresh_token,
+      expiresAt,
+    })
+  );
+
+  return { ok: true, data: { expiresAt } };
+}
+
+export const loginFn = createServerFn({ method: 'POST' }).handler(loginHandler);

--- a/apps/developer-portal/src/server/actions/logout.test.ts
+++ b/apps/developer-portal/src/server/actions/logout.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../config', () => ({
+  env: {
+    AUTH_SERVER_URL: 'http://localhost:3001',
+    PORTAL_SESSION_SECRET: 'test-secret-minimum-32-chars-long!!',
+    PORTAL_SESSION_TTL: 900,
+  },
+}));
+
+vi.mock('../auth-server-client', () => ({
+  authServerClient: {
+    logout: vi.fn(),
+  },
+}));
+
+vi.mock('../session-cookie', () => ({
+  SESSION_COOKIE_NAME: '__Host-qauth_portal_session',
+  readSessionCookie: vi.fn(),
+  clearSessionCookieHeader: vi.fn(
+    () => '__Host-qauth_portal_session=; Path=/; HttpOnly; Max-Age=0'
+  ),
+  signSession: vi.fn(),
+  setSessionCookieHeader: vi.fn(),
+  verifySession: vi.fn(),
+}));
+
+const { mockSetResponseHeader, mockGetRequestHeader } = vi.hoisted(() => ({
+  mockSetResponseHeader: vi.fn(),
+  mockGetRequestHeader: vi.fn(),
+}));
+
+vi.mock('@tanstack/react-start/server', () => ({
+  setResponseHeader: mockSetResponseHeader,
+  getRequestHeader: mockGetRequestHeader,
+}));
+
+import { authServerClient } from '../auth-server-client';
+import { clearSessionCookieHeader, readSessionCookie } from '../session-cookie';
+import { logoutHandler } from './logout';
+
+describe('logoutHandler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+  it('calls auth-server logout and clears the cookie when session exists', async () => {
+    const session = { accessToken: 'at', refreshToken: 'rt', expiresAt: Date.now() + 1000 };
+    vi.mocked(readSessionCookie).mockReturnValue(session);
+    vi.mocked(authServerClient.logout).mockResolvedValue({
+      ok: true,
+      data: { success: true, message: 'Successfully logged out' },
+    });
+    mockGetRequestHeader.mockReturnValue('__Host-qauth_portal_session=signed-value');
+
+    const result = await logoutHandler();
+
+    expect(authServerClient.logout).toHaveBeenCalledWith('at');
+    expect(clearSessionCookieHeader).toHaveBeenCalled();
+    expect(mockSetResponseHeader).toHaveBeenCalledWith('set-cookie', expect.any(String));
+    expect(result.ok).toBe(true);
+  });
+
+  it('still clears the cookie when no session cookie is present', async () => {
+    vi.mocked(readSessionCookie).mockReturnValue(null);
+    mockGetRequestHeader.mockReturnValue(undefined);
+    mockSetResponseHeader.mockClear();
+
+    const result = await logoutHandler();
+
+    expect(authServerClient.logout).not.toHaveBeenCalled();
+    expect(mockSetResponseHeader).toHaveBeenCalledWith('set-cookie', expect.any(String));
+    expect(result.ok).toBe(true);
+  });
+});

--- a/apps/developer-portal/src/server/actions/logout.ts
+++ b/apps/developer-portal/src/server/actions/logout.ts
@@ -1,0 +1,20 @@
+import { createServerFn } from '@tanstack/react-start';
+import { getRequestHeader, setResponseHeader } from '@tanstack/react-start/server';
+
+import { authServerClient } from '../auth-server-client';
+import { clearSessionCookieHeader, readSessionCookie } from '../session-cookie';
+
+export async function logoutHandler(): Promise<{ ok: true }> {
+  const cookieHeader = getRequestHeader('cookie');
+  const session = readSessionCookie(cookieHeader);
+
+  if (session) {
+    await authServerClient.logout(session.accessToken);
+  }
+
+  setResponseHeader('set-cookie', clearSessionCookieHeader());
+
+  return { ok: true };
+}
+
+export const logoutFn = createServerFn({ method: 'POST' }).handler(logoutHandler);

--- a/apps/developer-portal/src/server/actions/register.test.ts
+++ b/apps/developer-portal/src/server/actions/register.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../config', () => ({
+  env: {
+    AUTH_SERVER_URL: 'http://localhost:3001',
+    PORTAL_SESSION_SECRET: 'test-secret-minimum-32-chars-long!!',
+    PORTAL_SESSION_TTL: 900,
+  },
+}));
+
+vi.mock('../auth-server-client', () => ({
+  authServerClient: {
+    register: vi.fn(),
+  },
+}));
+
+import { authServerClient } from '../auth-server-client';
+import { registerHandler } from './register';
+
+describe('registerHandler', () => {
+  it('returns the result from authServerClient.register on success', async () => {
+    const data = {
+      id: 'user-id',
+      email: 'test@example.com',
+      emailVerified: false,
+      realmId: 'realm-id',
+      createdAt: Date.now(),
+      updatedAt: null,
+    };
+    vi.mocked(authServerClient.register).mockResolvedValue({ ok: true, data });
+
+    const result = await registerHandler({
+      data: { email: 'test@example.com', password: 'Password1!' },
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.data.email).toBe('test@example.com');
+    expect(authServerClient.register).toHaveBeenCalledWith('test@example.com', 'Password1!');
+  });
+
+  it('propagates error result from authServerClient.register', async () => {
+    vi.mocked(authServerClient.register).mockResolvedValue({
+      ok: false,
+      error: { code: 'WEAK_PASSWORD', message: 'Password too weak', status: 422 },
+    });
+
+    const result = await registerHandler({ data: { email: 'test@example.com', password: 'pw' } });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe('WEAK_PASSWORD');
+  });
+
+  it('propagates EMAIL_TAKEN error', async () => {
+    vi.mocked(authServerClient.register).mockResolvedValue({
+      ok: false,
+      error: { code: 'EMAIL_TAKEN', message: 'Email already in use', status: 409 },
+    });
+
+    const result = await registerHandler({
+      data: { email: 'existing@example.com', password: 'Password1!' },
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe('EMAIL_TAKEN');
+  });
+});

--- a/apps/developer-portal/src/server/actions/register.ts
+++ b/apps/developer-portal/src/server/actions/register.ts
@@ -1,0 +1,13 @@
+import { createServerFn } from '@tanstack/react-start';
+
+import { authServerClient, type RegisterData, type Result } from '../auth-server-client';
+
+export async function registerHandler({
+  data,
+}: {
+  data: { email: string; password: string };
+}): Promise<Result<RegisterData>> {
+  return authServerClient.register(data.email, data.password);
+}
+
+export const registerFn = createServerFn({ method: 'POST' }).handler(registerHandler);

--- a/apps/developer-portal/src/server/actions/resend-verification.test.ts
+++ b/apps/developer-portal/src/server/actions/resend-verification.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../config', () => ({
+  env: {
+    AUTH_SERVER_URL: 'http://localhost:3001',
+    PORTAL_SESSION_SECRET: 'test-secret-minimum-32-chars-long!!',
+    PORTAL_SESSION_TTL: 900,
+  },
+}));
+
+vi.mock('../auth-server-client', () => ({
+  authServerClient: {
+    resendVerification: vi.fn(),
+  },
+}));
+
+import { authServerClient } from '../auth-server-client';
+import { resendVerificationHandler } from './resend-verification';
+
+describe('resendVerificationHandler', () => {
+  it('returns ok result on success', async () => {
+    vi.mocked(authServerClient.resendVerification).mockResolvedValue({
+      ok: true,
+      data: { message: 'If the email exists, a verification link has been sent.' },
+    });
+
+    const result = await resendVerificationHandler({ data: { email: 'test@example.com' } });
+    expect(result.ok).toBe(true);
+    expect(authServerClient.resendVerification).toHaveBeenCalledWith('test@example.com');
+  });
+
+  it('propagates RATE_LIMITED error', async () => {
+    vi.mocked(authServerClient.resendVerification).mockResolvedValue({
+      ok: false,
+      error: { code: 'RATE_LIMITED', message: 'Too many requests', status: 429 },
+    });
+
+    const result = await resendVerificationHandler({ data: { email: 'test@example.com' } });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe('RATE_LIMITED');
+  });
+});

--- a/apps/developer-portal/src/server/actions/resend-verification.ts
+++ b/apps/developer-portal/src/server/actions/resend-verification.ts
@@ -1,0 +1,15 @@
+import { createServerFn } from '@tanstack/react-start';
+
+import { authServerClient, type ResendVerificationData, type Result } from '../auth-server-client';
+
+export async function resendVerificationHandler({
+  data,
+}: {
+  data: { email: string };
+}): Promise<Result<ResendVerificationData>> {
+  return authServerClient.resendVerification(data.email);
+}
+
+export const resendVerificationFn = createServerFn({ method: 'POST' }).handler(
+  resendVerificationHandler
+);

--- a/apps/developer-portal/src/server/actions/verify.test.ts
+++ b/apps/developer-portal/src/server/actions/verify.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../config', () => ({
+  env: {
+    AUTH_SERVER_URL: 'http://localhost:3001',
+    PORTAL_SESSION_SECRET: 'test-secret-minimum-32-chars-long!!',
+    PORTAL_SESSION_TTL: 900,
+  },
+}));
+
+vi.mock('../auth-server-client', () => ({
+  authServerClient: {
+    verifyEmail: vi.fn(),
+  },
+}));
+
+import { authServerClient } from '../auth-server-client';
+import { verifyHandler } from './verify';
+
+const validToken = 'a'.repeat(64);
+
+describe('verifyHandler', () => {
+  it('returns ok result on successful verification', async () => {
+    vi.mocked(authServerClient.verifyEmail).mockResolvedValue({
+      ok: true,
+      data: { message: 'Email verified successfully', email: 'test@example.com' },
+    });
+
+    const result = await verifyHandler({ data: { token: validToken } });
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.data.email).toBe('test@example.com');
+    expect(authServerClient.verifyEmail).toHaveBeenCalledWith(validToken);
+  });
+
+  it('propagates INVALID_TOKEN error', async () => {
+    vi.mocked(authServerClient.verifyEmail).mockResolvedValue({
+      ok: false,
+      error: { code: 'INVALID_TOKEN', message: 'Invalid or expired token', status: 400 },
+    });
+
+    const result = await verifyHandler({ data: { token: validToken } });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe('INVALID_TOKEN');
+  });
+
+  it('propagates EMAIL_ALREADY_VERIFIED error', async () => {
+    vi.mocked(authServerClient.verifyEmail).mockResolvedValue({
+      ok: false,
+      error: { code: 'EMAIL_ALREADY_VERIFIED', message: 'Email already verified', status: 409 },
+    });
+
+    const result = await verifyHandler({ data: { token: validToken } });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe('EMAIL_ALREADY_VERIFIED');
+  });
+});

--- a/apps/developer-portal/src/server/actions/verify.ts
+++ b/apps/developer-portal/src/server/actions/verify.ts
@@ -1,0 +1,13 @@
+import { createServerFn } from '@tanstack/react-start';
+
+import { authServerClient, type Result, type VerifyEmailData } from '../auth-server-client';
+
+export async function verifyHandler({
+  data,
+}: {
+  data: { token: string };
+}): Promise<Result<VerifyEmailData>> {
+  return authServerClient.verifyEmail(data.token);
+}
+
+export const verifyFn = createServerFn({ method: 'POST' }).handler(verifyHandler);

--- a/apps/developer-portal/src/server/auth-server-client.test.ts
+++ b/apps/developer-portal/src/server/auth-server-client.test.ts
@@ -1,0 +1,207 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('./config', () => ({
+  env: {
+    AUTH_SERVER_URL: 'http://auth-server:3001',
+    PORTAL_SESSION_SECRET: 'test-secret-minimum-32-chars-long!!',
+    PORTAL_SESSION_TTL: 900,
+  },
+}));
+
+import { authServerClient } from './auth-server-client';
+
+function mockFetch(status: number, body: unknown, ok = status >= 200 && status < 300) {
+  global.fetch = vi.fn().mockResolvedValue({
+    ok,
+    status,
+    json: () => Promise.resolve(body),
+  } as Response);
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('authServerClient.register', () => {
+  it('returns ok result on 201', async () => {
+    const data = {
+      id: 'user-id',
+      email: 'test@example.com',
+      emailVerified: false,
+      realmId: 'realm-id',
+      createdAt: Date.now(),
+      updatedAt: null,
+    };
+    mockFetch(201, data);
+    const result = await authServerClient.register('test@example.com', 'Password1!');
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.data.email).toBe('test@example.com');
+  });
+
+  it('returns WEAK_PASSWORD error', async () => {
+    mockFetch(
+      422,
+      { error: 'Weak password', statusCode: 422, code: 'WEAK_PASSWORD', feedback: ['Too short'] },
+      false
+    );
+    const result = await authServerClient.register('test@example.com', 'pw');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe('WEAK_PASSWORD');
+      expect(result.error.details).toEqual(['Too short']);
+    }
+  });
+
+  it('returns EMAIL_TAKEN error when unique constraint is violated', async () => {
+    mockFetch(
+      409,
+      {
+        error: 'Duplicate',
+        statusCode: 409,
+        code: 'UNIQUE_CONSTRAINT_VIOLATION',
+        constraint: 'users_email_unique',
+      },
+      false
+    );
+    const result = await authServerClient.register('test@example.com', 'Password1!');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe('EMAIL_TAKEN');
+  });
+
+  it('returns RATE_LIMITED on 429', async () => {
+    mockFetch(429, { error: 'Too many requests', statusCode: 429 }, false);
+    const result = await authServerClient.register('test@example.com', 'Password1!');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe('RATE_LIMITED');
+  });
+
+  it('returns NETWORK_ERROR when fetch throws', async () => {
+    global.fetch = vi.fn().mockRejectedValue(new Error('ECONNREFUSED'));
+    const result = await authServerClient.register('test@example.com', 'Password1!');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe('NETWORK_ERROR');
+      expect(result.error.status).toBe(0);
+    }
+  });
+});
+
+describe('authServerClient.login', () => {
+  it('returns ok result with tokens on 200', async () => {
+    const data = {
+      access_token: 'at',
+      refresh_token: 'rt',
+      expires_in: 900,
+      token_type: 'Bearer',
+    };
+    mockFetch(200, data);
+    const result = await authServerClient.login('test@example.com', 'Password1!');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.access_token).toBe('at');
+      expect(result.data.token_type).toBe('Bearer');
+    }
+  });
+
+  it('returns INVALID_CREDENTIALS on 401', async () => {
+    mockFetch(
+      401,
+      { error: 'Invalid email or password', statusCode: 401, code: 'INVALID_CREDENTIALS' },
+      false
+    );
+    const result = await authServerClient.login('bad@example.com', 'wrong');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe('INVALID_CREDENTIALS');
+  });
+
+  it('returns NETWORK_ERROR when fetch throws', async () => {
+    global.fetch = vi.fn().mockRejectedValue(new TypeError('fetch failed'));
+    const result = await authServerClient.login('test@example.com', 'Password1!');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe('NETWORK_ERROR');
+  });
+});
+
+describe('authServerClient.logout', () => {
+  it('returns ok result on success', async () => {
+    mockFetch(200, { success: true, message: 'Successfully logged out' });
+    const result = await authServerClient.logout('valid-access-token');
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.data.success).toBe(true);
+  });
+
+  it('returns UNKNOWN error on unexpected status', async () => {
+    mockFetch(500, { error: 'Internal server error', statusCode: 500 }, false);
+    const result = await authServerClient.logout('some-token');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe('UNKNOWN');
+  });
+});
+
+describe('authServerClient.verifyEmail', () => {
+  const validToken = 'a'.repeat(64);
+
+  it('returns ok result on 200', async () => {
+    mockFetch(200, { message: 'Email verified successfully', email: 'test@example.com' });
+    const result = await authServerClient.verifyEmail(validToken);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.data.email).toBe('test@example.com');
+  });
+
+  it('returns INVALID_TOKEN on 400 with code', async () => {
+    mockFetch(
+      400,
+      { error: 'Invalid or expired token', statusCode: 400, code: 'INVALID_TOKEN' },
+      false
+    );
+    const result = await authServerClient.verifyEmail(validToken);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe('INVALID_TOKEN');
+  });
+
+  it('returns EMAIL_ALREADY_VERIFIED on 409', async () => {
+    mockFetch(
+      409,
+      { error: 'Email already verified', statusCode: 409, code: 'EMAIL_ALREADY_VERIFIED' },
+      false
+    );
+    const result = await authServerClient.verifyEmail(validToken);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe('EMAIL_ALREADY_VERIFIED');
+  });
+});
+
+describe('authServerClient.resendVerification', () => {
+  it('returns ok result on 200', async () => {
+    mockFetch(200, { message: 'If the email exists, a verification link has been sent.' });
+    const result = await authServerClient.resendVerification('test@example.com');
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.data.message).toBeTruthy();
+  });
+
+  it('returns RATE_LIMITED on 429', async () => {
+    mockFetch(429, { error: 'Rate limit exceeded', statusCode: 429 }, false);
+    const result = await authServerClient.resendVerification('test@example.com');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe('RATE_LIMITED');
+  });
+});
+
+describe('authServerClient.userinfo', () => {
+  it('returns ok result with user claims', async () => {
+    mockFetch(200, { sub: 'user-id', email: 'test@example.com', email_verified: true });
+    const result = await authServerClient.userinfo('valid-access-token');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.sub).toBe('user-id');
+      expect(result.data.email).toBe('test@example.com');
+    }
+  });
+
+  it('returns UNKNOWN error on 401', async () => {
+    mockFetch(401, { error: 'Unauthorized', statusCode: 401 }, false);
+    const result = await authServerClient.userinfo('expired-token');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.status).toBe(401);
+  });
+});

--- a/apps/developer-portal/src/server/auth-server-client.ts
+++ b/apps/developer-portal/src/server/auth-server-client.ts
@@ -1,0 +1,168 @@
+import { env } from './config';
+
+export type Result<T> =
+  | { ok: true; data: T }
+  | { ok: false; error: { code: string; message: string; details?: unknown; status: number } };
+
+interface AuthServerErrorBody {
+  error: string;
+  statusCode: number;
+  code?: string;
+  feedback?: string[];
+  constraint?: string;
+}
+
+export interface RegisterData {
+  id: string;
+  email: string;
+  emailVerified: boolean;
+  realmId: string;
+  createdAt: number;
+  updatedAt: number | null;
+}
+
+export interface LoginData {
+  access_token: string;
+  refresh_token: string;
+  expires_in: number;
+  token_type: 'Bearer';
+}
+
+export interface LogoutData {
+  success: true;
+  message: string;
+}
+
+export interface VerifyEmailData {
+  message: string;
+  email: string;
+}
+
+export interface ResendVerificationData {
+  message: string;
+}
+
+export interface UserInfoData {
+  sub: string;
+  email?: string;
+  email_verified?: boolean;
+}
+
+function mapErrorCode(body: AuthServerErrorBody, httpStatus: number): string {
+  if (httpStatus === 429) return 'RATE_LIMITED';
+  switch (body.code) {
+    case 'INVALID_CREDENTIALS':
+      return 'INVALID_CREDENTIALS';
+    case 'WEAK_PASSWORD':
+      return 'WEAK_PASSWORD';
+    case 'UNIQUE_CONSTRAINT_VIOLATION':
+      return 'EMAIL_TAKEN';
+    case 'INVALID_TOKEN':
+      return 'INVALID_TOKEN';
+    case 'EMAIL_ALREADY_VERIFIED':
+      return 'EMAIL_ALREADY_VERIFIED';
+    default:
+      return 'UNKNOWN';
+  }
+}
+
+async function apiRequest<T>(
+  path: string,
+  init: RequestInit & { skipContentType?: boolean }
+): Promise<Result<T>> {
+  const { skipContentType, ...fetchInit } = init;
+  const headers: Record<string, string> = {
+    ...(fetchInit.headers as Record<string, string> | undefined),
+  };
+  if (!skipContentType && fetchInit.method !== 'GET') {
+    headers['Content-Type'] = 'application/json';
+  }
+
+  try {
+    const res = await fetch(`${env.AUTH_SERVER_URL}${path}`, {
+      ...fetchInit,
+      headers,
+    });
+
+    if (res.ok) {
+      const data = (await res.json()) as T;
+      return { ok: true, data };
+    }
+
+    let body: AuthServerErrorBody;
+    try {
+      body = (await res.json()) as AuthServerErrorBody;
+    } catch {
+      return {
+        ok: false,
+        error: { code: 'UNKNOWN', message: `HTTP ${res.status}`, status: res.status },
+      };
+    }
+
+    const details: unknown = body.feedback ?? body.constraint ?? undefined;
+    return {
+      ok: false,
+      error: {
+        code: mapErrorCode(body, res.status),
+        message: body.error,
+        ...(details !== undefined ? { details } : {}),
+        status: res.status,
+      },
+    };
+  } catch (err) {
+    return {
+      ok: false,
+      error: {
+        code: 'NETWORK_ERROR',
+        message: err instanceof Error ? err.message : 'Network error',
+        status: 0,
+      },
+    };
+  }
+}
+
+export const authServerClient = {
+  register(email: string, password: string, realmId?: string): Promise<Result<RegisterData>> {
+    return apiRequest<RegisterData>('/auth/register', {
+      method: 'POST',
+      body: JSON.stringify({ email, password, ...(realmId ? { realmId } : {}) }),
+    });
+  },
+
+  login(email: string, password: string): Promise<Result<LoginData>> {
+    return apiRequest<LoginData>('/auth/login', {
+      method: 'POST',
+      body: JSON.stringify({ email, password }),
+    });
+  },
+
+  logout(accessToken: string): Promise<Result<LogoutData>> {
+    return apiRequest<LogoutData>('/auth/logout', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${accessToken}` },
+      skipContentType: true,
+    });
+  },
+
+  verifyEmail(token: string): Promise<Result<VerifyEmailData>> {
+    return apiRequest<VerifyEmailData>(`/auth/verify?token=${encodeURIComponent(token)}`, {
+      method: 'GET',
+      skipContentType: true,
+    });
+  },
+
+  resendVerification(email: string): Promise<Result<ResendVerificationData>> {
+    return apiRequest<ResendVerificationData>('/auth/resend-verification', {
+      method: 'POST',
+      body: JSON.stringify({ email }),
+    });
+  },
+
+  userinfo(accessToken: string): Promise<Result<UserInfoData>> {
+    return apiRequest<UserInfoData>('/userinfo', {
+      method: 'GET',
+      headers: { Authorization: `Bearer ${accessToken}` },
+      skipContentType: true,
+    });
+  },
+};

--- a/apps/developer-portal/src/server/config.ts
+++ b/apps/developer-portal/src/server/config.ts
@@ -1,0 +1,16 @@
+const AUTH_SERVER_URL = process.env['AUTH_SERVER_URL'];
+const PORTAL_SESSION_SECRET = process.env['PORTAL_SESSION_SECRET'];
+const PORTAL_SESSION_TTL = parseInt(process.env['PORTAL_SESSION_TTL'] ?? '900', 10);
+
+if (!AUTH_SERVER_URL) {
+  throw new Error('Missing required environment variable: AUTH_SERVER_URL');
+}
+if (!PORTAL_SESSION_SECRET) {
+  throw new Error('Missing required environment variable: PORTAL_SESSION_SECRET');
+}
+
+export const env = {
+  AUTH_SERVER_URL,
+  PORTAL_SESSION_SECRET,
+  PORTAL_SESSION_TTL,
+} as const;

--- a/apps/developer-portal/src/server/session-cookie.test.ts
+++ b/apps/developer-portal/src/server/session-cookie.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('./config', () => ({
+  env: {
+    AUTH_SERVER_URL: 'http://localhost:3001',
+    PORTAL_SESSION_SECRET: 'test-secret-minimum-32-chars-long!!',
+    PORTAL_SESSION_TTL: 900,
+  },
+}));
+
+import type { PortalSessionPayload } from './session-cookie';
+import {
+  clearSessionCookieHeader,
+  readSessionCookie,
+  SESSION_COOKIE_NAME,
+  setSessionCookieHeader,
+  signSession,
+  verifySession,
+} from './session-cookie';
+
+const samplePayload: PortalSessionPayload = {
+  accessToken: 'access-token-value',
+  refreshToken: 'refresh-token-value',
+  expiresAt: Date.now() + 900_000,
+};
+
+describe('signSession / verifySession', () => {
+  it('round-trips a payload correctly', () => {
+    const signed = signSession(samplePayload);
+    const result = verifySession(signed);
+    expect(result).toEqual(samplePayload);
+  });
+
+  it('returns null for a tampered payload', () => {
+    const signed = signSession(samplePayload);
+    const parts = signed.split('.');
+    const tampered = `${parts[0]}TAMPERED.${parts[1]}`;
+    expect(verifySession(tampered)).toBeNull();
+  });
+
+  it('returns null for a tampered signature', () => {
+    const signed = signSession(samplePayload);
+    const lastDot = signed.lastIndexOf('.');
+    const tampered = `${signed.slice(0, lastDot)}.INVALIDSIGNATURE`;
+    expect(verifySession(tampered)).toBeNull();
+  });
+
+  it('returns null for an empty string', () => {
+    expect(verifySession('')).toBeNull();
+  });
+
+  it('returns null for a value with no separator', () => {
+    expect(verifySession('nodot')).toBeNull();
+  });
+
+  it('returns null for a value with only a leading separator', () => {
+    expect(verifySession('.abc')).toBeNull();
+  });
+});
+
+describe('setSessionCookieHeader', () => {
+  it('includes the cookie name and required attributes', () => {
+    const header = setSessionCookieHeader(samplePayload);
+    expect(header).toContain(`${SESSION_COOKIE_NAME}=`);
+    expect(header).toContain('HttpOnly');
+    expect(header).toContain('SameSite=Lax');
+    expect(header).toContain('Path=/');
+    expect(header).toContain('Max-Age=900');
+  });
+
+  it('does not include Secure outside production', () => {
+    const original = process.env['NODE_ENV'];
+    process.env['NODE_ENV'] = 'test';
+    const header = setSessionCookieHeader(samplePayload);
+    expect(header).not.toContain('Secure');
+    process.env['NODE_ENV'] = original;
+  });
+
+  it('includes Secure in production', () => {
+    const original = process.env['NODE_ENV'];
+    process.env['NODE_ENV'] = 'production';
+    const header = setSessionCookieHeader(samplePayload);
+    expect(header).toContain('Secure');
+    process.env['NODE_ENV'] = original;
+  });
+});
+
+describe('clearSessionCookieHeader', () => {
+  it('sets Max-Age=0 and clears the cookie value', () => {
+    const header = clearSessionCookieHeader();
+    expect(header).toContain(`${SESSION_COOKIE_NAME}=`);
+    expect(header).toContain('Max-Age=0');
+    expect(header).toContain('HttpOnly');
+  });
+});
+
+describe('readSessionCookie', () => {
+  it('returns null when cookieHeader is undefined', () => {
+    expect(readSessionCookie(undefined)).toBeNull();
+  });
+
+  it('returns null when the named cookie is absent', () => {
+    expect(readSessionCookie('other_cookie=value')).toBeNull();
+  });
+
+  it('returns null when the cookie value has been tampered', () => {
+    const signed = signSession(samplePayload);
+    const tampered = signed.slice(0, -5) + 'XXXXX';
+    const header = `${SESSION_COOKIE_NAME}=${tampered}`;
+    expect(readSessionCookie(header)).toBeNull();
+  });
+
+  it('round-trips through a cookie header string', () => {
+    const value = signSession(samplePayload);
+    const cookieHeader = `other=abc; ${SESSION_COOKIE_NAME}=${value}; extra=xyz`;
+    expect(readSessionCookie(cookieHeader)).toEqual(samplePayload);
+  });
+});

--- a/apps/developer-portal/src/server/session-cookie.test.ts
+++ b/apps/developer-portal/src/server/session-cookie.test.ts
@@ -68,19 +68,15 @@ describe('setSessionCookieHeader', () => {
     expect(header).toContain('Max-Age=900');
   });
 
-  it('does not include Secure outside production', () => {
+  // The `__Host-` prefix mandates `Secure`; browsers reject the cookie
+  // without it (RFC 6265bis §4.1.3.2). Emit it unconditionally.
+  it('always includes Secure regardless of NODE_ENV', () => {
     const original = process.env['NODE_ENV'];
-    process.env['NODE_ENV'] = 'test';
-    const header = setSessionCookieHeader(samplePayload);
-    expect(header).not.toContain('Secure');
-    process.env['NODE_ENV'] = original;
-  });
-
-  it('includes Secure in production', () => {
-    const original = process.env['NODE_ENV'];
-    process.env['NODE_ENV'] = 'production';
-    const header = setSessionCookieHeader(samplePayload);
-    expect(header).toContain('Secure');
+    for (const envValue of ['test', 'development', 'production']) {
+      process.env['NODE_ENV'] = envValue;
+      const header = setSessionCookieHeader(samplePayload);
+      expect(header).toContain('Secure');
+    }
     process.env['NODE_ENV'] = original;
   });
 });
@@ -91,6 +87,13 @@ describe('clearSessionCookieHeader', () => {
     expect(header).toContain(`${SESSION_COOKIE_NAME}=`);
     expect(header).toContain('Max-Age=0');
     expect(header).toContain('HttpOnly');
+  });
+
+  it('always includes Secure on the clearing header', () => {
+    const original = process.env['NODE_ENV'];
+    process.env['NODE_ENV'] = 'test';
+    expect(clearSessionCookieHeader()).toContain('Secure');
+    process.env['NODE_ENV'] = original;
   });
 });
 

--- a/apps/developer-portal/src/server/session-cookie.ts
+++ b/apps/developer-portal/src/server/session-cookie.ts
@@ -1,0 +1,78 @@
+import { createHmac, timingSafeEqual } from 'node:crypto';
+
+import { env } from './config';
+
+export const SESSION_COOKIE_NAME = '__Host-qauth_portal_session';
+
+export interface PortalSessionPayload {
+  accessToken: string;
+  refreshToken: string;
+  expiresAt: number;
+}
+
+const SEPARATOR = '.';
+
+function hmac(value: string): string {
+  return createHmac('sha256', env.PORTAL_SESSION_SECRET).update(value).digest('base64url');
+}
+
+export function signSession(payload: PortalSessionPayload): string {
+  const encodedPayload = Buffer.from(JSON.stringify(payload)).toString('base64url');
+  const signature = hmac(encodedPayload);
+  return `${encodedPayload}${SEPARATOR}${signature}`;
+}
+
+export function verifySession(value: string): PortalSessionPayload | null {
+  const idx = value.lastIndexOf(SEPARATOR);
+  if (idx <= 0 || idx === value.length - 1) return null;
+
+  const encodedPayload = value.slice(0, idx);
+  const providedSig = value.slice(idx + 1);
+  const expectedSig = hmac(encodedPayload);
+
+  const providedBuf = Buffer.from(providedSig, 'base64url');
+  const expectedBuf = Buffer.from(expectedSig, 'base64url');
+  if (providedBuf.length !== expectedBuf.length) return null;
+  if (!timingSafeEqual(providedBuf, expectedBuf)) return null;
+
+  try {
+    return JSON.parse(
+      Buffer.from(encodedPayload, 'base64url').toString('utf8')
+    ) as PortalSessionPayload;
+  } catch {
+    return null;
+  }
+}
+
+export function setSessionCookieHeader(payload: PortalSessionPayload): string {
+  const value = signSession(payload);
+  const attrs = [
+    `${SESSION_COOKIE_NAME}=${value}`,
+    'Path=/',
+    'HttpOnly',
+    'SameSite=Lax',
+    `Max-Age=${env.PORTAL_SESSION_TTL}`,
+  ];
+  if (process.env['NODE_ENV'] === 'production') attrs.push('Secure');
+  return attrs.join('; ');
+}
+
+export function clearSessionCookieHeader(): string {
+  const attrs = [`${SESSION_COOKIE_NAME}=`, 'Path=/', 'HttpOnly', 'SameSite=Lax', 'Max-Age=0'];
+  if (process.env['NODE_ENV'] === 'production') attrs.push('Secure');
+  return attrs.join('; ');
+}
+
+export function readSessionCookie(cookieHeader: string | undefined): PortalSessionPayload | null {
+  if (!cookieHeader) return null;
+  for (const part of cookieHeader.split(';')) {
+    const trimmed = part.trim();
+    const eq = trimmed.indexOf('=');
+    if (eq === -1) continue;
+    const key = trimmed.slice(0, eq);
+    if (key !== SESSION_COOKIE_NAME) continue;
+    const rawValue = trimmed.slice(eq + 1);
+    return verifySession(decodeURIComponent(rawValue));
+  }
+  return null;
+}

--- a/apps/developer-portal/src/server/session-cookie.ts
+++ b/apps/developer-portal/src/server/session-cookie.ts
@@ -44,23 +44,32 @@ export function verifySession(value: string): PortalSessionPayload | null {
   }
 }
 
+// `Secure` is always emitted: the `__Host-` prefix requires it (RFC 6265bis
+// §4.1.3.2). Browsers reject any `Set-Cookie` header for a `__Host-` cookie
+// without `Secure`, even on localhost. Dev over plain HTTP must therefore
+// loop back through localhost (which browsers treat as a secure context) or
+// use a TLS-terminating proxy.
 export function setSessionCookieHeader(payload: PortalSessionPayload): string {
   const value = signSession(payload);
-  const attrs = [
+  return [
     `${SESSION_COOKIE_NAME}=${value}`,
     'Path=/',
     'HttpOnly',
+    'Secure',
     'SameSite=Lax',
     `Max-Age=${env.PORTAL_SESSION_TTL}`,
-  ];
-  if (process.env['NODE_ENV'] === 'production') attrs.push('Secure');
-  return attrs.join('; ');
+  ].join('; ');
 }
 
 export function clearSessionCookieHeader(): string {
-  const attrs = [`${SESSION_COOKIE_NAME}=`, 'Path=/', 'HttpOnly', 'SameSite=Lax', 'Max-Age=0'];
-  if (process.env['NODE_ENV'] === 'production') attrs.push('Secure');
-  return attrs.join('; ');
+  return [
+    `${SESSION_COOKIE_NAME}=`,
+    'Path=/',
+    'HttpOnly',
+    'Secure',
+    'SameSite=Lax',
+    'Max-Age=0',
+  ].join('; ');
 }
 
 export function readSessionCookie(cookieHeader: string | undefined): PortalSessionPayload | null {

--- a/apps/developer-portal/vitest.config.ts
+++ b/apps/developer-portal/vitest.config.ts
@@ -1,0 +1,3 @@
+import baseConfig from '../../vitest.config';
+
+export default baseConfig;

--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -28,6 +28,7 @@ export default {
         'db',
         'api',
         'ui',
+        'portal',
         'sdk',
         'docs',
         'config',

--- a/libs/ui/src/primitives/button.test.tsx
+++ b/libs/ui/src/primitives/button.test.tsx
@@ -1,0 +1,44 @@
+import { renderToString } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+
+import { Button } from './button';
+
+describe('Button', () => {
+  it('renders default variant classes', () => {
+    const html = renderToString(<Button>click</Button>);
+    expect(html).toContain('rounded-md');
+    expect(html).toContain('bg-blue-500');
+  });
+
+  it('applies outline variant', () => {
+    const html = renderToString(<Button variant="outline">click</Button>);
+    expect(html).toContain('border-gray-300');
+  });
+
+  it('merges custom className with variant classes', () => {
+    const html = renderToString(<Button className="custom-x">click</Button>);
+    expect(html).toContain('custom-x');
+  });
+
+  it('forwards standard HTML button attributes', () => {
+    const html = renderToString(
+      <Button type="submit" disabled name="login" form="loginForm">
+        click
+      </Button>
+    );
+    expect(html).toContain('type="submit"');
+    expect(html).toContain('disabled');
+    expect(html).toContain('name="login"');
+    expect(html).toContain('form="loginForm"');
+  });
+
+  it('forwards aria attributes', () => {
+    const html = renderToString(
+      <Button aria-label="logout" aria-busy="true">
+        click
+      </Button>
+    );
+    expect(html).toContain('aria-label="logout"');
+    expect(html).toContain('aria-busy="true"');
+  });
+});

--- a/libs/ui/src/primitives/button.tsx
+++ b/libs/ui/src/primitives/button.tsx
@@ -7,24 +7,27 @@ export type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
   size?: 'default' | 'sm' | 'lg';
 };
 
-const buttonVariants = cva('rounded-md bg-blue-500 p-2 text-white hover:bg-blue-600', {
-  variants: {
-    variant: {
-      default: 'bg-blue-500 hover:bg-blue-600',
-      outline: 'border border-gray-300 bg-white text-gray-800 hover:bg-gray-100',
-      ghost: 'bg-transparent text-gray-800 hover:bg-gray-100',
-      link: 'p-0 text-blue-500 hover:underline',
+const buttonVariants = cva(
+  'rounded-md bg-blue-500 p-2 text-sm text-white hover:bg-blue-600 disabled:cursor-not-allowed disabled:opacity-50',
+  {
+    variants: {
+      variant: {
+        default: 'bg-blue-500 hover:bg-blue-600',
+        outline: 'border border-gray-300 bg-white text-gray-800 hover:bg-gray-100',
+        ghost: 'bg-transparent text-gray-800 hover:bg-gray-100',
+        link: 'p-0 text-blue-500 hover:underline',
+      },
+      size: {
+        default: 'p-2',
+        sm: 'p-1',
+        lg: 'p-3',
+      },
     },
-    size: {
-      default: 'p-2',
-      sm: 'p-1',
-      lg: 'p-3',
+    defaultVariants: {
+      variant: 'default',
     },
-  },
-  defaultVariants: {
-    variant: 'default',
-  },
-});
+  }
+);
 
 export const Button = ({
   children,

--- a/libs/ui/src/primitives/button.tsx
+++ b/libs/ui/src/primitives/button.tsx
@@ -31,6 +31,11 @@ export const Button = ({
   variant = 'default',
   size = 'default',
   className,
+  ...rest
 }: ButtonProps) => {
-  return <button className={cn(buttonVariants({ variant, size }), className)}>{children}</button>;
+  return (
+    <button {...rest} className={cn(buttonVariants({ variant, size }), className)}>
+      {children}
+    </button>
+  );
 };

--- a/libs/ui/src/primitives/card.test.tsx
+++ b/libs/ui/src/primitives/card.test.tsx
@@ -1,0 +1,89 @@
+import { createRef } from 'react';
+import { renderToString } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from './card';
+
+describe('Card', () => {
+  it('renders with default classes', () => {
+    const html = renderToString(<Card />);
+    expect(html).toContain('rounded-lg');
+    expect(html).toContain('border');
+    expect(html).toContain('shadow-sm');
+  });
+
+  it('merges className with defaults', () => {
+    const html = renderToString(<Card className="custom-class" />);
+    expect(html).toContain('custom-class');
+    expect(html).toContain('rounded-lg');
+  });
+
+  it('renders without error when ref is provided', () => {
+    const ref = createRef<HTMLDivElement>();
+    const html = renderToString(<Card ref={ref} />);
+    expect(html).toBeDefined();
+    expect(html).toContain('<div');
+  });
+
+  it('renders children', () => {
+    const html = renderToString(<Card>Card body</Card>);
+    expect(html).toContain('Card body');
+  });
+});
+
+describe('CardHeader', () => {
+  it('renders with default classes', () => {
+    const html = renderToString(<CardHeader />);
+    expect(html).toContain('flex');
+    expect(html).toContain('p-6');
+  });
+
+  it('merges className with defaults', () => {
+    const html = renderToString(<CardHeader className="extra" />);
+    expect(html).toContain('extra');
+    expect(html).toContain('p-6');
+  });
+
+  it('renders without error when ref is provided', () => {
+    const ref = createRef<HTMLDivElement>();
+    const html = renderToString(<CardHeader ref={ref} />);
+    expect(html).toBeDefined();
+  });
+});
+
+describe('CardContent', () => {
+  it('renders with default classes', () => {
+    const html = renderToString(<CardContent />);
+    expect(html).toContain('p-6');
+  });
+
+  it('merges className with defaults', () => {
+    const html = renderToString(<CardContent className="extra" />);
+    expect(html).toContain('extra');
+    expect(html).toContain('p-6');
+  });
+
+  it('renders without error when ref is provided', () => {
+    const ref = createRef<HTMLDivElement>();
+    const html = renderToString(<CardContent ref={ref} />);
+    expect(html).toBeDefined();
+  });
+});
+
+describe('CardTitle', () => {
+  it('renders as h3 with default classes', () => {
+    const html = renderToString(<CardTitle>Title</CardTitle>);
+    expect(html).toContain('<h3');
+    expect(html).toContain('font-semibold');
+    expect(html).toContain('Title');
+  });
+});
+
+describe('CardDescription', () => {
+  it('renders as p with default classes', () => {
+    const html = renderToString(<CardDescription>Desc</CardDescription>);
+    expect(html).toContain('<p');
+    expect(html).toContain('text-gray-500');
+    expect(html).toContain('Desc');
+  });
+});

--- a/libs/ui/src/primitives/card.tsx
+++ b/libs/ui/src/primitives/card.tsx
@@ -1,0 +1,51 @@
+import { forwardRef, type HTMLAttributes } from 'react';
+
+import { cn } from '../lib/utils';
+
+export const Card = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => {
+    return (
+      <div
+        ref={ref}
+        className={cn('rounded-lg border border-gray-200 bg-white shadow-sm', className)}
+        {...props}
+      />
+    );
+  }
+);
+Card.displayName = 'Card';
+
+export const CardHeader = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => {
+    return <div ref={ref} className={cn('flex flex-col space-y-1.5 p-6', className)} {...props} />;
+  }
+);
+CardHeader.displayName = 'CardHeader';
+
+export const CardTitle = forwardRef<HTMLHeadingElement, HTMLAttributes<HTMLHeadingElement>>(
+  ({ className, ...props }, ref) => {
+    return (
+      <h3
+        ref={ref}
+        className={cn('text-lg leading-none font-semibold tracking-tight', className)}
+        {...props}
+      />
+    );
+  }
+);
+CardTitle.displayName = 'CardTitle';
+
+export const CardDescription = forwardRef<
+  HTMLParagraphElement,
+  HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => {
+  return <p ref={ref} className={cn('text-sm text-gray-500', className)} {...props} />;
+});
+CardDescription.displayName = 'CardDescription';
+
+export const CardContent = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => {
+    return <div ref={ref} className={cn('p-6 pt-0', className)} {...props} />;
+  }
+);
+CardContent.displayName = 'CardContent';

--- a/libs/ui/src/primitives/form-field.test.tsx
+++ b/libs/ui/src/primitives/form-field.test.tsx
@@ -1,0 +1,80 @@
+import { renderToString } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+
+import { FormField } from './form-field';
+import { Input } from './input';
+
+describe('FormField', () => {
+  it('renders the label', () => {
+    const html = renderToString(
+      <FormField label="Email" htmlFor="email">
+        <Input id="email" />
+      </FormField>
+    );
+    expect(html).toContain('Email');
+    expect(html).toContain('<label');
+  });
+
+  it('associates label with the input via htmlFor', () => {
+    const html = renderToString(
+      <FormField label="Email" htmlFor="email">
+        <Input id="email" />
+      </FormField>
+    );
+    expect(html).toContain('for="email"');
+  });
+
+  it('renders children', () => {
+    const html = renderToString(
+      <FormField label="Name" htmlFor="name">
+        <Input id="name" placeholder="Enter name" />
+      </FormField>
+    );
+    expect(html).toContain('placeholder="Enter name"');
+  });
+
+  it('shows error message when error is provided', () => {
+    const html = renderToString(
+      <FormField label="Email" htmlFor="email" error="Email is required">
+        <Input id="email" />
+      </FormField>
+    );
+    expect(html).toContain('Email is required');
+    expect(html).toContain('text-red-600');
+  });
+
+  it('shows helperText when no error is provided', () => {
+    const html = renderToString(
+      <FormField label="Email" htmlFor="email" helperText="We will never share your email">
+        <Input id="email" />
+      </FormField>
+    );
+    expect(html).toContain('We will never share your email');
+    expect(html).toContain('text-gray-500');
+  });
+
+  it('shows error instead of helperText when both are provided', () => {
+    const html = renderToString(
+      <FormField
+        label="Email"
+        htmlFor="email"
+        error="Email is required"
+        helperText="Enter your email"
+      >
+        <Input id="email" />
+      </FormField>
+    );
+    expect(html).toContain('Email is required');
+    expect(html).not.toContain('Enter your email');
+  });
+
+  it('renders no helper or error text when neither is provided', () => {
+    const html = renderToString(
+      <FormField label="Email" htmlFor="email">
+        <Input id="email" />
+      </FormField>
+    );
+    expect(html).not.toContain('text-red-600');
+    expect(html).not.toContain('text-gray-500');
+  });
+});

--- a/libs/ui/src/primitives/form-field.tsx
+++ b/libs/ui/src/primitives/form-field.tsx
@@ -1,0 +1,25 @@
+import { type ReactNode } from 'react';
+
+import { Label } from './label';
+
+export interface FormFieldProps {
+  label: string;
+  htmlFor: string;
+  error?: string;
+  helperText?: string;
+  children: ReactNode;
+}
+
+export const FormField = ({ label, htmlFor, error, helperText, children }: FormFieldProps) => {
+  return (
+    <div className="flex flex-col space-y-1.5">
+      <Label htmlFor={htmlFor}>{label}</Label>
+      {children}
+      {error ? (
+        <p className="text-sm text-red-600">{error}</p>
+      ) : helperText ? (
+        <p className="text-sm text-gray-500">{helperText}</p>
+      ) : null}
+    </div>
+  );
+};

--- a/libs/ui/src/primitives/index.ts
+++ b/libs/ui/src/primitives/index.ts
@@ -1,1 +1,5 @@
 export * from './button';
+export * from './card';
+export * from './form-field';
+export * from './input';
+export * from './label';

--- a/libs/ui/src/primitives/input.test.tsx
+++ b/libs/ui/src/primitives/input.test.tsx
@@ -1,0 +1,45 @@
+import { createRef } from 'react';
+import { renderToString } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+
+import { Input } from './input';
+
+describe('Input', () => {
+  it('renders with default classes', () => {
+    const html = renderToString(<Input />);
+    expect(html).toContain('rounded-md');
+    expect(html).toContain('border');
+    expect(html).toContain('focus:ring-blue-500');
+  });
+
+  it('merges className with defaults', () => {
+    const html = renderToString(<Input className="custom-class" />);
+    expect(html).toContain('custom-class');
+    expect(html).toContain('rounded-md');
+  });
+
+  it('renders without error when ref is provided', () => {
+    const ref = createRef<HTMLInputElement>();
+    const html = renderToString(<Input ref={ref} />);
+    expect(html).toBeDefined();
+    expect(html).toContain('<input');
+  });
+
+  it('adds error styling class when aria-invalid is true', () => {
+    const html = renderToString(<Input aria-invalid="true" />);
+    expect(html).toContain('border-red-500');
+    expect(html).toContain('aria-invalid="true"');
+  });
+
+  it('does not add error styling class when aria-invalid is not set', () => {
+    const html = renderToString(<Input />);
+    expect(html).not.toContain('border-red-500');
+  });
+
+  it('passes through standard input attributes', () => {
+    const html = renderToString(<Input type="email" placeholder="Enter email" disabled />);
+    expect(html).toContain('type="email"');
+    expect(html).toContain('placeholder="Enter email"');
+    expect(html).toContain('disabled');
+  });
+});

--- a/libs/ui/src/primitives/input.tsx
+++ b/libs/ui/src/primitives/input.tsx
@@ -1,0 +1,27 @@
+import { forwardRef, type InputHTMLAttributes } from 'react';
+
+import { cn } from '../lib/utils';
+
+export type InputProps = InputHTMLAttributes<HTMLInputElement>;
+
+export const Input = forwardRef<HTMLInputElement, InputProps>(
+  ({ className, 'aria-invalid': ariaInvalid, ...props }, ref) => {
+    return (
+      <input
+        ref={ref}
+        aria-invalid={ariaInvalid}
+        className={cn(
+          'flex h-9 w-full rounded-md border border-gray-300 bg-white px-3 py-1 text-sm shadow-sm transition-colors',
+          'placeholder:text-gray-400',
+          'focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none',
+          'disabled:cursor-not-allowed disabled:opacity-50',
+          ariaInvalid === 'true' && 'border-red-500 focus:ring-red-500',
+          className
+        )}
+        {...props}
+      />
+    );
+  }
+);
+
+Input.displayName = 'Input';

--- a/libs/ui/src/primitives/label.test.tsx
+++ b/libs/ui/src/primitives/label.test.tsx
@@ -1,0 +1,36 @@
+import { createRef } from 'react';
+import { renderToString } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+
+import { Label } from './label';
+
+describe('Label', () => {
+  it('renders with default classes', () => {
+    const html = renderToString(<Label>Email</Label>);
+    expect(html).toContain('text-sm');
+    expect(html).toContain('font-medium');
+  });
+
+  it('renders children', () => {
+    const html = renderToString(<Label>Email address</Label>);
+    expect(html).toContain('Email address');
+  });
+
+  it('merges className with defaults', () => {
+    const html = renderToString(<Label className="custom-class">Name</Label>);
+    expect(html).toContain('custom-class');
+    expect(html).toContain('text-sm');
+  });
+
+  it('renders without error when ref is provided', () => {
+    const ref = createRef<HTMLLabelElement>();
+    const html = renderToString(<Label ref={ref}>Label text</Label>);
+    expect(html).toBeDefined();
+    expect(html).toContain('<label');
+  });
+
+  it('passes through htmlFor attribute', () => {
+    const html = renderToString(<Label htmlFor="email-input">Email</Label>);
+    expect(html).toContain('for="email-input"');
+  });
+});

--- a/libs/ui/src/primitives/label.tsx
+++ b/libs/ui/src/primitives/label.tsx
@@ -1,0 +1,20 @@
+import { forwardRef, type LabelHTMLAttributes } from 'react';
+
+import { cn } from '../lib/utils';
+
+export type LabelProps = LabelHTMLAttributes<HTMLLabelElement>;
+
+export const Label = forwardRef<HTMLLabelElement, LabelProps>(({ className, ...props }, ref) => {
+  return (
+    <label
+      ref={ref}
+      className={cn(
+        'text-sm leading-none font-medium peer-disabled:cursor-not-allowed peer-disabled:opacity-70',
+        className
+      )}
+      {...props}
+    />
+  );
+});
+
+Label.displayName = 'Label';

--- a/libs/ui/vitest.config.ts
+++ b/libs/ui/vitest.config.ts
@@ -1,0 +1,3 @@
+import baseConfig from '../../vitest.config';
+
+export default baseConfig;


### PR DESCRIPTION
## Summary

Implements MVP-PRD Phase 2.1 — developer-portal authentication UX. Developers can now register, verify their email, log in, see a (still placeholder) dashboard, and log out. Closes the six tasks below.

The portal owns its own session via an HttpOnly signed cookie (`__Host-qauth_portal_session`) holding the auth-server-issued access + refresh tokens. TanStack Start server functions are the only callers of auth-server endpoints — JWTs never enter the browser. This avoids the cross-origin `__Host-` cookie problem and lets the portal own its full UX.

## What's new

### `libs/ui` — additional primitives (Track A)
- `Input`, `Label`, `Card` family (`Card`, `CardHeader`, `CardContent`, `CardTitle`, `CardDescription`), `FormField`
- `Button` fix: now spreads HTML attrs onto the underlying element (was silently dropping `onClick`/`type`/`disabled`); base classes include `text-sm` + disabled state
- 35 tests via `renderToString` (RTL not installed; flagging as future work)

### `apps/developer-portal/src/server/` — server layer (Track B)
- `config.ts`: env validation (`AUTH_SERVER_URL`, `PORTAL_SESSION_SECRET`, `PORTAL_SESSION_TTL`)
- `session-cookie.ts`: HMAC-SHA256 sign/verify for `__Host-qauth_portal_session` (mirrors auth-server pattern, timing-safe compare)
- `auth-server-client.ts`: typed fetch wrappers for `/auth/{register,login,logout,verify,resend-verification}` and `/userinfo`. Returns `Result<T>` with stable error codes (`INVALID_CREDENTIALS`, `WEAK_PASSWORD`, `EMAIL_TAKEN`, `INVALID_TOKEN`, `EMAIL_ALREADY_VERIFIED`, `RATE_LIMITED`, `NETWORK_ERROR`, `UNKNOWN`); never throws
- `actions/`: `createServerFn` handlers for register, login (sets cookie), logout (clears cookie), verify, resend-verification, current-user

### `apps/developer-portal/src/routes/` — routes & auth guard (Track C)
- `/register` — form with `EMAIL_TAKEN` / `WEAK_PASSWORD` inline errors, success state with resend
- `/login` — anti-enumeration (single generic message), redirects authenticated users to `/dashboard`
- `/verify` — `validateSearch` rejects non-64-hex tokens before the network round-trip; pending/success/already-verified/error states
- `/_authed` — pathless layout: redirects unauthenticated to `/login`, exposes user via route context, header with logout
- `/_authed/dashboard` — welcome shell with placeholder cards for OAuth Clients (#85–#96, Phase 2.2) and API Keys (#97–#103, Phase 2.3)

### Workspace
- `chore(config)`: `portal` scope added to commitlint enum
- `.prettierignore`: TanStack-generated `routeTree.gen.ts` excluded (file's own header tells linters to leave it alone)

## Closes

Closes #79
Closes #80
Closes #81
Closes #82
Closes #83
Closes #84

## Test plan

- [x] `pnpm nx run-many -t test,lint --projects=ui,developer-portal` — green (35 + 71 = 106 tests)
- [x] `pnpm nx build developer-portal` — green
- [ ] `pnpm nx serve developer-portal` then walk:
  - [ ] `/register` → submit → "Check your inbox" success state
  - [ ] Click verify link from email → `/verify?token=…` → success → "Continue to login"
  - [ ] `/login` → submit valid creds → `/dashboard`
  - [ ] `/dashboard` shows email; click "Log out" → back to `/login`; cookie cleared
  - [ ] Visit `/dashboard` while logged out → redirects to `/login`
  - [ ] Visit `/login` while logged in → redirects to `/dashboard`
  - [ ] Bad token at `/verify?token=bad` → friendly error + resend form
  - [ ] Wrong password at `/login` → generic "Invalid email or password" (anti-enumeration)
  - [ ] Duplicate email at `/register` → inline "Email already registered."

## Required env (auth-server side adds none; portal-side adds 3)

```
AUTH_SERVER_URL=http://localhost:3000           # server-side fetch target
PORTAL_SESSION_SECRET=<32+ random bytes>        # HMAC for portal session cookie
PORTAL_SESSION_TTL=900                          # seconds (default 900)
```

The auth-server's existing `CORS_ORIGIN` should include the portal origin once both are deployed.

## Built by

Multi-agent team `qauth-portal-2.1` — `ui-builder` (libs/ui primitives), `server-builder` (portal server layer), `routes-builder` (TanStack routes + guards), team-lead (Button fixes, integration, this PR).