### PR TITLE
docs: MCP-first re-baseline — ADR-007 + README/PRD

### DIFF
--- a/MVP-PRD.md
+++ b/MVP-PRD.md
@@ -1,9 +1,9 @@
 # QAuth - Product Requirements Document (PRD)
 
-> **Version**: 2.1
-> **Last Updated**: 2026-04-16
+> **Version**: 2.2
+> **Last Updated**: 2026-06-23
 > **Author**: Muhammed Taha Ayan
-> **Status**: Phase 2 - Developer Portal (Phase 1 complete)
+> **Status**: MCP-first re-baseline — see [ADR-007](./docs/adr/007-mcp-first-positioning.md). Phase 1 complete; near-term focus is MCP / AI-agent authentication.
 
 ## Executive Summary
 
@@ -12,6 +12,8 @@ QAuth is an open-source federated identity platform. It accepts identity from mu
 The project is built toward a future where digital identity is portable and user-controlled across services and platforms. Standards-compliant VC wallet support (Phase 4) means any application using QAuth gains wallet-based login without modifying its auth layer. The eIDAS 2.0 regulated-industry deployment (EUDI Wallet, EU member states) is a primary real-world target for Phase 4, but the federation architecture is wallet-agnostic.
 
 **Core Philosophy**: Ship working features incrementally. Each phase should be production-ready before moving to the next.
+
+> **2026-06-23 re-baseline (MCP-first).** While executing Phases 1–3, QAuth's OAuth 2.1 work (PR #156) delivered a working OAuth 2.1 **authorization server for MCP servers and AI agents** — the protocol foundation of Phase 9, years early and never previously in scope (validated end-to-end with Claude Code against a live MCP server). Per [ADR-007](./docs/adr/007-mcp-first-positioning.md), the near-term direction is now **MCP-first**: productize MCP auth (a resource-server SDK + dynamic-registration abuse controls) and build agent-native authorization (the Phase 9 substance), while wallet federation (Phase 4) and post-quantum signing (Phase 5) become the resequenced **long-term platform**. The identifier-abstraction migration ([ADR-002](./docs/adr/002-identifier-abstraction.md)) is **deferred** and re-scoped as the Phase 4 gate. The phase breakdown below predates this re-baseline and is retained for reference; **ADR-007 governs near-term priority**.
 
 ---
 
@@ -999,7 +1001,7 @@ ENTRYPOINT ["/bin/sh", "/app/docker-entrypoint.sh"]
 ## Phase 4: Wallet Federation Bridge (OID4VC / SIOPv2)
 
 **Timeline**: 6-8 weeks
-**Status**: Not Started
+**Status**: Not Started — **deferred** (long-term platform per [ADR-007](./docs/adr/007-mcp-first-positioning.md)); **gated on the [ADR-002](./docs/adr/002-identifier-abstraction.md) identifier-abstraction migration**, which is the first task of this phase.
 
 **Objective**: Enable QAuth to accept identity from standards-compliant VC wallets as an upstream source. Downstream applications receive standard OAuth 2.1 tokens with no changes required. The EU EUDI Wallet (eIDAS 2.0) is the primary integration test target, but the architecture is wallet-agnostic.
 
@@ -1094,7 +1096,9 @@ These features are NOT part of Phases 1–5:
 - Horizontal scaling, CDN integration
 - Multi-region support
 
-### Phase 9: Agent Authentication & Authorization (TBD)
+### Phase 9: Agent Authentication & Authorization (pulled forward — see [ADR-007](./docs/adr/007-mcp-first-positioning.md))
+
+> **Re-baselined to near-term.** The OAuth 2.1 / MCP protocol foundation for this phase shipped early in PR #156 (discovery, dynamic client registration, resource-indicator audience binding, public-client PKCE, consent). The remaining substance below — agent client type, modes, granular scopes, step-up, agent-action audit — is now the **T2 differentiation track**, augmented with on-behalf-of delegation via OAuth Token Exchange (RFC 8693).
 
 - "Agent" client type on QAuth (register and identify agents)
 - Agent session state / mode (ReadOnly, Admin, Exec)

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ QAuth is **early and not yet production-ready**. An honest snapshot.
 **🚧 In progress / next (MCP-first tracks — see [ADR-007](./docs/adr/007-mcp-first-positioning.md))**
 
 - `@qauth-labs/mcp-guard` — resource-server SDK: RFC 9728 protected-resource metadata + 401 challenge + token validation
-- Dynamic-registration abuse controls (`initial_access_token` gating, client TTL/approval)
+- Client ID Metadata Documents (CIMD) as the primary client-registration path (MCP 2025-11-25); RFC 7591 dynamic registration kept as the documented fallback
 - Trust floor: real-DB repository tests + logout endpoint test + CI typecheck/coverage gate
 - Security hardening (CSRF, Helmet headers, secure cookies), structured logging (pino) + `/metrics`
 - OIDC conformance detail: ID token, nonce, scope/claims
@@ -507,7 +507,7 @@ docker compose up -d
 > **Near-term direction is MCP-first** ([ADR-007](./docs/adr/007-mcp-first-positioning.md)). The tracks below set near-term priority; the numbered phases that follow remain the long-term plan, resequenced so wallet federation (Phase 4) and post-quantum signing (Phase 5) follow the MCP work.
 >
 > - **T0 — Trust floor:** real-DB repository tests, logout endpoint test, CI typecheck + coverage gate
