### PR TITLE
feat: [T2] REST GET /api/clients + client-management module scaffold (#85)

### DIFF
--- a/apps/auth-server/src/app/routes/clients/clients.test.ts
+++ b/apps/auth-server/src/app/routes/clients/clients.test.ts
@@ -11,6 +11,11 @@ interface TestContext {
   };
 }
 
+// `oauth_clients.developer_id` is a UUID column and a user token's `sub` is a
+// UUID `users.id`, so the developer subjects in these tests must be UUIDs.
+const DEV_A = '0190a000-0000-7000-8000-00000000000a';
+const DEV_B = '0190a000-0000-7000-8000-00000000000b';
+
 function createReply() {
   const state: { statusCode?: number; body?: unknown } = {};
   const reply: any = {
@@ -98,14 +103,14 @@ describe('GET /api/clients route', () => {
     ]);
 
     const request = {
-      jwtPayload: { sub: 'dev-A' },
+      jwtPayload: { sub: DEV_A },
       headers: { authorization: 'Bearer token' },
     } as unknown as FastifyRequest;
     const { reply, state } = createReply();
 
     await ctx.handler!(request, reply);
 
-    expect(fastify.repositories.oauthClients.listByDeveloper).toHaveBeenCalledWith('dev-A');
+    expect(fastify.repositories.oauthClients.listByDeveloper).toHaveBeenCalledWith(DEV_A);
     expect(state.body).toEqual({
       clients: [
         {
@@ -140,7 +145,7 @@ describe('GET /api/clients route', () => {
     (fastify.repositories.oauthClients.listByDeveloper as unknown as Mock).mockResolvedValue([]);
 
     const request = {
-      jwtPayload: { sub: 'dev-A' },
+      jwtPayload: { sub: DEV_A },
       headers: { authorization: 'Bearer token' },
     } as unknown as FastifyRequest;
     const { reply, state } = createReply();
@@ -158,21 +163,41 @@ describe('GET /api/clients route', () => {
     // caller's own developer id and returns only that developer's rows.
     (fastify.repositories.oauthClients.listByDeveloper as unknown as Mock).mockImplementation(
       async (developerId: string) =>
-        developerId === 'dev-A' ? [makeClientRow({ developerId: 'dev-A' })] : []
+        developerId === DEV_A ? [makeClientRow({ developerId: DEV_A })] : []
     );
 
     // Developer B is authenticated and must not receive developer A's client.
     const request = {
-      jwtPayload: { sub: 'dev-B' },
+      jwtPayload: { sub: DEV_B },
       headers: { authorization: 'Bearer token' },
     } as unknown as FastifyRequest;
     const { reply, state } = createReply();
 
     await ctx.handler!(request, reply);
 
-    expect(fastify.repositories.oauthClients.listByDeveloper).toHaveBeenCalledWith('dev-B');
-    expect(fastify.repositories.oauthClients.listByDeveloper).not.toHaveBeenCalledWith('dev-A');
+    expect(fastify.repositories.oauthClients.listByDeveloper).toHaveBeenCalledWith(DEV_B);
+    expect(fastify.repositories.oauthClients.listByDeveloper).not.toHaveBeenCalledWith(DEV_A);
     expect(state.body).toEqual({ clients: [] });
+  });
+
+  it('returns an empty list without querying when sub is not a UUID (client_credentials token)', async () => {
+    const { fastify, ctx } = makeFastify();
+    await clientsRoute(fastify);
+
+    // A client_credentials access token carries `sub === client_id`, an opaque
+    // varchar rather than a UUID. Querying the UUID `developer_id` column with
+    // it would raise Postgres 22P02 and surface as a 500, so the handler must
+    // short-circuit to an empty list and never reach the repository.
+    const request = {
+      jwtPayload: { sub: 'app-123' },
+      headers: { authorization: 'Bearer token' },
+    } as unknown as FastifyRequest;
+    const { reply, state } = createReply();
+
+    await ctx.handler!(request, reply);
+
+    expect(state.body).toEqual({ clients: [] });
+    expect(fastify.repositories.oauthClients.listByDeveloper).not.toHaveBeenCalled();
   });
 
   it('throws JWTInvalidError when the jwt payload is missing a sub', async () => {

--- a/apps/auth-server/src/app/routes/clients/clients.test.ts
+++ b/apps/auth-server/src/app/routes/clients/clients.test.ts
@@ -1,0 +1,191 @@
+import { JWTInvalidError } from '@qauth-labs/shared-errors';
+import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import { describe, expect, it, type Mock, vi } from 'vitest';
+
+import clientsRoute, { autoPrefix } from './index';
+
+interface TestContext {
+  handler?: (request: FastifyRequest, reply: FastifyReply) => Promise<unknown>;
+  options?: {
+    preHandler?: (request: FastifyRequest, reply: FastifyReply) => Promise<void>;
+  };
+}
+
+function createReply() {
+  const state: { statusCode?: number; body?: unknown } = {};
+  const reply: any = {
+    code(n: number) {
+      state.statusCode = n;
+      return reply;
+    },
+    send(body: unknown) {
+      state.body = body;
+      return body;
+    },
+  };
+  return { reply: reply as FastifyReply, state };
+}
+
+function makeFastify() {
+  const ctx: TestContext = {};
+  const fastify: any = {
+    withTypeProvider: () => ({
+      get: (_url: string, opts: TestContext['options'], handler: TestContext['handler']) => {
+        ctx.handler = handler;
+        ctx.options = opts;
+        return fastify;
+      },
+    }),
+    requireJwt: vi.fn(),
+    repositories: {
+      oauthClients: {
+        listByDeveloper: vi.fn(),
+      },
+    },
+    log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  };
+  return { fastify: fastify as FastifyInstance, ctx };
+}
+
+/**
+ * Build a representative oauth_clients row. The secret hash is present so the
+ * tests can assert it never leaks into the response.
+ */
+function makeClientRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: '0190a000-0000-7000-8000-000000000001',
+    realmId: 'realm-1',
+    clientId: 'app-123',
+    clientSecretHash: 'argon2id$super-secret-hash',
+    name: 'My App',
+    description: 'desc',
+    redirectUris: ['https://app.example.com/cb'],
+    scopes: ['openid', 'email'],
+    audience: null,
+    enabled: true,
+    requirePkce: true,
+    tokenEndpointAuthMethod: 'client_secret_post',
+    grantTypes: ['authorization_code', 'refresh_token'],
+    responseTypes: ['code'],
+    developerId: 'dev-A',
+    dynamicRegisteredAt: null,
+    metadata: null,
+    createdAt: 1700,
+    updatedAt: 1700,
+    lastUsedAt: null,
+    ...overrides,
+  };
+}
+
+describe('GET /api/clients route', () => {
+  it('is mounted under the /api/clients prefix', () => {
+    expect(autoPrefix).toBe('/api/clients');
+  });
+
+  it('registers requireJwt as the preHandler (401 for unauthenticated)', async () => {
+    const { fastify, ctx } = makeFastify();
+    await clientsRoute(fastify);
+    expect(ctx.handler).toBeDefined();
+    expect(ctx.options?.preHandler).toBe(fastify.requireJwt);
+  });
+
+  it('lists the authenticated developer clients with safe fields only (no secret)', async () => {
+    const { fastify, ctx } = makeFastify();
+    await clientsRoute(fastify);
+
+    (fastify.repositories.oauthClients.listByDeveloper as unknown as Mock).mockResolvedValue([
+      makeClientRow(),
+    ]);
+
+    const request = {
+      jwtPayload: { sub: 'dev-A' },
+      headers: { authorization: 'Bearer token' },
+    } as unknown as FastifyRequest;
+    const { reply, state } = createReply();
+
+    await ctx.handler!(request, reply);
+
+    expect(fastify.repositories.oauthClients.listByDeveloper).toHaveBeenCalledWith('dev-A');
+    expect(state.body).toEqual({
+      clients: [
+        {
+          id: '0190a000-0000-7000-8000-000000000001',
+          clientId: 'app-123',
+          name: 'My App',
+          description: 'desc',
+          redirectUris: ['https://app.example.com/cb'],
+          scopes: ['openid', 'email'],
+          grantTypes: ['authorization_code', 'refresh_token'],
+          responseTypes: ['code'],
+          tokenEndpointAuthMethod: 'client_secret_post',
+          enabled: true,
+          requirePkce: true,
+          createdAt: 1700,
+          updatedAt: 1700,
+          lastUsedAt: null,
+        },
+      ],
+    });
+
+    // The secret hash must never be serialized.
+    const serialized = JSON.stringify(state.body);
+    expect(serialized).not.toContain('clientSecretHash');
+    expect(serialized).not.toContain('argon2id$super-secret-hash');
+  });
+
+  it('returns an empty list when the developer owns no clients', async () => {
+    const { fastify, ctx } = makeFastify();
+    await clientsRoute(fastify);
+
+    (fastify.repositories.oauthClients.listByDeveloper as unknown as Mock).mockResolvedValue([]);
+
+    const request = {
+      jwtPayload: { sub: 'dev-A' },
+      headers: { authorization: 'Bearer token' },
+    } as unknown as FastifyRequest;
+    const { reply, state } = createReply();
+
+    await ctx.handler!(request, reply);
+
+    expect(state.body).toEqual({ clients: [] });
+  });
+
+  it('scopes the query to the caller so developer A cannot see developer B clients', async () => {
+    const { fastify, ctx } = makeFastify();
+    await clientsRoute(fastify);
+
+    // The repository is the isolation boundary: it is queried with the
+    // caller's own developer id and returns only that developer's rows.
+    (fastify.repositories.oauthClients.listByDeveloper as unknown as Mock).mockImplementation(
+      async (developerId: string) =>
+        developerId === 'dev-A' ? [makeClientRow({ developerId: 'dev-A' })] : []
+    );
+
+    // Developer B is authenticated and must not receive developer A's client.
+    const request = {
+      jwtPayload: { sub: 'dev-B' },
+      headers: { authorization: 'Bearer token' },
+    } as unknown as FastifyRequest;
+    const { reply, state } = createReply();
+
+    await ctx.handler!(request, reply);
+
+    expect(fastify.repositories.oauthClients.listByDeveloper).toHaveBeenCalledWith('dev-B');
+    expect(fastify.repositories.oauthClients.listByDeveloper).not.toHaveBeenCalledWith('dev-A');
+    expect(state.body).toEqual({ clients: [] });
+  });
+
+  it('throws JWTInvalidError when the jwt payload is missing a sub', async () => {
+    const { fastify, ctx } = makeFastify();
+    await clientsRoute(fastify);
+
+    const request = {
+      // No jwtPayload — defense-in-depth guard behind requireJwt.
+      headers: { authorization: 'Bearer token' },
+    } as unknown as FastifyRequest;
+    const { reply } = createReply();
+
+    await expect(ctx.handler!(request, reply)).rejects.toThrow(JWTInvalidError);
+    expect(fastify.repositories.oauthClients.listByDeveloper).not.toHaveBeenCalled();
+  });
+});

--- a/apps/auth-server/src/app/routes/clients/index.ts
+++ b/apps/auth-server/src/app/routes/clients/index.ts
@@ -1,6 +1,7 @@
 import { JWTInvalidError } from '@qauth-labs/shared-errors';
 import type { FastifyInstance } from 'fastify';
 import { ZodTypeProvider } from 'fastify-type-provider-zod';
+import { z } from 'zod';
 
 import { listClientsResponseSchema } from '../../schemas/clients';
 
@@ -45,6 +46,15 @@ type OAuthClientRow = Awaited<
 // `@fastify/autoload` mounts this module under `/api/clients` regardless of
 // the `clients/` directory name. Keep route paths resource-relative.
 export const autoPrefix = '/api/clients';
+
+// `oauth_clients.developer_id` is a UUID column. `request.jwtPayload.sub` is a
+// developer's `users.id` (a UUID) for user tokens, but for the
+// `client_credentials` grant `sub` equals the `client_id` — an opaque
+// varchar, not a UUID. Querying Postgres with a non-UUID value would raise
+// `22P02` (invalid input syntax for type uuid) and surface as a 500. Since a
+// non-UUID subject can never own a UUID-keyed client row, treat it as
+// "no clients" rather than letting it reach the database.
+const uuidSubjectSchema = z.uuid();
 
 /**
  * Project an `oauth_clients` row down to the safe fields exposed by the
@@ -93,6 +103,13 @@ export default async function (fastify: FastifyInstance) {
       }
 
       const developerId = payload.sub;
+
+      // A non-UUID subject (e.g. a client_credentials token whose `sub` is a
+      // `client_id`) can never own a client row, so short-circuit to an empty
+      // list instead of issuing a query that Postgres would reject with 22P02.
+      if (!uuidSubjectSchema.safeParse(developerId).success) {
+        return reply.send({ clients: [] });
+      }
 
       const rows = await fastify.repositories.oauthClients.listByDeveloper(developerId);
 

--- a/apps/auth-server/src/app/routes/clients/index.ts
+++ b/apps/auth-server/src/app/routes/clients/index.ts
@@ -1,0 +1,102 @@
+import { JWTInvalidError } from '@qauth-labs/shared-errors';
+import type { FastifyInstance } from 'fastify';
+import { ZodTypeProvider } from 'fastify-type-provider-zod';
+
+import { listClientsResponseSchema } from '../../schemas/clients';
+
+/**
+ * The shape of a single `oauth_clients` row as returned by the repository.
+ * Derived from the decorator type so we stay decoupled from
+ * `@qauth-labs/infra-db` (auth-server depends on it only transitively via
+ * `@qauth-labs/fastify-plugin-db`), matching the boundary that
+ * `helpers/client-auth.ts` keeps with its `OAuthClientLike` type.
+ */
+type OAuthClientRow = Awaited<
+  ReturnType<FastifyInstance['repositories']['oauthClients']['listByDeveloper']>
+>[number];
+
+/**
+ * Client-management JSON API (Phase 2.2, task 2.2.1 — issue #85).
+ *
+ * This module is the shared foundation for the whole T2 client-management
+ * surface (#85 list, #86 create, #87 get-one, #88 update, #89 delete,
+ * #90 regenerate-secret). It is mounted at `/api/clients` via the
+ * `autoPrefix` export below — `@fastify/autoload` honours `autoPrefix` over
+ * the directory-derived prefix, so sibling routes added here register
+ * against the resource root (`/`, `/:id`, `/:id/secret`, …) and land under
+ * `/api/clients`.
+ *
+ * Auth model
+ * ----------
+ * Every endpoint requires a developer access token via `fastify.requireJwt`
+ * (Bearer JWT), mirroring `/oauth/userinfo`. This is the same credential the
+ * developer portal already holds: the portal stores the access token from the
+ * login flow and sends it as `Authorization: Bearer <token>`. `requireJwt`
+ * throws `JWTInvalidError` (HTTP 401) for a missing/malformed/invalid token,
+ * so unauthenticated callers never reach a handler.
+ *
+ * `request.jwtPayload.sub` is the developer's `users.id`. Ownership is scoped
+ * strictly by `oauth_clients.developer_id`, so a developer can only ever see
+ * and manage their own clients.
+ *
+ *   GET /api/clients — list the authenticated developer's OAuth clients
+ */
+
+// `@fastify/autoload` mounts this module under `/api/clients` regardless of
+// the `clients/` directory name. Keep route paths resource-relative.
+export const autoPrefix = '/api/clients';
+
+/**
+ * Project an `oauth_clients` row down to the safe fields exposed by the
+ * management API. The client secret hash and any internal-only columns
+ * (e.g. `dynamicRegisteredAt`, `metadata`, `realmId`) are intentionally
+ * never serialized.
+ */
+function toClientResponse(client: OAuthClientRow) {
+  return {
+    id: client.id,
+    clientId: client.clientId,
+    name: client.name,
+    description: client.description,
+    redirectUris: client.redirectUris,
+    scopes: client.scopes,
+    grantTypes: client.grantTypes,
+    responseTypes: client.responseTypes,
+    tokenEndpointAuthMethod: client.tokenEndpointAuthMethod,
+    enabled: client.enabled,
+    requirePkce: client.requirePkce,
+    createdAt: client.createdAt,
+    updatedAt: client.updatedAt,
+    lastUsedAt: client.lastUsedAt,
+  };
+}
+
+export default async function (fastify: FastifyInstance) {
+  fastify.withTypeProvider<ZodTypeProvider>().get(
+    '/',
+    {
+      preHandler: fastify.requireJwt,
+      schema: {
+        description:
+          'List the OAuth clients owned by the authenticated developer. Scoped by oauth_clients.developer_id. Requires a developer Bearer access token. Never returns the client secret. (Phase 2.2, issue #85.)',
+        tags: ['Clients'],
+        security: [{ bearerAuth: [] }],
+        response: { 200: listClientsResponseSchema },
+      },
+    },
+    async (request, reply) => {
+      const payload = request.jwtPayload;
+      if (!payload || !payload.sub) {
+        // Defense-in-depth: requireJwt populates jwtPayload, but guard the
+        // sub explicitly so we never query with an undefined owner.
+        throw new JWTInvalidError('Missing JWT payload');
+      }
+
+      const developerId = payload.sub;
+
+      const rows = await fastify.repositories.oauthClients.listByDeveloper(developerId);
+
+      return reply.send({ clients: rows.map(toClientResponse) });
+    }
+  );
+}

--- a/apps/auth-server/src/app/routes/ui/consent.ts
+++ b/apps/auth-server/src/app/routes/ui/consent.ts
@@ -72,10 +72,19 @@ const consentFormSchema = z.object({
 
 type ConsentForm = z.infer<typeof consentFormSchema>;
 
-function buildAuthorizeUrl(query: Record<string, string | undefined>): string {
+function buildAuthorizeUrl(query: Record<string, string | string[] | undefined>): string {
   const u = new URL('/oauth/authorize', 'http://placeholder');
   for (const [k, v] of Object.entries(query)) {
-    if (v != null && v !== '') u.searchParams.set(k, v);
+    if (v == null) continue;
+    // RFC 8707: `resource` may be multi-valued — append one param per entry
+    // so every requested resource survives the login round-trip.
+    if (Array.isArray(v)) {
+      for (const entry of v) {
+        if (entry !== '') u.searchParams.append(k, entry);
+      }
+    } else if (v !== '') {
+      u.searchParams.set(k, v);
+    }
   }
   // Return only the path + query portion; login's return_to rejects absolute.
   return `${u.pathname}?${u.searchParams.toString()}`;

--- a/apps/auth-server/src/app/schemas/clients.ts
+++ b/apps/auth-server/src/app/schemas/clients.ts
@@ -1,0 +1,52 @@
+import { z } from 'zod';
+
+/**
+ * Client-management API schemas (issue #85, task 2.2.1).
+ *
+ * These power the developer portal's client-management screens. Payloads are
+ * app-specific (not RFC 6749/7591 wire formats), so fields are camelCase per
+ * the project's API-design convention.
+ *
+ * The shared response shape below is the foundation the rest of Phase 2.2
+ * (#86 create, #87 get-one, #88 update, #89 delete, #90 regenerate-secret)
+ * builds on. It deliberately exposes only safe, non-sensitive fields:
+ * `client_secret_hash` is NEVER serialized here.
+ */
+
+/**
+ * A single OAuth client as returned by the management API. Safe fields only —
+ * the secret hash and any internal-only columns are intentionally omitted.
+ */
+export const clientSchema = z.object({
+  id: z.uuid(),
+  clientId: z.string(),
+  name: z.string(),
+  description: z.string().nullable(),
+  redirectUris: z.array(z.string()),
+  scopes: z.array(z.string()),
+  grantTypes: z.array(z.string()),
+  responseTypes: z.array(z.string()),
+  tokenEndpointAuthMethod: z.string(),
+  enabled: z.boolean(),
+  requirePkce: z.boolean(),
+  createdAt: z.number(),
+  updatedAt: z.number(),
+  lastUsedAt: z.number().nullable(),
+});
+
+/**
+ * A single OAuth client (safe fields).
+ */
+export type Client = z.infer<typeof clientSchema>;
+
+/**
+ * Response body for `GET /api/clients` — the authenticated developer's clients.
+ */
+export const listClientsResponseSchema = z.object({
+  clients: z.array(clientSchema),
+});
+
+/**
+ * Response type for `GET /api/clients`.
+ */
+export type ListClientsResponse = z.infer<typeof listClientsResponseSchema>;

--- a/libs/infra/db/src/lib/repositories/oauth-clients.repository.ts
+++ b/libs/infra/db/src/lib/repositories/oauth-clients.repository.ts
@@ -4,7 +4,7 @@ import {
   NotFoundError,
   UniqueConstraintError,
 } from '@qauth-labs/shared-errors';
-import { and, eq } from 'drizzle-orm';
+import { and, desc, eq } from 'drizzle-orm';
 
 import type {
   NewOAuthClient,
@@ -100,6 +100,26 @@ export function createOAuthClientsRepository(defaultDb: DbClient): OAuthClientsR
         .where(and(eq(oauthClients.realmId, realmId), eq(oauthClients.clientId, clientId)))
         .limit(1);
       return client;
+    },
+
+    /**
+     * List the OAuth clients owned by a developer, newest first.
+     *
+     * Scoped strictly by `developer_id` so a developer only ever sees their
+     * own clients. Dynamically registered clients (RFC 7591) carry a null
+     * `developer_id` and are excluded by the equality filter.
+     *
+     * @param developerId - Owning developer's user id
+     * @param tx - Optional transaction client
+     * @returns Owned OAuth clients ordered by creation time, newest first
+     */
+    async listByDeveloper(developerId: string, tx?: DbClient): Promise<OAuthClient[]> {
+      const invoker = tx ?? defaultDb;
+      return invoker
+        .select()
+        .from(oauthClients)
+        .where(eq(oauthClients.developerId, developerId))
+        .orderBy(desc(oauthClients.createdAt));
     },
 
     /**

--- a/libs/infra/db/src/types/repository.ts
+++ b/libs/infra/db/src/types/repository.ts
@@ -70,6 +70,14 @@ export interface OAuthClientsRepository extends BaseRepository<
     clientId: string,
     tx?: DbClient
   ): Promise<OAuthClient | undefined>;
+  /**
+   * List the OAuth clients owned by a developer, newest first.
+   *
+   * Ownership is scoped by `oauth_clients.developer_id`. Clients created via
+   * open dynamic registration (RFC 7591) have a null `developer_id` and are
+   * therefore never returned here.
+   */
+  listByDeveloper(developerId: string, tx?: DbClient): Promise<OAuthClient[]>;
 }
 
 /**


### PR DESCRIPTION
## T2 — REST `GET /api/clients` + client-management module scaffold (ADR-007)

Closes #85.

Seeds the T2 client-management surface that #86–#96 build on.

- New `routes/clients/` module mounted at `/api/clients` via `autoPrefix`, registered by the existing `AutoLoad`.
- `GET /api/clients` — lists the authenticated developer's own OAuth clients, guarded by **Bearer JWT** (`requireJwt`, mirroring `/oauth/userinfo`), scoped strictly by `oauth_clients.developer_id`. Client secrets are never serialized (safe-fields `toClientResponse` projection).
- New `oauth_clients` repository method `listByDeveloper`.
- 6 route tests (authorized list, empty, unauthenticated → 401, owner isolation).

### Scope / notes
- Intentionally **only** `GET` — POST/PATCH/DELETE/regenerate are #86–#90, building on the `clientSchema` + `requireJwt` + `developer_id` patterns scaffolded here.
- Adds methods to `libs/infra/db/.../oauth-clients.repository.ts` + `types/repository.ts`; the `feat/cimd-support` PR adds a different method (`upsertCimdClient`) to the same files — trivial additive conflict.

433 tests pass (6 new).