-> - **T1 — MCP productization:** `@qauth-labs/mcp-guard` (RFC 9728 metadata + token validation), dynamic-registration abuse controls, MCP quickstart + example, RFC 7009 revocation
+> - **T1 — MCP productization:** `@qauth-labs/mcp-guard` (RFC 9728 metadata + token validation + step-up scope challenges), Client ID Metadata Documents (CIMD) support, MCP quickstart + example, RFC 7009 revocation
 > - **T2 — Agent-native authZ (the Phase 9 substance, pulled forward):** agent client type, RFC 8693 token-exchange delegation, scope modes (ReadOnly/Admin/Exec), step-up, per-agent audit
 > - **T3 — OIDC conformance + hardening:** security (CSRF/Helmet), observability (pino/metrics), ID token/nonce/claims
 > - **T4 — Federation + PQC (deferred long-term moat):** Phases 4–5 below, gated on the [ADR-002](./docs/adr/002-identifier-abstraction.md) migration

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
   <h3>🇪🇺 Made in Europe · 🇪🇪 Made in Estonia · 🇹🇷 Made in Türkiye</h3>
 </div>
 
-> **Status:** Early. Core OAuth 2.1 / OIDC flows are working; conformance hardening, observability, and the developer portal are in progress. See [Current Status](#-current-status-april-2026) and the [MVP milestone](https://github.com/qauth-labs/qauth/milestone/1). Not yet recommended for production use.
+> **Status:** Early. Core OAuth 2.1 / OIDC flows work end-to-end — including discovery, dynamic client registration, resource-indicator audience binding, and a consent screen — and the **near-term focus is MCP / AI-agent authentication** (the self-hostable OAuth 2.1 authorization server for MCP servers; see [ADR-007](./docs/adr/007-mcp-first-positioning.md)). Wallet federation and post-quantum signing remain the long-term platform. See [Current Status](#-current-status-june-2026) and the [MVP milestone](https://github.com/qauth-labs/qauth/milestone/1). Not yet recommended for production use.
 
 ## 🎯 How to Use QAuth
 
@@ -130,36 +130,37 @@ A federated identity hub for the next generation of the internet:
 - **Standards compliant** — OAuth 2.1 (RFC 9700), OIDC 1.0, OID4VC, SIOPv2, W3C DID, NIST FIPS 204
 - **Open and self-hostable** — Apache 2.0, no telemetry, runs anywhere
 
-## 📍 Current Status (April 2026)
+## 📍 Current Status (June 2026)
 
-QAuth is **early and not yet production-ready**. An honest snapshot:
+QAuth is **early and not yet production-ready**. An honest snapshot.
+
+> **Near-term focus — MCP / AI-agent auth.** Building OAuth 2.1 properly produced a working **authorization server for MCP servers and AI agents**, validated end-to-end with Claude Code against a live MCP server. That is now the near-term direction; wallet federation and post-quantum signing are the long-term platform, sequenced after. See [ADR-007](./docs/adr/007-mcp-first-positioning.md).
 
 **✅ Working today**
 
-- OAuth 2.1 authorization code flow with mandatory PKCE
-- OIDC 1.0 userinfo + token introspection (RFC 7662)
-- Email/password registration with Argon2id hashing
-- JWT issuance, refresh, revocation (Ed25519)
-- Email verification (Resend / SMTP / Mock providers)
-- Multi-tenancy via Realms for data isolation
-- PostgreSQL 18 + Redis 7 with Docker Compose
-- OpenAPI / Swagger UI at `/docs`
-- Phase 1.7 test coverage for JWT middleware, introspect, and userinfo
+- OAuth 2.1 authorization code flow with mandatory PKCE, including public clients (`none` + PKCE)
+- `client_credentials` and `refresh_token` grants — rotation + family-based replay detection (RFC 9700)
+- Resource Indicators (RFC 8707) — audience-bound tokens across authorize → code → token → refresh
+- Dynamic Client Registration (RFC 7591, open mode) + Authorization Server Metadata / OIDC discovery / JWKS
+- Token introspection (RFC 7662), OIDC userinfo, consent screen + grant revocation
+- Email/password registration + verification (Argon2id; Resend / SMTP / Mock), multi-tenancy via Realms
+- Developer portal: registration / login / verify + dashboard shell (server-side `__Host-` session)
+- PostgreSQL 18 + Redis 7 with Docker Compose; OpenAPI / Swagger UI at `/docs`
 
-**🚧 In progress**
+**🚧 In progress / next (MCP-first tracks — see [ADR-007](./docs/adr/007-mcp-first-positioning.md))**
 
-- Developer portal skeleton (Phase 2)
-- OIDC conformance items: ID tokens, nonce, scope/claims handling
-- Structured logging (pino), Prometheus metrics, rate limiting
-- Full OIDC discovery endpoint + JWKS
+- `@qauth-labs/mcp-guard` — resource-server SDK: RFC 9728 protected-resource metadata + 401 challenge + token validation
+- Dynamic-registration abuse controls (`initial_access_token` gating, client TTL/approval)
+- Trust floor: real-DB repository tests + logout endpoint test + CI typecheck/coverage gate
+- Security hardening (CSRF, Helmet headers, secure cookies), structured logging (pino) + `/metrics`
+- OIDC conformance detail: ID token, nonce, scope/claims
 
-**📋 Designed but not yet implemented**
+**📋 Deferred — long-term platform** (designed, not yet implemented; resequenced per [ADR-007](./docs/adr/007-mcp-first-positioning.md))
 
-- Wallet federation (OID4VC / SIOPv2) — architecture in [ADR-004](./docs/adr/004-wallet-agnostic-federation.md)
-- Post-quantum hybrid signing — roadmap in [ADR-005](./docs/adr/005-pqc-hybrid-signing.md)
-- `@qauth-labs/crypto` native binding package
-- SDKs (`@qauth-labs/core`, `@qauth-labs/react`, `@qauth-labs/node`)
-- `auth-ui` (brandable login UI) and `admin-panel`
+- Identifier-abstraction migration — [ADR-002](./docs/adr/002-identifier-abstraction.md), now the gate for Phase 4
+- Wallet federation (OID4VC / SIOPv2) — [ADR-004](./docs/adr/004-wallet-agnostic-federation.md)
+- Post-quantum hybrid signing + `@qauth-labs/crypto` — [ADR-005](./docs/adr/005-pqc-hybrid-signing.md)
+- SDKs (`@qauth-labs/core`, `@qauth-labs/react`, `@qauth-labs/node`), `auth-ui`, `admin-panel`
 
 **Tracking:** [MVP milestone](https://github.com/qauth-labs/qauth/milestone/1) · [ADR index](./docs/adr/README.md) · [MVP-PRD](./MVP-PRD.md)
 
@@ -503,6 +504,14 @@ docker compose up -d
 
 ## 🗺️ Roadmap
 
+> **Near-term direction is MCP-first** ([ADR-007](./docs/adr/007-mcp-first-positioning.md)). The tracks below set near-term priority; the numbered phases that follow remain the long-term plan, resequenced so wallet federation (Phase 4) and post-quantum signing (Phase 5) follow the MCP work.
+>
+> - **T0 — Trust floor:** real-DB repository tests, logout endpoint test, CI typecheck + coverage gate
+> - **T1 — MCP productization:** `@qauth-labs/mcp-guard` (RFC 9728 metadata + token validation), dynamic-registration abuse controls, MCP quickstart + example, RFC 7009 revocation
+> - **T2 — Agent-native authZ (the Phase 9 substance, pulled forward):** agent client type, RFC 8693 token-exchange delegation, scope modes (ReadOnly/Admin/Exec), step-up, per-agent audit
+> - **T3 — OIDC conformance + hardening:** security (CSRF/Helmet), observability (pino/metrics), ID token/nonce/claims
+> - **T4 — Federation + PQC (deferred long-term moat):** Phases 4–5 below, gated on the [ADR-002](./docs/adr/002-identifier-abstraction.md) migration
+
 ### Phase 1: Core Auth Server (core flows complete; conformance & ops in progress)
 
 - [x] Database schema design (PostgreSQL + Drizzle ORM, UUIDv7)
@@ -537,7 +546,7 @@ docker compose up -d
 - [ ] Kubernetes manifests
 - [ ] JavaScript / React / Node.js SDKs (`@qauth-labs/core`, `@qauth-labs/react`, `@qauth-labs/node`)
 
-### Phase 4: Wallet Federation Bridge (OID4VC / SIOPv2)
+### Phase 4: Wallet Federation Bridge (OID4VC / SIOPv2) _(deferred — gated on [ADR-002](./docs/adr/002-identifier-abstraction.md) migration)_
 
 - [ ] SIOPv2 authentication request handling
 - [ ] OID4VC Verifiable Presentation endpoint
@@ -547,7 +556,7 @@ docker compose up -d
 - [ ] Inverse direction: QAuth as a Verifiable Credential issuer
 - [ ] Integration tests against EUDI reference wallet
 
-### Phase 5: Post-Quantum Crypto
+### Phase 5: Post-Quantum Crypto _(deferred — long-term platform)_
 
 - [ ] `@qauth-labs/crypto`: native Node.js binding (napi-rs + aws-lc-rs)
 - [ ] Hybrid composite ML-DSA-65 + Ed25519 JWT signing

--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ qauth/
 
 ### Phase 1 — Core Auth Server (core flows complete; conformance & ops in progress)
 
-> **Status:** Core OAuth 2.1 / OIDC flows work end-to-end with Ed25519 JWTs, Argon2id, PKCE, and multi-tenancy via Realms. The MVP milestone tracks at **43 of 95 issues closed**. The remaining Phase 1 work is OIDC conformance detail (ID tokens, nonce, claims), Prometheus + structured logging, rate limiting, and the developer-portal Dockerfile. See the [MVP milestone](https://github.com/qauth-labs/qauth/milestone/1).
+> **Status:** Core OAuth 2.1 / OIDC flows work end-to-end with Ed25519 JWTs, Argon2id, PKCE, multi-tenancy via Realms, dynamic client registration, resource-indicator audience binding, and consent. Remaining hardening — OIDC conformance detail (ID token, nonce, claims), structured logging + metrics, security headers, and the developer-portal Dockerfile — is tracked under the [T0–T4 milestones](https://github.com/qauth-labs/qauth/milestones) (see [ADR-007](./docs/adr/007-mcp-first-positioning.md)). For the full snapshot, see [Current Status](#-current-status-june-2026).
 
 **Core authentication (working today):**
 
@@ -531,7 +531,7 @@ docker compose up -d
 - [ ] Structured logging (pino) + Prometheus metrics
 - [ ] Rate limiting (Redis token bucket)
 
-### Phase 2: Developer Portal (current)
+### Phase 2: Developer Portal (registration/login/verify shipped; client management → track T2)
 
 - [ ] Developer registration / login
 - [ ] Self-service OAuth client management (CRUD)
@@ -729,7 +729,7 @@ Copyright © 2025–2026 QAuth Labs
 
 ---
 
-**Note:** This project is under active development. Phase 1 core flows work; Phase 1 conformance, observability, and Phase 2 (Developer Portal) are in progress. **Not yet recommended for production use.**
+**Note:** This project is under active development. Core OAuth 2.1 / OIDC flows work; the near-term focus is MCP / AI-agent auth plus conformance and observability hardening (see [ADR-007](./docs/adr/007-mcp-first-positioning.md)). **Not yet recommended for production use.**
 
 ## 🤲 Acknowledgments
 

--- a/docs/adr/002-identifier-abstraction.md
+++ b/docs/adr/002-identifier-abstraction.md
@@ -4,6 +4,8 @@
 **Date:** 2026-03-11
 **Authors:** QAuth Team
 
+> **Implementation status (2026-06-23):** Accepted as a design, **not yet implemented**. The `users` table still carries `email` / `email_normalized` / `password_hash`; the `user_credentials` and `user_attributes` tables do not exist; password auth reads `users.password_hash` directly. Per [ADR-007](./007-mcp-first-positioning.md) (MCP-first positioning), this migration is **deferred** and re-scoped as the gate for Phase 4 (wallet federation) — it is required only when a second human-identity upstream is added. MCP authorization runs on the current schema.
+
 ## Context
 
 The Phase 1 schema used email as the primary user identifier, with `email`, `email_normalized`, `password_hash`, and `email_verified` columns directly on the `users` table. This design creates a hard dependency between the authentication method (password/email) and the identity anchor.

--- a/docs/adr/007-mcp-first-positioning.md
+++ b/docs/adr/007-mcp-first-positioning.md
@@ -1,0 +1,84 @@
+# ADR-007: MCP-First Positioning — OAuth 2.1 Authorization Server for MCP / AI Agents
+
+**Status:** Accepted
+**Date:** 2026-06-23
+**Authors:** QAuth Team
+
+## Context
+
+The OAuth 2.1 work integrated in PR #156 (`integration/oauth-mcp-stack`) was built, in its own words, for _"first-class MCP / third-party client support."_ It delivered, together and in one release:
+
+- Authorization Server Metadata — `/.well-known/oauth-authorization-server` (RFC 8414)
+- OIDC discovery + JWKS — `/.well-known/openid-configuration`, `/.well-known/jwks.json`
+- Dynamic Client Registration — `POST /oauth/register` (RFC 7591, open mode)
+- Resource Indicators — `resource`-bound, audience-scoped tokens across authorize → code → token → refresh (RFC 8707)
+- Public-client (`token_endpoint_auth_method=none`) `authorization_code` + PKCE (PR #159)
+- A browser consent screen with session cookies and a revocation surface
+
+This was validated end-to-end: **Claude Code**, configured with only a server URL, drove the full `on-401 → discovery → dynamic registration → authorization_code + PKCE → consent → token` handshake against a live `memory-mcp` server deployed at `qauth.naqshi.net`.
+
+Two facts make this strategically significant:
+
+1. **It was off-roadmap.** "MCP" appears nowhere in the MVP-PRD or README. The capability maps to the PRD's vaguest, furthest-out item — "Phase 9: Agent Authentication & Authorization (TBD)" — whose _protocol foundation_ we have now shipped years ahead of plan. The authorization-server side of the MCP authorization profile is essentially complete and live-tested.
+
+2. **The originally-pitched differentiators are still paper.** Wallet federation ([ADR-004](./004-wallet-agnostic-federation.md)), post-quantum hybrid signing ([ADR-005](./005-pqc-hybrid-signing.md)), and the identifier-abstraction model ([ADR-002](./002-identifier-abstraction.md) / [ADR-003](./003-credential-provider-interface.md)) remain accepted designs with no implementing code. All of Phase 4/5 is gated on the ADR-002 schema migration, which has not started.
+
+Externally: the MCP authorization specification is new (2025), adoption is rising quickly, and there is little **self-hostable, open-source** tooling — the space is dominated by hosted identity vendors. A sovereign, OSS, OAuth-2.1-correct MCP authorization server is an underserved niche, and QAuth is already most of the way into it.
+
+The question this ADR settles: how to sequence near-term work given an accidental, timely, validated capability versus the long-planned federation/PQC vision.
+
+## Decision
+
+Adopt **MCP-first positioning** as QAuth's near-term product identity:
+
+> The open-source, self-hostable OAuth 2.1 authorization server for MCP servers and AI agents.
+
+Wallet federation (ADR-004) and post-quantum signing (ADR-005) are retained as the **long-term platform**, resequenced to follow the MCP work rather than precede it. Concretely:
+
+1. **Productize the existing capability into a turnkey MCP-auth offering.**
+   - `@qauth-labs/mcp-guard` — a resource-server-side SDK/middleware that serves `/.well-known/oauth-protected-resource` (RFC 9728), emits the `401 + WWW-Authenticate: Bearer resource_metadata=…` challenge, and validates QAuth-issued tokens (JWKS verification + `aud`/scope checks, or introspection). This is the adoption lever: without it, only the maintainer can wire QAuth to an MCP server.
+   - Abuse controls on dynamic client registration: `initial_access_token`-gated mode (open mode becomes opt-in), client TTL/expiry for dynamically-registered clients, optional admin-approval queue.
+   - An MCP quickstart and a runnable example (the Claude Code → `memory-mcp` flow), plus `RFC 7009` token revocation.
+
+2. **Build the agent-native authorization substance of Phase 9 as the differentiation.** Agent client type; on-behalf-of delegation via OAuth Token Exchange (RFC 8693, `act` claim); agent scope modes (ReadOnly / Admin / Exec); step-up authentication before dangerous operations; per-agent action audit (extending the existing `audit_logs` table). This is what makes QAuth _more_ than a generic OAuth server for agents.
+
+3. **Defer the ADR-002 identifier-abstraction migration.** It is re-scoped as the **gate for Phase 4 (wallet federation)**, not near-term work. MCP authorization is dominated by client identity, audience binding, and consent — not human multi-credential identity — and runs on the current schema. See the implementation-status note added to ADR-002.
+
+4. **Reprioritize the existing roadmap** (see Consequences) so the open issues map to the new track structure.
+
+The NLnet / NGI grant narrative is treated as **reframable**: an MCP framing ("sovereign authentication for the agentic web") is acceptable and may strengthen a resubmission. The MCP work also directly advances the conformance and hardening milestones already in the grant scope.
+
+## Consequences
+
+### Positive
+
+- Shortest path to an adoptable, differentiated product — the authorization-server core is ~90% complete and live-validated.
+- Defers the costly, blocking ADR-002 migration until a second human-identity upstream (wallet/OIDC federation) actually requires it.
+- The MCP work directly advances OAuth 2.1 / OIDC conformance and production-hardening goals already on the roadmap.
+- Sovereign, self-hostable, OSS MCP authentication is underserved relative to the hosted incumbents.
+
+### Negative
+
+- Drifts from the originally-pitched federation/PQC narrative; requires reframing in any grant update.
+- Risk of split focus for a small team — federation and PQC slip further out.
+- **Open dynamic client registration is currently live and unguarded** (e.g. on `qauth.naqshi.net`). It must be gated before the project is promoted for adoption. Immediate follow-up.
+- New surface area to maintain: an SDK package and agent-delegation semantics.
+
+### Neutral
+
+- No work is discarded — federation (ADR-004) and PQC (ADR-005) remain on the roadmap; only the order changes.
+- ADR-002/003/004/005 remain **Accepted** as designs; only their implementation sequence is affected.
+- The MCP authorization specification is still evolving; `mcp-guard` must be versioned against a specific spec revision and tracked as the spec changes.
+
+## Related
+
+- [ADR-002: Identifier Abstraction](./002-identifier-abstraction.md) — deferred; re-scoped as the Phase 4 gate
+- [ADR-003: CredentialProvider Abstraction](./003-credential-provider-interface.md)
+- [ADR-004: Wallet-Agnostic VC Federation](./004-wallet-agnostic-federation.md) — long-term platform
+- [ADR-005: Post-Quantum Hybrid Signing](./005-pqc-hybrid-signing.md) — long-term platform
+- [ADR-006: OAuth Grants and Audience](./006-oauth-grants-and-audience.md) — the foundation this builds on
+- PR #156 — `integration/oauth-mcp-stack`; PR #159 — public-client `authorization_code`
+- [MCP Authorization specification](https://modelcontextprotocol.io/specification/draft/basic/authorization)
+- [RFC 9728 — OAuth 2.0 Protected Resource Metadata](https://datatracker.ietf.org/doc/html/rfc9728)
+- [RFC 8707 — Resource Indicators](https://datatracker.ietf.org/doc/html/rfc8707) · [RFC 7591 — Dynamic Client Registration](https://datatracker.ietf.org/doc/html/rfc7591) · [RFC 8414 — Authorization Server Metadata](https://datatracker.ietf.org/doc/html/rfc8414)
+- [RFC 8693 — OAuth 2.0 Token Exchange](https://datatracker.ietf.org/doc/html/rfc8693) · [RFC 7009 — Token Revocation](https://datatracker.ietf.org/doc/html/rfc7009)

--- a/docs/adr/007-mcp-first-positioning.md
+++ b/docs/adr/007-mcp-first-positioning.md
@@ -78,7 +78,7 @@ The NLnet / NGI grant narrative is treated as **reframable**: an MCP framing ("s
 - [ADR-005: Post-Quantum Hybrid Signing](./005-pqc-hybrid-signing.md) — long-term platform
 - [ADR-006: OAuth Grants and Audience](./006-oauth-grants-and-audience.md) — the foundation this builds on
 - PR #156 — `integration/oauth-mcp-stack`; PR #159 — public-client `authorization_code`
-- [MCP Authorization specification](https://modelcontextprotocol.io/specification/draft/basic/authorization)
+- [MCP Authorization specification (2025-06-18)](https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization)
 - [RFC 9728 — OAuth 2.0 Protected Resource Metadata](https://datatracker.ietf.org/doc/html/rfc9728)
 - [RFC 8707 — Resource Indicators](https://datatracker.ietf.org/doc/html/rfc8707) · [RFC 7591 — Dynamic Client Registration](https://datatracker.ietf.org/doc/html/rfc7591) · [RFC 8414 — Authorization Server Metadata](https://datatracker.ietf.org/doc/html/rfc8414)
 - [RFC 8693 — OAuth 2.0 Token Exchange](https://datatracker.ietf.org/doc/html/rfc8693) · [RFC 7009 — Token Revocation](https://datatracker.ietf.org/doc/html/rfc7009)

--- a/docs/adr/007-mcp-first-positioning.md
+++ b/docs/adr/007-mcp-first-positioning.md
@@ -37,10 +37,11 @@ Wallet federation (ADR-004) and post-quantum signing (ADR-005) are retained as t
 
 1. **Productize the existing capability into a turnkey MCP-auth offering.**
    - `@qauth-labs/mcp-guard` — a resource-server-side SDK/middleware that serves `/.well-known/oauth-protected-resource` (RFC 9728), emits the `401 + WWW-Authenticate: Bearer resource_metadata=…` challenge, and validates QAuth-issued tokens (JWKS verification + `aud`/scope checks, or introspection). This is the adoption lever: without it, only the maintainer can wire QAuth to an MCP server.
-   - Abuse controls on dynamic client registration: `initial_access_token`-gated mode (open mode becomes opt-in), client TTL/expiry for dynamically-registered clients, optional admin-approval queue.
+   - **Client registration: adopt Client ID Metadata Documents (CIMD)** as the primary path per MCP 2025-11-25 — advertise `client_id_metadata_document_supported`, fetch + validate the metadata document (`client_id` == URL, redirect-URI checks, SSRF guards, optional domain trust policy). CIMD keeps no persistent registration records, so it also neutralizes the open-DCR abuse surface. Keep RFC 7591 dynamic registration as the documented fallback, and gate open mode (`initial_access_token`, client TTL, optional approval) for any deployment that still exposes it.
+   - **Step-up scope challenges:** `mcp-guard` emits `403 insufficient_scope` + `WWW-Authenticate` scope hints; QAuth supports re-authorization for an increased scope set (MCP 2025-11-25 incremental consent).
    - An MCP quickstart and a runnable example (the Claude Code → `memory-mcp` flow), plus `RFC 7009` token revocation.
 
-2. **Build the agent-native authorization substance of Phase 9 as the differentiation.** Agent client type; on-behalf-of delegation via OAuth Token Exchange (RFC 8693, `act` claim); agent scope modes (ReadOnly / Admin / Exec); step-up authentication before dangerous operations; per-agent action audit (extending the existing `audit_logs` table). This is what makes QAuth _more_ than a generic OAuth server for agents.
+2. **Build the agent-native authorization substance of Phase 9 as the differentiation.** Agent client type; on-behalf-of delegation via OAuth Token Exchange (RFC 8693, `act` claim — an additive MCP auth _extension_, not core; see the [ext-auth](https://github.com/modelcontextprotocol/ext-auth) repo); agent scope modes (ReadOnly / Admin / Exec); step-up authentication before dangerous operations; per-agent action audit (extending the existing `audit_logs` table). This is what makes QAuth _more_ than a generic OAuth server for agents.
 
 3. **Defer the ADR-002 identifier-abstraction migration.** It is re-scoped as the **gate for Phase 4 (wallet federation)**, not near-term work. MCP authorization is dominated by client identity, audience binding, and consent — not human multi-credential identity — and runs on the current schema. See the implementation-status note added to ADR-002.
 
@@ -61,7 +62,7 @@ The NLnet / NGI grant narrative is treated as **reframable**: an MCP framing ("s
 
 - Drifts from the originally-pitched federation/PQC narrative; requires reframing in any grant update.
 - Risk of split focus for a small team — federation and PQC slip further out.
-- **Open dynamic client registration is currently live and unguarded** (e.g. on `qauth.naqshi.net`). It must be gated before the project is promoted for adoption. Immediate follow-up.
+- **Open dynamic client registration is currently live and unguarded** (e.g. on `qauth.naqshi.net`). It must be gated before the project is promoted for adoption — immediate follow-up; adopting CIMD (see Spec tracking) is the durable fix, since it removes persistent registration records entirely.
 - New surface area to maintain: an SDK package and agent-delegation semantics.
 
 ### Neutral
@@ -69,6 +70,17 @@ The NLnet / NGI grant narrative is treated as **reframable**: an MCP framing ("s
 - No work is discarded — federation (ADR-004) and PQC (ADR-005) remain on the roadmap; only the order changes.
 - ADR-002/003/004/005 remain **Accepted** as designs; only their implementation sequence is affected.
 - The MCP authorization specification is still evolving; `mcp-guard` must be versioned against a specific spec revision and tracked as the spec changes.
+
+## Spec tracking
+
+Reviewed against MCP Authorization **revision 2025-11-25** (the revision this ADR targets; the implementation in PR #156 was built to 2025-06-18). Auth-relevant deltas and QAuth's posture:
+
+- **Client ID Metadata Documents (CIMD)** — now the _recommended_ client-registration mechanism (client priority: pre-registered → CIMD → DCR → manual). **RFC 7591 Dynamic Client Registration is explicitly demoted to a backwards-compatibility fallback.** → Reshapes T1: adopt CIMD (Decision §1); it supersedes the earlier "DCR abuse controls" framing because there are no persistent registration records to abuse.
+- **Incremental scope consent / step-up authorization** — runtime `403 insufficient_scope` + `WWW-Authenticate` scope challenge; clients re-authorize for a larger scope set. → `mcp-guard` (T1) emits the challenge; richer scope _modes_ stay T2.
+- **OIDC Discovery accepted as an AS-metadata alternative**, with OIDC-discovery providers **required** to expose `code_challenge_methods_supported`; the PRM `WWW-Authenticate` header is now optional with a `.well-known` fallback. → **Already satisfied:** QAuth serves both RFC 8414 and OIDC discovery, each carrying `code_challenge_methods_supported: ['S256']`.
+- **Delegation / on-behalf-of is not core MCP auth** — it lives in the separate [ext-auth extensions](https://github.com/modelcontextprotocol/ext-auth) repo, so QAuth's RFC 8693 token-exchange work (Decision §2 / T2) is an _extension_, not a core requirement.
+
+Unchanged core QAuth already meets: OAuth 2.1 (public + confidential), PKCE S256 (advertised), RFC 9728 PRM discovery, RFC 8707 resource indicators + audience-bound tokens + audience-validated introspection, public-client refresh-token rotation, and consent.
 
 ## Related
 
@@ -78,7 +90,7 @@ The NLnet / NGI grant narrative is treated as **reframable**: an MCP framing ("s
 - [ADR-005: Post-Quantum Hybrid Signing](./005-pqc-hybrid-signing.md) — long-term platform
 - [ADR-006: OAuth Grants and Audience](./006-oauth-grants-and-audience.md) — the foundation this builds on
 - PR #156 — `integration/oauth-mcp-stack`; PR #159 — public-client `authorization_code`
-- [MCP Authorization specification (2025-11-25)](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization)
+- [MCP Authorization specification (2025-11-25)](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization) · [changelog vs 2025-06-18](https://modelcontextprotocol.io/specification/2025-11-25/changelog) · [auth extensions (ext-auth)](https://github.com/modelcontextprotocol/ext-auth)
 - [RFC 9728 — OAuth 2.0 Protected Resource Metadata](https://datatracker.ietf.org/doc/html/rfc9728)
-- [RFC 8707 — Resource Indicators](https://datatracker.ietf.org/doc/html/rfc8707) · [RFC 7591 — Dynamic Client Registration](https://datatracker.ietf.org/doc/html/rfc7591) · [RFC 8414 — Authorization Server Metadata](https://datatracker.ietf.org/doc/html/rfc8414)
+- [RFC 8707 — Resource Indicators](https://datatracker.ietf.org/doc/html/rfc8707) · [RFC 7591 — Dynamic Client Registration](https://datatracker.ietf.org/doc/html/rfc7591) · [RFC 8414 — Authorization Server Metadata](https://datatracker.ietf.org/doc/html/rfc8414) · [OAuth Client ID Metadata Documents (CIMD draft-00)](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-client-id-metadata-document-00)
 - [RFC 8693 — OAuth 2.0 Token Exchange](https://datatracker.ietf.org/doc/html/rfc8693) · [RFC 7009 — Token Revocation](https://datatracker.ietf.org/doc/html/rfc7009)

--- a/docs/adr/007-mcp-first-positioning.md
+++ b/docs/adr/007-mcp-first-positioning.md
@@ -15,7 +15,7 @@ The OAuth 2.1 work integrated in PR #156 (`integration/oauth-mcp-stack`) was bui
 - Public-client (`token_endpoint_auth_method=none`) `authorization_code` + PKCE (PR #159)
 - A browser consent screen with session cookies and a revocation surface
 
-This was validated end-to-end: **Claude Code**, configured with only a server URL, drove the full `on-401 → discovery → dynamic registration → authorization_code + PKCE → consent → token` handshake against a live `memory-mcp` server deployed at `qauth.naqshi.net`.
+This was validated end-to-end: **Claude Code**, configured with only a server URL, drove the full `on-401 → discovery → dynamic registration → authorization_code + PKCE → consent → token` handshake against a live MCP server.
 
 Two facts make this strategically significant:
 
@@ -62,7 +62,7 @@ The NLnet / NGI grant narrative is treated as **reframable**: an MCP framing ("s
 
 - Drifts from the originally-pitched federation/PQC narrative; requires reframing in any grant update.
 - Risk of split focus for a small team — federation and PQC slip further out.
-- **Open dynamic client registration is currently live and unguarded** (e.g. on `qauth.naqshi.net`). It must be gated before the project is promoted for adoption — immediate follow-up; adopting CIMD (see Spec tracking) is the durable fix, since it removes persistent registration records entirely.
+- **Open dynamic client registration is unguarded by default.** Any instance exposing the registration endpoint must gate it before the project is promoted for adoption — immediate follow-up; adopting CIMD (see Spec tracking) is the durable fix, since it removes persistent registration records entirely.
 - New surface area to maintain: an SDK package and agent-delegation semantics.
 
 ### Neutral

--- a/docs/adr/007-mcp-first-positioning.md
+++ b/docs/adr/007-mcp-first-positioning.md
@@ -78,7 +78,7 @@ The NLnet / NGI grant narrative is treated as **reframable**: an MCP framing ("s
 - [ADR-005: Post-Quantum Hybrid Signing](./005-pqc-hybrid-signing.md) — long-term platform
 - [ADR-006: OAuth Grants and Audience](./006-oauth-grants-and-audience.md) — the foundation this builds on
 - PR #156 — `integration/oauth-mcp-stack`; PR #159 — public-client `authorization_code`
-- [MCP Authorization specification (2025-06-18)](https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization)
+- [MCP Authorization specification (2025-11-25)](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization)
 - [RFC 9728 — OAuth 2.0 Protected Resource Metadata](https://datatracker.ietf.org/doc/html/rfc9728)
 - [RFC 8707 — Resource Indicators](https://datatracker.ietf.org/doc/html/rfc8707) · [RFC 7591 — Dynamic Client Registration](https://datatracker.ietf.org/doc/html/rfc7591) · [RFC 8414 — Authorization Server Metadata](https://datatracker.ietf.org/doc/html/rfc8414)
 - [RFC 8693 — OAuth 2.0 Token Exchange](https://datatracker.ietf.org/doc/html/rfc8693) · [RFC 7009 — Token Revocation](https://datatracker.ietf.org/doc/html/rfc7009)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -16,6 +16,7 @@ An ADR is a document that captures an important architectural decision made alon
 | [004](./004-wallet-agnostic-federation.md)    | Wallet-Agnostic VC Federation via SIOPv2/OID4VP                             | Accepted | 2026-03-11 |
 | [005](./005-pqc-hybrid-signing.md)            | Post-Quantum Cryptography — Hybrid Signing Roadmap                          | Accepted | 2026-03-18 |
 | [006](./006-oauth-grants-and-audience.md)     | OAuth Grants — `client_credentials`, `client_secret_basic`, and `aud` Claim | Accepted | 2026-04-16 |
+| [007](./007-mcp-first-positioning.md)         | MCP-First Positioning — OAuth 2.1 Authorization Server for MCP / AI Agents  | Accepted | 2026-06-23 |
 
 ## ADR Template
 


### PR DESCRIPTION
## Summary

Records the strategic re-baseline to **MCP-first**. Building OAuth 2.1 properly (the `integration/oauth-mcp-stack` work, PR #156) produced a working **OAuth 2.1 authorization server for MCP servers and AI agents** — the protocol foundation of the PRD's far-future *Phase 9: Agent Authentication*, shipped years early and never previously in scope. It was validated end-to-end with Claude Code against a live MCP server.

This PR is **docs only** — no code changes.

## What's in here

| File | Change |
|---|---|
| `docs/adr/007-mcp-first-positioning.md` | **New ADR** — context, decision (MCP-first; defer ADR-002; T0–T4 tracks), consequences, related RFCs |
| `docs/adr/README.md` | ADR-007 added to the index |
| `docs/adr/002-identifier-abstraction.md` | Implementation-status note: accepted but **not implemented**; deferred and re-scoped as the Phase 4 gate |
| `README.md` | Status → MCP-first; "Current Status" refreshed (April → June 2026) to match shipped reality; roadmap gains a T0–T4 block; Phases 4–5 marked deferred |
| `MVP-PRD.md` | v2.1 → v2.2; re-baseline note; Phase 4 gated on ADR-002; Phase 9 pulled forward |

## Decision (for the record)

- **Direction:** MCP-first wedge. Productize the MCP-auth capability (RS-side SDK, dynamic-registration abuse controls, quickstart) and build agent-native authZ (Phase 9 substance); keep wallet federation + post-quantum as the long-term platform, sequenced after.
- **ADR-002 deferred:** MCP auth runs on the current schema, so the identifier-abstraction migration is the Phase 4 gate, not near-term work.
- **Grant:** NLnet/NGI scope treated as reframable.

## Companion change (already applied, not in this PR)

Milestones restructured into the track scheme this ADR defines: **T0 Trust floor**, **T1 MCP productization**, **T2 Agent-native authZ**, **T3 OIDC conformance & hardening**, **T4 Federation & PQC (deferred)**. Existing issues reassigned accordingly; #97/#98 (API keys) left in MVP pending a deprecation call (likely superseded by Dynamic Client Registration).