### PR TITLE
feat: [T1] CIMD (Client ID Metadata Documents) support (#165)

### DIFF
--- a/apps/auth-server/src/app/helpers/cimd.test.ts
+++ b/apps/auth-server/src/app/helpers/cimd.test.ts
@@ -1,0 +1,216 @@
+import { InvalidClientError } from '@qauth-labs/shared-errors';
+import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
+
+const { ENV, ssrfSafeGet } = vi.hoisted(() => ({
+  ENV: {
+    CIMD_ENABLED: true,
+    CIMD_TRUST_POLICY: 'accept-any-https' as 'accept-any-https' | 'allowlist',
+    CIMD_TRUSTED_DOMAINS: [] as string[],
+    CIMD_CACHE_DEFAULT_TTL: 300,
+    CIMD_CACHE_MAX_TTL: 3600,
+    CIMD_MAX_DOCUMENT_BYTES: 65536,
+    CIMD_FETCH_TIMEOUT_MS: 5000,
+    CIMD_ALLOW_PRIVATE_ADDRESSES: false,
+  },
+  ssrfSafeGet: vi.fn(),
+}));
+
+vi.mock('../../config/env', () => ({ env: ENV }));
+
+vi.mock('./ssrf-safe-fetch', async () => {
+  const actual = await vi.importActual<typeof import('./ssrf-safe-fetch')>('./ssrf-safe-fetch');
+  return { ...actual, ssrfSafeGet };
+});
+
+import { fetchAndValidateCimdDocument, isCimdClientId, resolveCacheTtlSeconds } from './cimd';
+
+const CLIENT_ID = 'https://app.example.com/oauth/client-metadata.json';
+
+function validDoc(overrides: Record<string, unknown> = {}) {
+  return {
+    client_id: CLIENT_ID,
+    client_name: 'Example MCP Client',
+    redirect_uris: ['https://app.example.com/callback'],
+    ...overrides,
+  };
+}
+
+function fastifyStub() {
+  const store = new Map<string, string>();
+  return {
+    redis: {
+      get: vi.fn(async (k: string) => store.get(k) ?? null),
+      set: vi.fn(async (k: string, v: string) => {
+        store.set(k, v);
+        return 'OK';
+      }),
+    },
+    log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  } as any;
+}
+
+function ok(body: unknown, headers: Record<string, string> = {}) {
+  return { status: 200, body: JSON.stringify(body), headers };
+}
+
+beforeEach(() => {
+  ssrfSafeGet.mockReset();
+  ENV.CIMD_ENABLED = true;
+  ENV.CIMD_TRUST_POLICY = 'accept-any-https';
+  ENV.CIMD_TRUSTED_DOMAINS = [];
+});
+
+describe('isCimdClientId', () => {
+  it('accepts https URLs with a path component', () => {
+    expect(isCimdClientId('https://app.example.com/client.json')).toBe(true);
+    expect(isCimdClientId('https://a.test/.well-known/oauth-client')).toBe(true);
+  });
+
+  it('rejects opaque ids, http, bare origins, and fragments', () => {
+    expect(isCimdClientId('app-123')).toBe(false); // opaque pre-registered id
+    expect(isCimdClientId('550e8400-e29b-41d4-a716-446655440000')).toBe(false); // DCR uuid
+    expect(isCimdClientId('http://app.example.com/client.json')).toBe(false); // not https
+    expect(isCimdClientId('https://app.example.com')).toBe(false); // bare origin, no path
+    expect(isCimdClientId('https://app.example.com/')).toBe(false); // root path only
+    expect(isCimdClientId('https://app.example.com/c.json#x')).toBe(false); // fragment
+  });
+});
+
+describe('resolveCacheTtlSeconds', () => {
+  it('honours Cache-Control max-age, clamped to the max', () => {
+    expect(resolveCacheTtlSeconds({ 'cache-control': 'public, max-age=120' })).toBe(120);
+    expect(resolveCacheTtlSeconds({ 'cache-control': 'max-age=999999' })).toBe(
+      ENV.CIMD_CACHE_MAX_TTL
+    );
+  });
+
+  it('returns 0 (do not cache) for no-store / no-cache', () => {
+    expect(resolveCacheTtlSeconds({ 'cache-control': 'no-store' })).toBe(0);
+    expect(resolveCacheTtlSeconds({ 'cache-control': 'private, no-cache' })).toBe(0);
+  });
+
+  it('falls back to the default TTL with no usable headers', () => {
+    expect(resolveCacheTtlSeconds({})).toBe(ENV.CIMD_CACHE_DEFAULT_TTL);
+  });
+});
+
+describe('fetchAndValidateCimdDocument', () => {
+  it('happy path: fetches, validates, caches, and returns the document', async () => {
+    const fastify = fastifyStub();
+    ssrfSafeGet.mockResolvedValue(ok(validDoc(), { 'cache-control': 'max-age=600' }));
+
+    const doc = await fetchAndValidateCimdDocument(fastify, CLIENT_ID);
+
+    expect(doc.client_id).toBe(CLIENT_ID);
+    expect(doc.client_name).toBe('Example MCP Client');
+    expect(doc.redirect_uris).toEqual(['https://app.example.com/callback']);
+    expect(ssrfSafeGet).toHaveBeenCalledTimes(1);
+    // Cached with the clamped max-age (600 < max 3600).
+    expect((fastify.redis.set as Mock).mock.calls[0][3]).toBe(600);
+  });
+
+  it('rejects when the document client_id does not equal the URL (impersonation)', async () => {
+    const fastify = fastifyStub();
+    ssrfSafeGet.mockResolvedValue(ok(validDoc({ client_id: 'https://evil.example/other.json' })));
+
+    await expect(fetchAndValidateCimdDocument(fastify, CLIENT_ID)).rejects.toBeInstanceOf(
+      InvalidClientError
+    );
+  });
+
+  it('rejects a document missing required fields', async () => {
+    const fastify = fastifyStub();
+    ssrfSafeGet.mockResolvedValue(ok({ client_id: CLIENT_ID })); // no client_name / redirect_uris
+
+    await expect(fetchAndValidateCimdDocument(fastify, CLIENT_ID)).rejects.toBeInstanceOf(
+      InvalidClientError
+    );
+  });
+
+  it('rejects invalid JSON', async () => {
+    const fastify = fastifyStub();
+    ssrfSafeGet.mockResolvedValue({ status: 200, body: '<<not json>>', headers: {} });
+
+    await expect(fetchAndValidateCimdDocument(fastify, CLIENT_ID)).rejects.toBeInstanceOf(
+      InvalidClientError
+    );
+  });
+
+  it('surfaces an SSRF-blocked target as invalid_client and never caches it', async () => {
+    const fastify = fastifyStub();
+    const { SsrfBlockedError } = await import('./ssrf-safe-fetch');
+    ssrfSafeGet.mockRejectedValue(new SsrfBlockedError('resolves to 169.254.169.254'));
+
+    await expect(fetchAndValidateCimdDocument(fastify, CLIENT_ID)).rejects.toBeInstanceOf(
+      InvalidClientError
+    );
+    expect(fastify.redis.set).not.toHaveBeenCalled();
+  });
+
+  it('rejects a non-200 fetch', async () => {
+    const fastify = fastifyStub();
+    ssrfSafeGet.mockResolvedValue({ status: 404, body: '', headers: {} });
+
+    await expect(fetchAndValidateCimdDocument(fastify, CLIENT_ID)).rejects.toBeInstanceOf(
+      InvalidClientError
+    );
+  });
+
+  it('serves a cached document without re-fetching (cache-header behaviour)', async () => {
+    const fastify = fastifyStub();
+    ssrfSafeGet.mockResolvedValue(ok(validDoc(), { 'cache-control': 'max-age=600' }));
+
+    await fetchAndValidateCimdDocument(fastify, CLIENT_ID); // populate cache
+    expect(ssrfSafeGet).toHaveBeenCalledTimes(1);
+
+    const second = await fetchAndValidateCimdDocument(fastify, CLIENT_ID);
+    expect(second.client_id).toBe(CLIENT_ID);
+    // No second network fetch — served from cache.
+    expect(ssrfSafeGet).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT cache when the response says no-store (re-fetches next time)', async () => {
+    const fastify = fastifyStub();
+    ssrfSafeGet.mockResolvedValue(ok(validDoc(), { 'cache-control': 'no-store' }));
+
+    await fetchAndValidateCimdDocument(fastify, CLIENT_ID);
+    await fetchAndValidateCimdDocument(fastify, CLIENT_ID);
+
+    expect(fastify.redis.set).not.toHaveBeenCalled();
+    expect(ssrfSafeGet).toHaveBeenCalledTimes(2);
+  });
+
+  it('rejects when CIMD is disabled', async () => {
+    ENV.CIMD_ENABLED = false;
+    const fastify = fastifyStub();
+    ssrfSafeGet.mockResolvedValue(ok(validDoc()));
+
+    await expect(fetchAndValidateCimdDocument(fastify, CLIENT_ID)).rejects.toBeInstanceOf(
+      InvalidClientError
+    );
+    expect(ssrfSafeGet).not.toHaveBeenCalled();
+  });
+
+  it('enforces the allowlist trust policy', async () => {
+    ENV.CIMD_TRUST_POLICY = 'allowlist';
+    ENV.CIMD_TRUSTED_DOMAINS = ['trusted.example'];
+    const fastify = fastifyStub();
+    ssrfSafeGet.mockResolvedValue(ok(validDoc()));
+
+    // app.example.com is not allowlisted → rejected before any fetch.
+    await expect(fetchAndValidateCimdDocument(fastify, CLIENT_ID)).rejects.toBeInstanceOf(
+      InvalidClientError
+    );
+    expect(ssrfSafeGet).not.toHaveBeenCalled();
+  });
+
+  it('accepts a wildcard-allowlisted subdomain', async () => {
+    ENV.CIMD_TRUST_POLICY = 'allowlist';
+    ENV.CIMD_TRUSTED_DOMAINS = ['*.example.com'];
+    const fastify = fastifyStub();
+    ssrfSafeGet.mockResolvedValue(ok(validDoc()));
+
+    const doc = await fetchAndValidateCimdDocument(fastify, CLIENT_ID);
+    expect(doc.client_id).toBe(CLIENT_ID);
+  });
+});

--- a/apps/auth-server/src/app/helpers/cimd.ts
+++ b/apps/auth-server/src/app/helpers/cimd.ts
@@ -1,0 +1,344 @@
+import { createHash } from 'node:crypto';
+
+import { InvalidClientError } from '@qauth-labs/shared-errors';
+import type { FastifyInstance } from 'fastify';
+import { z } from 'zod';
+
+import { env } from '../../config/env';
+import { SsrfBlockedError, ssrfSafeGet } from './ssrf-safe-fetch';
+
+/**
+ * Client ID Metadata Documents (CIMD) resolver.
+ *
+ * draft-ietf-oauth-client-id-metadata-document-00 + MCP Authorization rev
+ * 2025-11-25. A CIMD `client_id` is itself an HTTPS URL; the authorization
+ * server fetches the JSON document at that URL on demand instead of looking
+ * up a persisted registration record. Client-resolution priority is
+ * therefore: pre-registered (DB) → CIMD (URL client_id) → RFC 7591 DCR
+ * (fallback) → manual.
+ *
+ * Security-critical invariants enforced here:
+ *   - The document is fetched through {@link ssrfSafeGet} (SSRF guards,
+ *     https-only, no redirects, DNS-pinned IP validation) — CIMD §6.
+ *   - `client_id` inside the document MUST equal the URL it was fetched
+ *     from, byte-for-byte. This binds the document to its own URL and
+ *     prevents a document hosted at URL A from claiming to be client B.
+ *   - The authorization request's `redirect_uri` MUST be one of the
+ *     document's `redirect_uris` (exact match — no wildcards).
+ *   - An optional deployment-configured domain trust policy gates which
+ *     hosts may act as CIMD clients at all.
+ *
+ * CIMD clients are deliberately NOT persisted: there is no registration
+ * record to spam, which is what neutralizes the open-DCR abuse surface
+ * (ADR-007 §1 / spec tracking).
+ */
+
+/** Cache key namespace for stored CIMD documents in Redis. */
+const CIMD_CACHE_PREFIX = 'cimd:doc:';
+
+/**
+ * CIMD metadata document shape. Mirrors the RFC 7591 client-metadata
+ * vocabulary; the draft requires `client_id` and reuses 7591 field names.
+ * We require the three fields the issue calls out (`client_id`,
+ * `client_name`, `redirect_uris`) and accept the common optional subset.
+ * Unknown fields are stripped (Zod default), per RFC 7591 §3.2 "servers
+ * MUST ignore unrecognized metadata".
+ */
+export const cimdDocumentSchema = z.object({
+  client_id: z.string().min(1).max(2048),
+  client_name: z.string().min(1).max(255),
+  redirect_uris: z.array(z.string().min(1).max(2048)).min(1).max(20),
+  scope: z.string().max(2048).optional(),
+  grant_types: z
+    .array(z.enum(['authorization_code', 'refresh_token', 'client_credentials']))
+    .max(8)
+    .optional(),
+  response_types: z
+    .array(z.enum(['code']))
+    .max(4)
+    .optional(),
+  token_endpoint_auth_method: z
+    .enum(['none', 'client_secret_basic', 'client_secret_post'])
+    .optional(),
+  client_uri: z.string().max(2048).optional(),
+  logo_uri: z.string().max(2048).optional(),
+  tos_uri: z.string().max(2048).optional(),
+  policy_uri: z.string().max(2048).optional(),
+});
+
+export type CimdDocument = z.infer<typeof cimdDocumentSchema>;
+
+/**
+ * Insert payload for a materialised CIMD client. The auth-code,
+ * refresh-token, and audit-log tables all carry a NOT-NULL foreign key to
+ * `oauth_clients.id`, so a CIMD client must be backed by a real row before a
+ * code/token can be issued for it. We therefore idempotently upsert a row
+ * keyed by (realm_id, client_id) — see `upsertCimdClient`. This is NOT open
+ * registration: the row is keyed by the (validated, SSRF-checked) URL, so
+ * re-resolving the same client_id updates one row instead of creating new
+ * ones; there is no record to spam.
+ */
+export type CimdGrantType = 'authorization_code' | 'refresh_token' | 'client_credentials';
+
+export interface CimdClientInsert {
+  realmId: string;
+  clientId: string;
+  clientSecretHash: string;
+  name: string;
+  description: string;
+  redirectUris: string[];
+  grantTypes: CimdGrantType[];
+  responseTypes: 'code'[];
+  tokenEndpointAuthMethod: 'none';
+  requirePkce: true;
+  enabled: true;
+  developerId: null;
+  scopes: string[];
+  metadata: Record<string, unknown>;
+}
+
+/**
+ * Whether a `client_id` is CIMD-formatted: an absolute https URL with a
+ * non-root path component (the draft requires a path so a bare origin like
+ * `https://example.com` is not mistaken for a metadata URL). Anything that
+ * is not a parseable https URL with a path is treated as an opaque,
+ * pre-registered client_id.
+ */
+export function isCimdClientId(clientId: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(clientId);
+  } catch {
+    return false;
+  }
+  if (parsed.protocol !== 'https:') return false;
+  // Require a path component beyond "/". A metadata document lives at a
+  // specific path, not a bare origin.
+  if (parsed.pathname === '' || parsed.pathname === '/') return false;
+  // Fragments are meaningless for a fetch target and a sign of a malformed id.
+  if (parsed.hash) return false;
+  return true;
+}
+
+/**
+ * Apply the configured domain trust policy to a CIMD client_id URL host.
+ * Throws {@link InvalidClientError} when the host is not trusted. Runs
+ * AFTER the SSRF / structural checks; it is a coarse-grained, operator-set
+ * gate, not a security boundary on its own.
+ */
+function enforceTrustPolicy(host: string): void {
+  if (env.CIMD_TRUST_POLICY === 'accept-any-https') return;
+
+  // allowlist policy
+  const h = host.toLowerCase();
+  const trusted = env.CIMD_TRUSTED_DOMAINS.some((entry) => {
+    if (entry.startsWith('*.')) {
+      const suffix = entry.slice(1); // ".example.com"
+      return h.endsWith(suffix) && h.length > suffix.length;
+    }
+    return h === entry;
+  });
+  if (!trusted) {
+    throw new InvalidClientError('client_id host is not in the CIMD trust allowlist');
+  }
+}
+
+/**
+ * Parse `Cache-Control: max-age` / `Expires` from a response header map and
+ * clamp to the configured min(default)/max bounds. Returns a TTL in
+ * seconds. `no-store` / `no-cache` → 0 (do not cache).
+ */
+export function resolveCacheTtlSeconds(headers: Record<string, string>): number {
+  const cacheControl = headers['cache-control'];
+  if (cacheControl) {
+    const cc = cacheControl.toLowerCase();
+    if (cc.includes('no-store') || cc.includes('no-cache')) return 0;
+    const maxAge = cc.match(/max-age\s*=\s*(\d+)/);
+    if (maxAge) {
+      const seconds = Number.parseInt(maxAge[1], 10);
+      if (Number.isFinite(seconds)) {
+        return Math.min(Math.max(seconds, 0), env.CIMD_CACHE_MAX_TTL);
+      }
+    }
+  }
+
+  const expires = headers['expires'];
+  if (expires) {
+    const expMs = Date.parse(expires);
+    if (Number.isFinite(expMs)) {
+      const ttl = Math.floor((expMs - Date.now()) / 1000);
+      return Math.min(Math.max(ttl, 0), env.CIMD_CACHE_MAX_TTL);
+    }
+  }
+
+  return Math.min(env.CIMD_CACHE_DEFAULT_TTL, env.CIMD_CACHE_MAX_TTL);
+}
+
+function cacheKey(clientId: string): string {
+  // Hash the URL so the Redis key is bounded and free of reserved chars.
+  return CIMD_CACHE_PREFIX + createHash('sha256').update(clientId).digest('hex');
+}
+
+/**
+ * Map a validated CIMD document to the persistence insert payload. CIMD
+ * clients are always public (PKCE) — the AS has no shared secret with a
+ * client it never registered, so `token_endpoint_auth_method=none` and
+ * `requirePkce=true`. Scopes are intentionally left empty: the authorize
+ * route's deny-by-default `filterRequestedScopes` then grants only what the
+ * realm/consent layer permits, exactly as for an unknown-scope DCR client.
+ *
+ * `clientSecretHash` is a non-verifiable sentinel (the column is NOT NULL).
+ * Because the client is public, no `client_secret_post`/`basic` attempt can
+ * ever succeed against it.
+ */
+export function toCimdClientInsert(
+  realmId: string,
+  clientId: string,
+  doc: CimdDocument,
+  sentinelSecretHash: string
+): CimdClientInsert {
+  const grantTypes: CimdGrantType[] =
+    doc.grant_types && doc.grant_types.length > 0
+      ? doc.grant_types
+      : ['authorization_code', 'refresh_token'];
+  const responseTypes: 'code'[] =
+    doc.response_types && doc.response_types.length > 0 ? doc.response_types : ['code'];
+
+  return {
+    realmId,
+    clientId,
+    clientSecretHash: sentinelSecretHash,
+    name: doc.client_name,
+    description: 'CIMD client (client_id metadata document)',
+    redirectUris: doc.redirect_uris,
+    grantTypes,
+    responseTypes,
+    tokenEndpointAuthMethod: 'none',
+    requirePkce: true,
+    enabled: true,
+    developerId: null,
+    scopes: [],
+    metadata: {
+      registrationType: 'cimd',
+      client_id_metadata_url: clientId,
+      ...(doc.client_uri ? { client_uri: doc.client_uri } : {}),
+      ...(doc.logo_uri ? { logo_uri: doc.logo_uri } : {}),
+      ...(doc.tos_uri ? { tos_uri: doc.tos_uri } : {}),
+      ...(doc.policy_uri ? { policy_uri: doc.policy_uri } : {}),
+    },
+  };
+}
+
+/**
+ * Read a cached, already-validated CIMD document from Redis. Returns null on
+ * a miss or any cache error (cache is best-effort; a miss just re-fetches).
+ */
+async function readCache(fastify: FastifyInstance, clientId: string): Promise<CimdDocument | null> {
+  try {
+    const raw = await fastify.redis.get(cacheKey(clientId));
+    if (!raw) return null;
+    const parsed = cimdDocumentSchema.safeParse(JSON.parse(raw));
+    return parsed.success ? parsed.data : null;
+  } catch {
+    return null;
+  }
+}
+
+async function writeCache(
+  fastify: FastifyInstance,
+  clientId: string,
+  doc: CimdDocument,
+  ttlSeconds: number
+): Promise<void> {
+  if (ttlSeconds <= 0) return;
+  try {
+    await fastify.redis.set(cacheKey(clientId), JSON.stringify(doc), 'EX', ttlSeconds);
+  } catch {
+    // Best-effort cache; ignore write failures.
+  }
+}
+
+/**
+ * Fetch + validate a CIMD `client_id` URL into a parsed metadata document.
+ *
+ * Steps (all of which can reject):
+ *   1. CIMD enabled + structural client_id check.
+ *   2. Domain trust policy (operator-set allowlist / accept-any-https).
+ *   3. Document cache hit → return cached doc (HTTP cache-header behaviour).
+ *   4. SSRF-guarded https GET (no redirects, DNS-pinned, size/time-bounded).
+ *   5. 200 + valid JSON + required fields.
+ *   6. **client_id == document URL** (exact) — the core CIMD binding.
+ *   7. Cache the validated doc per the response cache headers.
+ *
+ * Throws {@link InvalidClientError} (RFC 6749 §5.2 `invalid_client`) for any
+ * failure so the caller surfaces a uniform error and never leaks why the
+ * document was rejected; the message carries detail for the caller's audit
+ * log only.
+ *
+ * Returns the validated document; persistence into a client row is the
+ * caller's responsibility (see client-resolution.ts).
+ */
+export async function fetchAndValidateCimdDocument(
+  fastify: FastifyInstance,
+  clientId: string
+): Promise<CimdDocument> {
+  if (!env.CIMD_ENABLED) {
+    throw new InvalidClientError();
+  }
+  if (!isCimdClientId(clientId)) {
+    throw new InvalidClientError();
+  }
+
+  const host = new URL(clientId).hostname;
+  enforceTrustPolicy(host);
+
+  // Cache hit: serve without re-fetching (HTTP cache-header behaviour).
+  const cached = await readCache(fastify, clientId);
+  if (cached) {
+    return cached;
+  }
+
+  let result;
+  try {
+    result = await ssrfSafeGet(clientId, {
+      timeoutMs: env.CIMD_FETCH_TIMEOUT_MS,
+      maxBytes: env.CIMD_MAX_DOCUMENT_BYTES,
+      allowPrivateAddresses: env.CIMD_ALLOW_PRIVATE_ADDRESSES,
+    });
+  } catch (err) {
+    if (err instanceof SsrfBlockedError) {
+      // Distinguish in the error chain for the caller's audit log, but still
+      // present invalid_client to the client.
+      throw new InvalidClientError(`CIMD fetch blocked: ${err.message}`);
+    }
+    throw new InvalidClientError('CIMD document fetch failed');
+  }
+
+  if (result.status !== 200) {
+    throw new InvalidClientError(`CIMD document fetch returned ${result.status}`);
+  }
+
+  let json: unknown;
+  try {
+    json = JSON.parse(result.body);
+  } catch {
+    throw new InvalidClientError('CIMD document is not valid JSON');
+  }
+
+  const parsed = cimdDocumentSchema.safeParse(json);
+  if (!parsed.success) {
+    throw new InvalidClientError('CIMD document is missing required fields');
+  }
+
+  // Core CIMD binding: the document's own client_id MUST equal the URL it
+  // was fetched from, exactly. This stops a document hosted at URL A from
+  // impersonating client B.
+  if (parsed.data.client_id !== clientId) {
+    throw new InvalidClientError('CIMD client_id does not match the document URL');
+  }
+
+  const ttl = resolveCacheTtlSeconds(result.headers);
+  await writeCache(fastify, clientId, parsed.data, ttl);
+
+  return parsed.data;
+}

--- a/apps/auth-server/src/app/helpers/client-auth.test.ts
+++ b/apps/auth-server/src/app/helpers/client-auth.test.ts
@@ -2,6 +2,21 @@ import { InvalidClientError, InvalidScopeError } from '@qauth-labs/shared-errors
 import type { FastifyInstance, FastifyRequest } from 'fastify';
 import { describe, expect, it, type Mock, vi } from 'vitest';
 
+// client-auth → client-resolution → cimd pulls in the env module; stub it so
+// the real env-schema parse (which needs DB/EMAIL vars) does not run in tests.
+vi.mock('../../config/env', () => ({
+  env: {
+    CIMD_ENABLED: true,
+    CIMD_TRUST_POLICY: 'accept-any-https',
+    CIMD_TRUSTED_DOMAINS: [],
+    CIMD_CACHE_DEFAULT_TTL: 300,
+    CIMD_CACHE_MAX_TTL: 3600,
+    CIMD_MAX_DOCUMENT_BYTES: 65536,
+    CIMD_FETCH_TIMEOUT_MS: 5000,
+    CIMD_ALLOW_PRIVATE_ADDRESSES: false,
+  },
+}));
+
 import {
   authenticateClient,
   extractClientCredentials,

--- a/apps/auth-server/src/app/helpers/client-auth.ts
+++ b/apps/auth-server/src/app/helpers/client-auth.ts
@@ -2,6 +2,8 @@ import { InvalidClientError, InvalidScopeError } from '@qauth-labs/shared-errors
 import type { FastifyInstance, FastifyRequest } from 'fastify';
 import { z } from 'zod';
 
+import { resolveClient } from './client-resolution';
+
 /** Maximum length of a single audience URI (defensive cap, RFC 8707 leaves this open). */
 const AUDIENCE_ENTRY_MAX_LENGTH = 256;
 /** Maximum number of audience entries per client (defensive cap to bound JWT size). */
@@ -162,13 +164,16 @@ export async function authenticateClientPublicOrConfidential(
     return authenticateClient(fastify, realmId, creds);
   }
 
-  // Public-client path: only `client_id` supplied. Resolve the client
-  // record and verify it's registered as public. Confidential clients
-  // that omit credentials get `invalid_client` (RFC 6749 §5.2).
+  // Public-client path: only `client_id` supplied. Resolve via the shared
+  // pre-registered → CIMD chain. A CIMD client (https-URL client_id) is
+  // materialised here too, so a direct token call whose authorize-time row
+  // was never created (or whose document cache expired) still resolves.
+  // CIMD clients are public by construction (token_endpoint_auth_method:
+  // 'none'), so they satisfy the public-client requirement below.
   if (!bodyClientId) {
     throw new InvalidClientError();
   }
-  const client = await fastify.repositories.oauthClients.findByClientId(realmId, bodyClientId);
+  const { client } = await resolveClient(fastify, realmId, bodyClientId);
   if (!client || !client.enabled) {
     throw new InvalidClientError();
   }
@@ -176,7 +181,7 @@ export async function authenticateClientPublicOrConfidential(
     // Confidential client missing its secret.
     throw new InvalidClientError();
   }
-  return client;
+  return client as unknown as OAuthClientLike;
 }
 
 /**

--- a/apps/auth-server/src/app/helpers/client-resolution.test.ts
+++ b/apps/auth-server/src/app/helpers/client-resolution.test.ts
@@ -23,7 +23,7 @@ vi.mock('./ssrf-safe-fetch', async () => {
   return { ...actual, ssrfSafeGet };
 });
 
-import { isCimdClient, resolveClient } from './client-resolution';
+import { cimdSentinelSecretHash, isCimdClient, resolveClient } from './client-resolution';
 
 const CIMD_ID = 'https://app.example.com/client.json';
 
@@ -116,6 +116,27 @@ describe('resolveClient — pre-registered → CIMD priority (MCP 2025-11-25)', 
     expect(isCimdClient(client!)).toBe(true);
   });
 
+  // Regression (DoS / OWASP API4): the unauthenticated CIMD resolution path
+  // must NOT invoke the CPU/memory-intensive Argon2id KDF. It stores a
+  // synchronously-built, well-formed argon2id sentinel instead.
+  it('does NOT run Argon2id on the unauthenticated CIMD path (DoS guard)', async () => {
+    const { fastify, upserted } = fastifyStub();
+    fastify.repositories.oauthClients.findByClientId.mockResolvedValue(undefined);
+    ssrfSafeGet.mockResolvedValue(
+      ok({
+        client_id: CIMD_ID,
+        client_name: 'Example',
+        redirect_uris: ['https://app.example.com/cb'],
+      })
+    );
+
+    await resolveClient(fastify, 'realm-1', CIMD_ID);
+
+    expect(fastify.passwordHasher.hashPassword).not.toHaveBeenCalled();
+    // Sentinel is shaped like a genuine argon2id PHC string.
+    expect(upserted[0].clientSecretHash).toMatch(/^\$argon2id\$v=19\$m=\d+,t=\d+,p=\d+\$/);
+  });
+
   it('returns null + reason when CIMD resolution fails (client_id ≠ URL)', async () => {
     const { fastify } = fastifyStub();
     fastify.repositories.oauthClients.findByClientId.mockResolvedValue(undefined);
@@ -134,6 +155,13 @@ describe('resolveClient — pre-registered → CIMD priority (MCP 2025-11-25)', 
     expect(reason).toMatch(/does not match/);
     // Never materialised a row for the rejected document.
     expect(fastify.repositories.oauthClients.upsertCimdClient).not.toHaveBeenCalled();
+  });
+
+  it('cimdSentinelSecretHash returns a unique, well-formed, unverifiable argon2id string', () => {
+    const a = cimdSentinelSecretHash();
+    const b = cimdSentinelSecretHash();
+    expect(a).toMatch(/^\$argon2id\$v=19\$m=\d+,t=\d+,p=\d+\$[^$]+\$[^$]+$/);
+    expect(a).not.toBe(b); // random salt + digest each call
   });
 
   it('returns null for an unknown opaque client_id (priority 3, no CIMD attempt)', async () => {

--- a/apps/auth-server/src/app/helpers/client-resolution.test.ts
+++ b/apps/auth-server/src/app/helpers/client-resolution.test.ts
@@ -1,0 +1,149 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { ENV, ssrfSafeGet } = vi.hoisted(() => ({
+  ENV: {
+    CIMD_ENABLED: true,
+    CIMD_TRUST_POLICY: 'accept-any-https' as const,
+    CIMD_TRUSTED_DOMAINS: [] as string[],
+    CIMD_CACHE_DEFAULT_TTL: 300,
+    CIMD_CACHE_MAX_TTL: 3600,
+    CIMD_MAX_DOCUMENT_BYTES: 65536,
+    CIMD_FETCH_TIMEOUT_MS: 5000,
+    CIMD_ALLOW_PRIVATE_ADDRESSES: false,
+  },
+  ssrfSafeGet: vi.fn(),
+}));
+vi.mock('../../config/env', () => ({ env: ENV }));
+
+// Mock only the network layer; exercise the REAL CIMD resolver + the REAL
+// pre-registered → CIMD priority logic. Errors thus originate inside cimd.ts,
+// not the test file.
+vi.mock('./ssrf-safe-fetch', async () => {
+  const actual = await vi.importActual<typeof import('./ssrf-safe-fetch')>('./ssrf-safe-fetch');
+  return { ...actual, ssrfSafeGet };
+});
+
+import { isCimdClient, resolveClient } from './client-resolution';
+
+const CIMD_ID = 'https://app.example.com/client.json';
+
+function ok(body: unknown, headers: Record<string, string> = {}) {
+  return { status: 200, body: JSON.stringify(body), headers };
+}
+
+function fastifyStub() {
+  const upserted: any[] = [];
+  const store = new Map<string, string>();
+  return {
+    fastify: {
+      redis: {
+        get: vi.fn(async (k: string) => store.get(k) ?? null),
+        set: vi.fn(async (k: string, v: string) => {
+          store.set(k, v);
+          return 'OK';
+        }),
+      },
+      repositories: {
+        oauthClients: {
+          findByClientId: vi.fn(),
+          upsertCimdClient: vi.fn(async (row: any) => {
+            const persisted = {
+              ...row,
+              id: '11111111-1111-1111-1111-111111111111',
+              audience: null,
+              dynamicRegisteredAt: null,
+              createdAt: 1,
+              updatedAt: 1,
+            };
+            upserted.push(persisted);
+            return persisted;
+          }),
+        },
+      },
+      passwordHasher: { hashPassword: vi.fn(async () => 'argon2id$sentinel') },
+    } as any,
+    upserted,
+  };
+}
+
+beforeEach(() => {
+  ssrfSafeGet.mockReset();
+  ENV.CIMD_ENABLED = true;
+});
+
+describe('resolveClient — pre-registered → CIMD priority (MCP 2025-11-25)', () => {
+  it('returns a pre-registered client without consulting CIMD (priority 1)', async () => {
+    const { fastify } = fastifyStub();
+    const preReg = { id: 'db-uuid', clientId: 'app-123', redirectUris: [], metadata: null };
+    fastify.repositories.oauthClients.findByClientId.mockResolvedValue(preReg);
+
+    const { client } = await resolveClient(fastify, 'realm-1', 'app-123');
+
+    expect(client).toBe(preReg);
+    expect(ssrfSafeGet).not.toHaveBeenCalled();
+  });
+
+  it('a pre-registered URL client_id still wins over a re-fetch (priority 1)', async () => {
+    const { fastify } = fastifyStub();
+    const preReg = { id: 'db-uuid', clientId: CIMD_ID, redirectUris: [], metadata: null };
+    fastify.repositories.oauthClients.findByClientId.mockResolvedValue(preReg);
+
+    const { client } = await resolveClient(fastify, 'realm-1', CIMD_ID);
+
+    expect(client).toBe(preReg);
+    expect(ssrfSafeGet).not.toHaveBeenCalled();
+  });
+
+  it('materialises a CIMD client when not pre-registered (priority 2)', async () => {
+    const { fastify, upserted } = fastifyStub();
+    fastify.repositories.oauthClients.findByClientId.mockResolvedValue(undefined);
+    ssrfSafeGet.mockResolvedValue(
+      ok({
+        client_id: CIMD_ID,
+        client_name: 'Example',
+        redirect_uris: ['https://app.example.com/cb'],
+      })
+    );
+
+    const { client } = await resolveClient(fastify, 'realm-1', CIMD_ID);
+
+    expect(client).not.toBeNull();
+    expect(client!.clientId).toBe(CIMD_ID);
+    expect(client!.redirectUris).toEqual(['https://app.example.com/cb']);
+    // Persisted as a public client so auth-code / refresh / audit FKs hold.
+    expect(upserted[0].tokenEndpointAuthMethod).toBe('none');
+    expect(upserted[0].requirePkce).toBe(true);
+    expect(isCimdClient(client!)).toBe(true);
+  });
+
+  it('returns null + reason when CIMD resolution fails (client_id ≠ URL)', async () => {
+    const { fastify } = fastifyStub();
+    fastify.repositories.oauthClients.findByClientId.mockResolvedValue(undefined);
+    // Document claims a different client_id than the URL it was fetched from.
+    ssrfSafeGet.mockResolvedValue(
+      ok({
+        client_id: 'https://evil.example/other.json',
+        client_name: 'Impostor',
+        redirect_uris: ['https://evil.example/cb'],
+      })
+    );
+
+    const { client, reason } = await resolveClient(fastify, 'realm-1', CIMD_ID);
+
+    expect(client).toBeNull();
+    expect(reason).toMatch(/does not match/);
+    // Never materialised a row for the rejected document.
+    expect(fastify.repositories.oauthClients.upsertCimdClient).not.toHaveBeenCalled();
+  });
+
+  it('returns null for an unknown opaque client_id (priority 3, no CIMD attempt)', async () => {
+    const { fastify } = fastifyStub();
+    fastify.repositories.oauthClients.findByClientId.mockResolvedValue(undefined);
+
+    const { client, reason } = await resolveClient(fastify, 'realm-1', 'totally-unknown');
+
+    expect(client).toBeNull();
+    expect(reason).toBe('invalid_client');
+    expect(ssrfSafeGet).not.toHaveBeenCalled();
+  });
+});

--- a/apps/auth-server/src/app/helpers/client-resolution.ts
+++ b/apps/auth-server/src/app/helpers/client-resolution.ts
@@ -51,6 +51,32 @@ export function isCimdClient(client: { metadata: Record<string, unknown> | null 
 }
 
 /**
+ * Build a non-verifiable sentinel for the NOT-NULL `client_secret_hash`
+ * column of a CIMD (public) client, WITHOUT running Argon2id.
+ *
+ * CIMD clients are public (`token_endpoint_auth_method=none`, PKCE-only) and
+ * have no shared secret, but the column is NOT NULL. The previous code ran
+ * the CPU/memory-intensive Argon2id KDF here — on the *unauthenticated*,
+ * on-demand `resolveClient` path — which is a denial-of-service / CPU- and
+ * memory-exhaustion amplifier (OWASP API4 Unrestricted Resource Consumption):
+ * an attacker drives any number of distinct CIMD `client_id`s through
+ * authorize and forces one ~64MB Argon2id computation per resolution.
+ *
+ * We instead synthesise a well-formed argon2id PHC string from random bytes.
+ * It is structurally a hash but corresponds to no known password, so
+ * `verifyPassword` returns `false` for every input (it does not throw — see
+ * @qauth-labs/server-password), i.e. any `client_secret` attempt fails
+ * closed. Cost is a few `randomBytes` calls instead of a full KDF.
+ */
+export function cimdSentinelSecretHash(): string {
+  const salt = randomBytes(16).toString('base64').replace(/=+$/, '');
+  const digest = randomBytes(32).toString('base64').replace(/=+$/, '');
+  // Mirrors the @node-rs/argon2 default params (m=65536,t=3,p=4) so the value
+  // is shaped like a genuine hash; the salt/digest are random and unverifiable.
+  return `$argon2id$v=19$m=65536,t=3,p=4$${salt}$${digest}`;
+}
+
+/**
  * Resolve a client_id to a client record, honouring the pre-registered →
  * CIMD priority. Returns `{ client: null, reason }` when no client can be
  * resolved so the caller controls the audit-log shape and error mapping.
@@ -76,11 +102,10 @@ export async function resolveClient(
       const doc = await fetchAndValidateCimdDocument(fastify, clientId);
 
       // Public client → no usable secret. Store a non-verifiable sentinel
-      // (random hash of random bytes) sized like a real argon2id hash so the
-      // NOT-NULL column is satisfied and any client_secret attempt fails.
-      const sentinelSecretHash = await fastify.passwordHasher.hashPassword(
-        randomBytes(32).toString('hex')
-      );
+      // shaped like a real argon2id hash so the NOT-NULL column is satisfied
+      // and any client_secret attempt fails closed. Built synchronously
+      // (no Argon2id) — see cimdSentinelSecretHash for the DoS rationale.
+      const sentinelSecretHash = cimdSentinelSecretHash();
 
       const insert = toCimdClientInsert(realmId, clientId, doc, sentinelSecretHash);
       const row = await fastify.repositories.oauthClients.upsertCimdClient(insert);

--- a/apps/auth-server/src/app/helpers/client-resolution.ts
+++ b/apps/auth-server/src/app/helpers/client-resolution.ts
@@ -1,0 +1,96 @@
+import { randomBytes } from 'node:crypto';
+
+import { InvalidClientError } from '@qauth-labs/shared-errors';
+import type { FastifyInstance } from 'fastify';
+
+import { fetchAndValidateCimdDocument, isCimdClientId, toCimdClientInsert } from './cimd';
+
+/**
+ * Unified OAuth client resolution implementing the MCP 2025-11-25 client
+ * priority order: **pre-registered (DB) → CIMD → DCR/manual**.
+ *
+ * - A pre-registered client_id (opaque string OR a URL already stored as a
+ *   persisted client) always wins — an operator-provisioned record takes
+ *   precedence over an on-demand metadata fetch. A previously-resolved CIMD
+ *   client is itself a persisted row, so the second authorize for the same
+ *   client_id short-circuits here without re-fetching unless its document
+ *   cache has expired (`upsertCimdClient` then refreshes it).
+ * - Otherwise, a URL-formatted client_id (https + path) is resolved as a
+ *   CIMD client: fetched + validated (SSRF-guarded) then idempotently
+ *   materialised into a row so the auth-code / refresh-token / audit foreign
+ *   keys are satisfied.
+ * - Anything else is an unknown client → `invalid_client`.
+ *
+ * RFC 7591 Dynamic Client Registration remains the documented fallback: a
+ * DCR-registered client is simply a pre-registered record by the time it
+ * reaches this resolver, so it is handled by the first branch.
+ *
+ * The returned object is the persisted `OAuthClient` row (structural
+ * superset of `OAuthClientLike`), so the authorize / token / consent code
+ * paths treat CIMD and pre-registered clients identically.
+ */
+export interface ResolvedClient {
+  id: string;
+  clientId: string;
+  clientSecretHash: string;
+  enabled: boolean;
+  grantTypes: string[];
+  responseTypes: string[];
+  scopes: string[];
+  audience: string[] | null;
+  redirectUris: string[];
+  tokenEndpointAuthMethod?: string;
+  name: string;
+  dynamicRegisteredAt: number | null;
+  metadata: Record<string, unknown> | null;
+}
+
+/** True iff the resolved client originated from a CIMD metadata document. */
+export function isCimdClient(client: { metadata: Record<string, unknown> | null }): boolean {
+  return client.metadata?.registrationType === 'cimd';
+}
+
+/**
+ * Resolve a client_id to a client record, honouring the pre-registered →
+ * CIMD priority. Returns `{ client: null, reason }` when no client can be
+ * resolved so the caller controls the audit-log shape and error mapping.
+ * CIMD-specific validation/SSRF/trust failures surface as
+ * {@link InvalidClientError} from {@link fetchAndValidateCimdDocument}; they
+ * are caught here and converted to a null + reason.
+ */
+export async function resolveClient(
+  fastify: FastifyInstance,
+  realmId: string,
+  clientId: string
+): Promise<{ client: ResolvedClient | null; reason?: string }> {
+  // 1. Pre-registered (DB) — highest priority. A previously-materialised
+  //    CIMD client also lives here once its first authorize succeeded.
+  const persisted = await fastify.repositories.oauthClients.findByClientId(realmId, clientId);
+  if (persisted) {
+    return { client: persisted as unknown as ResolvedClient };
+  }
+
+  // 2. CIMD — URL-formatted client_id resolved + materialised on demand.
+  if (isCimdClientId(clientId)) {
+    try {
+      const doc = await fetchAndValidateCimdDocument(fastify, clientId);
+
+      // Public client → no usable secret. Store a non-verifiable sentinel
+      // (random hash of random bytes) sized like a real argon2id hash so the
+      // NOT-NULL column is satisfied and any client_secret attempt fails.
+      const sentinelSecretHash = await fastify.passwordHasher.hashPassword(
+        randomBytes(32).toString('hex')
+      );
+
+      const insert = toCimdClientInsert(realmId, clientId, doc, sentinelSecretHash);
+      const row = await fastify.repositories.oauthClients.upsertCimdClient(insert);
+      return { client: row as unknown as ResolvedClient };
+    } catch (err) {
+      const reason = err instanceof InvalidClientError ? err.message : 'cimd_resolution_failed';
+      return { client: null, reason };
+    }
+  }
+
+  // 3. Unknown.
+  return { client: null, reason: 'invalid_client' };
+}

--- a/apps/auth-server/src/app/helpers/consent.test.ts
+++ b/apps/auth-server/src/app/helpers/consent.test.ts
@@ -11,6 +11,7 @@ import {
   describeScope,
   filterRequestedScopes,
   isDynamicClientWithinBadgeWindow,
+  isLoopbackRedirect,
   isScopeSubset,
   type OAuthClientLike,
   type OAuthConsentLike,
@@ -115,6 +116,38 @@ describe('canSkipConsent', () => {
   it('dynamic client inside badge window forces re-consent', () => {
     const c = client({ dynamicRegisteredAt: Date.now() - 1 * 24 * 60 * 60 * 1000 });
     expect(canSkipConsent(consent({ scopes: ['email'] }), c, ['email'])).toBe(false);
+  });
+});
+
+describe('isLoopbackRedirect', () => {
+  it('flags localhost and ::1', () => {
+    expect(isLoopbackRedirect('http://localhost/cb')).toBe(true);
+    expect(isLoopbackRedirect('http://localhost:8080/cb')).toBe(true);
+    expect(isLoopbackRedirect('http://[::1]:5173/cb')).toBe(true); // URL strips brackets
+  });
+
+  it('flags 127.0.0.1', () => {
+    expect(isLoopbackRedirect('http://127.0.0.1/cb')).toBe(true);
+    expect(isLoopbackRedirect('http://127.0.0.1:3000/cb')).toBe(true);
+  });
+
+  // Regression: the entire 127.0.0.0/8 block loops back, not just 127.0.0.1.
+  // A client could otherwise dodge the consent-screen warning via 127.0.0.2.
+  it('flags the whole 127.0.0.0/8 loopback range', () => {
+    expect(isLoopbackRedirect('http://127.0.0.2/cb')).toBe(true);
+    expect(isLoopbackRedirect('http://127.1.2.3/cb')).toBe(true);
+    expect(isLoopbackRedirect('http://127.255.255.254:9000/cb')).toBe(true);
+  });
+
+  it('does NOT flag genuine remote hosts', () => {
+    expect(isLoopbackRedirect('https://app.example.com/cb')).toBe(false);
+    expect(isLoopbackRedirect('https://12.7.0.0.1.example.com/cb')).toBe(false);
+    expect(isLoopbackRedirect('https://128.0.0.1/cb')).toBe(false);
+    expect(isLoopbackRedirect('https://1.2.3.4/cb')).toBe(false);
+  });
+
+  it('returns false for an unparseable redirect_uri', () => {
+    expect(isLoopbackRedirect('not a url')).toBe(false);
   });
 });
 

--- a/apps/auth-server/src/app/helpers/consent.ts
+++ b/apps/auth-server/src/app/helpers/consent.ts
@@ -115,7 +115,29 @@ export function describeScope(scope: string): string {
   return SCOPE_DESCRIPTIONS[scope] ?? scope;
 }
 
-const LOOPBACK_HOSTS = new Set(['127.0.0.1', '::1', '[::1]', 'localhost']);
+/**
+ * Non-IPv4 loopback host literals, matched after stripping any IPv6 brackets
+ * (Node's `URL.hostname` returns `[::1]` *with* brackets). The full IPv4
+ * `127.0.0.0/8` range is matched separately — see below.
+ */
+const LOOPBACK_HOSTS = new Set(['::1', 'localhost']);
+
+/**
+ * True when `host` is anywhere in the IPv4 loopback block `127.0.0.0/8`
+ * (RFC 1122 §3.2.1.3). The whole /8 — not just `127.0.0.1` — loops back, so
+ * `127.0.0.2`, `127.1.2.3`, etc. must all be treated as loopback; matching
+ * only `127.0.0.1` let a malicious client dodge the consent-screen warning.
+ */
+function isIpv4Loopback(host: string): boolean {
+  const octets = host.split('.');
+  if (octets.length !== 4) return false;
+  for (const o of octets) {
+    if (!/^\d{1,3}$/.test(o)) return false;
+    const n = Number(o);
+    if (n < 0 || n > 255) return false;
+  }
+  return Number(octets[0]) === 127;
+}
 
 /**
  * Extract the hostname of a redirect_uri for display at the consent screen.
@@ -142,8 +164,10 @@ export function redirectHost(redirectUri: string): string {
  */
 export function isLoopbackRedirect(redirectUri: string): boolean {
   try {
-    const host = new URL(redirectUri).hostname.toLowerCase();
-    return LOOPBACK_HOSTS.has(host);
+    // URL.hostname keeps the brackets on IPv6 literals (`[::1]`); strip them
+    // so both bracketed and bare forms match.
+    const host = new URL(redirectUri).hostname.toLowerCase().replace(/^\[|\]$/g, '');
+    return LOOPBACK_HOSTS.has(host) || isIpv4Loopback(host);
   } catch {
     return false;
   }

--- a/apps/auth-server/src/app/helpers/consent.ts
+++ b/apps/auth-server/src/app/helpers/consent.ts
@@ -114,3 +114,37 @@ const SCOPE_DESCRIPTIONS: Record<string, string> = {
 export function describeScope(scope: string): string {
   return SCOPE_DESCRIPTIONS[scope] ?? scope;
 }
+
+const LOOPBACK_HOSTS = new Set(['127.0.0.1', '::1', '[::1]', 'localhost']);
+
+/**
+ * Extract the hostname of a redirect_uri for display at the consent screen.
+ * CIMD §6 calls out localhost-redirect impersonation: a malicious client can
+ * present a `client_id` document whose redirect_uri points at the user's own
+ * machine to intercept the code. Surfacing the destination host lets the
+ * user notice an unexpected target. Returns the raw value if it can't be
+ * parsed (so the screen still shows *something* rather than hiding it).
+ */
+export function redirectHost(redirectUri: string): string {
+  try {
+    return new URL(redirectUri).host || redirectUri;
+  } catch {
+    return redirectUri;
+  }
+}
+
+/**
+ * True when the redirect_uri targets a loopback / localhost address. The
+ * consent screen warns on these because, for a client the AS never
+ * pre-registered (CIMD), a localhost redirect means the authorization code
+ * is delivered to whatever is listening on the user's own machine — a known
+ * impersonation vector (CIMD §6, "localhost-redirect impersonation").
+ */
+export function isLoopbackRedirect(redirectUri: string): boolean {
+  try {
+    const host = new URL(redirectUri).hostname.toLowerCase();
+    return LOOPBACK_HOSTS.has(host);
+  } catch {
+    return false;
+  }
+}

--- a/apps/auth-server/src/app/helpers/discovery.test.ts
+++ b/apps/auth-server/src/app/helpers/discovery.test.ts
@@ -61,6 +61,26 @@ describe('buildAuthorizationServerMetadata', () => {
     expect(meta['issuer']).toBe(ISSUER);
     expect(meta['token_endpoint']).toBe(`${ISSUER}/oauth/token`);
   });
+
+  it('advertises client_id_metadata_document_supported when CIMD is enabled (MCP 2025-11-25)', () => {
+    const meta = buildAuthorizationServerMetadata({
+      issuer: ISSUER,
+      clientIdMetadataDocumentSupported: true,
+    });
+
+    expect(meta['client_id_metadata_document_supported']).toBe(true);
+  });
+
+  it('omits the CIMD flag entirely when disabled (does not over-advertise)', () => {
+    const enabledDefault = buildAuthorizationServerMetadata({ issuer: ISSUER });
+    const explicitlyOff = buildAuthorizationServerMetadata({
+      issuer: ISSUER,
+      clientIdMetadataDocumentSupported: false,
+    });
+
+    expect('client_id_metadata_document_supported' in enabledDefault).toBe(false);
+    expect('client_id_metadata_document_supported' in explicitlyOff).toBe(false);
+  });
 });
 
 describe('buildOpenIdConfiguration', () => {
@@ -76,5 +96,14 @@ describe('buildOpenIdConfiguration', () => {
     expect(oidc['claims_supported']).toEqual(
       expect.arrayContaining(['sub', 'iss', 'aud', 'exp', 'iat', 'email', 'email_verified'])
     );
+  });
+
+  it('carries the CIMD flag into the OIDC config too (advertised on BOTH documents)', () => {
+    const oidc = buildOpenIdConfiguration({
+      issuer: ISSUER,
+      clientIdMetadataDocumentSupported: true,
+    });
+
+    expect(oidc['client_id_metadata_document_supported']).toBe(true);
   });
 });

--- a/apps/auth-server/src/app/helpers/discovery.ts
+++ b/apps/auth-server/src/app/helpers/discovery.ts
@@ -33,6 +33,14 @@ export interface DiscoveryMetadataInput {
   issuer: string;
   /** Supported scopes list; defaults to {@link DEFAULT_SCOPES_SUPPORTED}. */
   scopesSupported?: readonly string[];
+  /**
+   * Whether the server accepts Client ID Metadata Documents (CIMD) —
+   * draft-ietf-oauth-client-id-metadata-document-00 / MCP 2025-11-25.
+   * When true, `client_id_metadata_document_supported: true` is advertised
+   * so MCP clients know they can present an https-URL `client_id`. Defaults
+   * to false here; the route layer passes the env-gated value.
+   */
+  clientIdMetadataDocumentSupported?: boolean;
 }
 
 /**
@@ -72,6 +80,13 @@ export function buildAuthorizationServerMetadata(
     // RFC 8707 §3: advertise Resource Indicator support. Clients that want
     // audience-scoped tokens can rely on this metadata flag.
     resource_indicators_supported: true,
+    // CIMD (draft-ietf-oauth-client-id-metadata-document-00 / MCP
+    // 2025-11-25): advertise that an https-URL `client_id` resolves to a
+    // metadata document fetched on demand. Only emitted when enabled so a
+    // deployment that turns CIMD off does not over-advertise.
+    ...(input.clientIdMetadataDocumentSupported
+      ? { client_id_metadata_document_supported: true }
+      : {}),
   };
 }
 

--- a/apps/auth-server/src/app/helpers/ssrf-safe-fetch.test.ts
+++ b/apps/auth-server/src/app/helpers/ssrf-safe-fetch.test.ts
@@ -1,0 +1,118 @@
+import { createServer, type Server } from 'node:http';
+import { AddressInfo } from 'node:net';
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { isPublicUnicastAddress, SsrfBlockedError, ssrfSafeGet } from './ssrf-safe-fetch';
+
+describe('isPublicUnicastAddress — SSRF blocklist (CIMD §6)', () => {
+  it('blocks IPv4 loopback', () => {
+    expect(isPublicUnicastAddress('127.0.0.1')).toBe(false);
+    expect(isPublicUnicastAddress('127.255.255.254')).toBe(false);
+  });
+
+  it('blocks the cloud-metadata link-local address and the whole 169.254/16', () => {
+    expect(isPublicUnicastAddress('169.254.169.254')).toBe(false); // AWS/GCP/Azure metadata
+    expect(isPublicUnicastAddress('169.254.0.1')).toBe(false);
+  });
+
+  it('blocks RFC 1918 private ranges', () => {
+    expect(isPublicUnicastAddress('10.0.0.1')).toBe(false);
+    expect(isPublicUnicastAddress('172.16.5.4')).toBe(false);
+    expect(isPublicUnicastAddress('172.31.255.255')).toBe(false);
+    expect(isPublicUnicastAddress('192.168.1.1')).toBe(false);
+  });
+
+  it('blocks CGNAT, unspecified, multicast and reserved IPv4', () => {
+    expect(isPublicUnicastAddress('100.64.0.1')).toBe(false); // CGNAT
+    expect(isPublicUnicastAddress('0.0.0.0')).toBe(false);
+    expect(isPublicUnicastAddress('224.0.0.1')).toBe(false); // multicast
+    expect(isPublicUnicastAddress('255.255.255.255')).toBe(false);
+  });
+
+  it('blocks IPv6 loopback, link-local, unique-local, and IPv4-mapped private', () => {
+    expect(isPublicUnicastAddress('::1')).toBe(false);
+    expect(isPublicUnicastAddress('::')).toBe(false);
+    expect(isPublicUnicastAddress('fe80::1')).toBe(false); // link-local
+    expect(isPublicUnicastAddress('fd00::1')).toBe(false); // unique-local
+    expect(isPublicUnicastAddress('fd00:ec2::254')).toBe(false); // AWS IPv6 metadata
+    expect(isPublicUnicastAddress('::ffff:169.254.169.254')).toBe(false); // mapped metadata
+    expect(isPublicUnicastAddress('::ffff:10.0.0.1')).toBe(false); // mapped private
+  });
+
+  it('allows genuine public addresses', () => {
+    expect(isPublicUnicastAddress('8.8.8.8')).toBe(true);
+    expect(isPublicUnicastAddress('1.1.1.1')).toBe(true);
+    expect(isPublicUnicastAddress('203.0.113.10')).toBe(true);
+    expect(isPublicUnicastAddress('2606:4700:4700::1111')).toBe(true); // Cloudflare DNS
+  });
+
+  it('rejects non-IP input', () => {
+    expect(isPublicUnicastAddress('not-an-ip')).toBe(false);
+    expect(isPublicUnicastAddress('')).toBe(false);
+  });
+});
+
+describe('ssrfSafeGet — request-level guards', () => {
+  it('rejects non-https schemes', async () => {
+    await expect(
+      ssrfSafeGet('http://example.com/doc', { timeoutMs: 1000, maxBytes: 1024 })
+    ).rejects.toBeInstanceOf(SsrfBlockedError);
+  });
+
+  it('rejects embedded credentials in the URL', async () => {
+    await expect(
+      ssrfSafeGet('https://user:pass@example.com/doc', { timeoutMs: 1000, maxBytes: 1024 })
+    ).rejects.toBeInstanceOf(SsrfBlockedError);
+  });
+
+  it('rejects an unparseable URL', async () => {
+    await expect(
+      ssrfSafeGet('::::not a url::::', { timeoutMs: 1000, maxBytes: 1024 })
+    ).rejects.toBeInstanceOf(SsrfBlockedError);
+  });
+});
+
+describe('ssrfSafeGet — DNS/IP pinning blocks loopback targets end-to-end', () => {
+  let server: Server;
+  let port: number;
+
+  beforeAll(async () => {
+    server = createServer((_req, res) => {
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ secret: 'should-never-be-reachable' }));
+    });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    port = (server.address() as AddressInfo).port;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  it('refuses to connect to a 127.0.0.1 target (the SSRF primitive)', async () => {
+    // Even though the target is reachable over plain http on loopback, the
+    // https-only + IP-guard combination must refuse it. We point at https on
+    // the loopback IP: the IP guard fires before any TLS handshake.
+    await expect(
+      ssrfSafeGet(`https://127.0.0.1:${port}/cimd.json`, {
+        timeoutMs: 1500,
+        maxBytes: 4096,
+      })
+    ).rejects.toBeInstanceOf(SsrfBlockedError);
+  });
+
+  it('can be opted into private addresses for local fixtures only', async () => {
+    // With allowPrivateAddresses the IP guard is skipped; the request now
+    // fails at the TLS layer instead of the SSRF guard (the fixture is plain
+    // http), proving the guard — not a network error — is what blocked it
+    // above. Either way it is NOT an SsrfBlockedError here.
+    await expect(
+      ssrfSafeGet(`https://127.0.0.1:${port}/cimd.json`, {
+        timeoutMs: 1500,
+        maxBytes: 4096,
+        allowPrivateAddresses: true,
+      })
+    ).rejects.not.toBeInstanceOf(SsrfBlockedError);
+  });
+});

--- a/apps/auth-server/src/app/helpers/ssrf-safe-fetch.test.ts
+++ b/apps/auth-server/src/app/helpers/ssrf-safe-fetch.test.ts
@@ -40,6 +40,37 @@ describe('isPublicUnicastAddress — SSRF blocklist (CIMD §6)', () => {
     expect(isPublicUnicastAddress('::ffff:10.0.0.1')).toBe(false); // mapped private
   });
 
+  // Regression: the IPv4-mapped check previously only matched the
+  // dot-decimal text form (::ffff:127.0.0.1). The pure-hex form of the SAME
+  // address (::ffff:7f00:1) bypassed every range check (its first hextet is
+  // 0) and was wrongly classified public — a loopback/RFC1918 SSRF bypass.
+  // Both notations must now normalise to the same embedded v4 and be blocked.
+  it('blocks the HEX form of IPv4-mapped private/loopback addresses (SSRF bypass)', () => {
+    expect(isPublicUnicastAddress('::ffff:7f00:1')).toBe(false); // == 127.0.0.1
+    expect(isPublicUnicastAddress('::ffff:7f00:0001')).toBe(false); // == 127.0.0.1
+    expect(isPublicUnicastAddress('::ffff:a9fe:a9fe')).toBe(false); // == 169.254.169.254 metadata
+    expect(isPublicUnicastAddress('::ffff:a00:1')).toBe(false); // == 10.0.0.1
+    expect(isPublicUnicastAddress('::ffff:c0a8:101')).toBe(false); // == 192.168.1.1
+    expect(isPublicUnicastAddress('::ffff:ac10:5')).toBe(false); // == 172.16.0.5
+    // Fully-expanded hex notation of the same mapped loopback address.
+    expect(isPublicUnicastAddress('0:0:0:0:0:ffff:7f00:1')).toBe(false);
+  });
+
+  // IPv4-compatible (::a.b.c.d) addresses embed a v4 address under an all-zero
+  // /96 prefix; the hex form (::7f00:1) must be blocked the same way.
+  it('blocks IPv4-compatible addresses embedding private/loopback v4 (hex + dotted)', () => {
+    expect(isPublicUnicastAddress('::7f00:1')).toBe(false); // == 127.0.0.1
+    expect(isPublicUnicastAddress('::a9fe:a9fe')).toBe(false); // == 169.254.169.254 metadata
+    expect(isPublicUnicastAddress('::a00:1')).toBe(false); // == 10.0.0.1
+  });
+
+  // Guard against over-blocking: a genuine public IPv6 must NOT be mistaken
+  // for an embedded-v4 form (its /96 prefix is neither ::ffff:0:0 nor ::).
+  it('still allows genuine public IPv6 that is not an embedded-v4 form', () => {
+    expect(isPublicUnicastAddress('2606:4700:4700::1111')).toBe(true); // Cloudflare
+    expect(isPublicUnicastAddress('2001:4860:4860::8888')).toBe(true); // Google DNS
+  });
+
   it('allows genuine public addresses', () => {
     expect(isPublicUnicastAddress('8.8.8.8')).toBe(true);
     expect(isPublicUnicastAddress('1.1.1.1')).toBe(true);

--- a/apps/auth-server/src/app/helpers/ssrf-safe-fetch.ts
+++ b/apps/auth-server/src/app/helpers/ssrf-safe-fetch.ts
@@ -141,16 +141,59 @@ function isPublicIpv4(ip: string): boolean {
   return true;
 }
 
+/**
+ * Extract the embedded IPv4 address from a fully-expanded (8-hextet) IPv6
+ * literal when it is an IPv4-mapped (`::ffff:a.b.c.d`) or IPv4-compatible
+ * (`::a.b.c.d`) address, in EITHER notation:
+ *
+ *   ::ffff:127.0.0.1  → expandIpv6 → 0:0:0:0:0:ffff:7f00:1
+ *   ::ffff:7f00:1     → expandIpv6 → 0:0:0:0:0:ffff:7f00:1   (same form)
+ *
+ * Both collapse to the same hextet sequence, so working off the expanded form
+ * normalises the two notations and closes the hex-form SSRF bypass. Returns
+ * the dotted-quad string (e.g. `"127.0.0.1"`) or `null` when the address is
+ * not an embedded-v4 form.
+ *
+ * Only the well-known prefixes `::ffff:0:0/96` (mapped) and `::/96`
+ * (compatible) carry an embedded v4 address; any other prefix is a native
+ * IPv6 address whose trailing hextets are NOT a v4 address.
+ */
+function extractEmbeddedIpv4(expanded: string): string | null {
+  const parts = expanded.split(':');
+  if (parts.length !== 8) return null;
+
+  const prefix = parts.slice(0, 6).join(':');
+  const isMapped = prefix === '0:0:0:0:0:ffff';
+  const isCompatible = prefix === '0:0:0:0:0:0';
+  if (!isMapped && !isCompatible) return null;
+
+  const high = Number.parseInt(parts[6], 16);
+  const low = Number.parseInt(parts[7], 16);
+  if (!Number.isFinite(high) || !Number.isFinite(low)) return null;
+  if (high < 0 || high > 0xffff || low < 0 || low > 0xffff) return null;
+
+  return `${high >> 8}.${high & 0xff}.${low >> 8}.${low & 0xff}`;
+}
+
 function isPublicIpv6(ip: string): boolean {
   const expanded = expandIpv6(ip);
 
   // Unspecified (::) and loopback (::1).
   if (expanded === '0:0:0:0:0:0:0:0' || expanded === '0:0:0:0:0:0:0:1') return false;
 
-  // IPv4-mapped (::ffff:a.b.c.d) and IPv4-compatible — re-check the embedded
-  // v4 address so `::ffff:169.254.169.254` cannot slip through.
-  const mapped = ip.toLowerCase().match(/::ffff:(\d+\.\d+\.\d+\.\d+)$/);
-  if (mapped) return isPublicIpv4(mapped[1]);
+  // IPv4-mapped (::ffff:a.b.c.d) and IPv4-compatible (::a.b.c.d) — re-check
+  // the embedded v4 address so `::ffff:169.254.169.254` cannot slip through.
+  //
+  // CRITICAL: this must catch BOTH notations of the embedded address:
+  //   - dot-decimal  ::ffff:127.0.0.1
+  //   - pure hex     ::ffff:7f00:1   (== 127.0.0.1)
+  // Matching only the dot-decimal text form lets the hex form bypass every
+  // check below (its `firstHextet` is 0), enabling loopback/RFC1918 SSRF.
+  // We therefore work off the fully-expanded 8-hextet form, which normalises
+  // both notations identically (expandIpv6 collapses `::ffff:7f00:1` and
+  // `::ffff:127.0.0.1` to the same `0:0:0:0:0:ffff:7f00:1`).
+  const embeddedIpv4 = extractEmbeddedIpv4(expanded);
+  if (embeddedIpv4 !== null) return isPublicIpv4(embeddedIpv4);
 
   const firstHextet = Number.parseInt(expanded.split(':')[0] || '0', 16);
   // fe80::/10 — link-local. (fe80–febf)

--- a/apps/auth-server/src/app/helpers/ssrf-safe-fetch.ts
+++ b/apps/auth-server/src/app/helpers/ssrf-safe-fetch.ts
@@ -1,0 +1,319 @@
+import type { LookupAddress } from 'node:dns';
+import { lookup as dnsLookup } from 'node:dns';
+import { request as httpsRequest } from 'node:https';
+import { isIP } from 'node:net';
+
+/**
+ * SSRF-safe HTTPS fetcher (CIMD §6 / OWASP API7 / OWASP A?:2025 SSRF).
+ *
+ * A `client_id` in CIMD is a fully attacker-controlled URL that the
+ * authorization server fetches on demand. Without hardening this is a
+ * textbook SSRF primitive: an attacker registers
+ * `client_id=https://169.254.169.254/latest/meta-data/...` (or a name that
+ * resolves to a loopback / RFC 1918 address) and the AS happily proxies the
+ * request into the deployment's private network or cloud metadata service.
+ *
+ * Defenses layered here (defense-in-depth):
+ *   1. **Scheme allowlist** — https only. http/file/gopher/data rejected.
+ *   2. **No credentials / non-default surprises** — userinfo (`user:pass@`)
+ *      in the URL is rejected.
+ *   3. **DNS-pinned IP validation that is TOCTOU-safe.** We do NOT resolve
+ *      the host, validate, and then let the HTTP client resolve again
+ *      (classic DNS-rebinding window). Instead we hand `node:https` a custom
+ *      `lookup` callback. The IP that callback returns is the exact IP the
+ *      socket connects to, and we validate it inside the callback — so the
+ *      address that is checked and the address that is dialed are guaranteed
+ *      identical. Every A/AAAA record is checked; if any is non-public the
+ *      whole connection is refused.
+ *   4. **No redirect following.** A 3xx is surfaced as an error, never
+ *      transparently followed — otherwise the upstream could 302 us to
+ *      `http://169.254.169.254` and bypass every check above.
+ *   5. **Response size + time bounds.** A slow-loris or multi-GB body can't
+ *      exhaust the server.
+ *
+ * The blocklist covers the ranges CIMD §6 and the SSRF literature call out:
+ * loopback, link-local (incl. the 169.254.169.254 cloud-metadata address and
+ * its IPv6 fd00:ec2 equivalent), private/RFC1918, CGNAT, IPv4-mapped IPv6,
+ * unique-local IPv6, and unspecified addresses.
+ */
+
+export interface SsrfSafeFetchOptions {
+  /** Per-request timeout in milliseconds. */
+  timeoutMs: number;
+  /** Maximum response body size in bytes. */
+  maxBytes: number;
+  /**
+   * Escape hatch for local dev/integration fixtures only. When true the
+   * private/loopback/link-local IP checks are skipped. MUST be false in
+   * production — it removes the core SSRF guard.
+   */
+  allowPrivateAddresses?: boolean;
+}
+
+export interface SsrfSafeFetchResult {
+  status: number;
+  body: string;
+  /** Lower-cased header map (single value per header; last wins). */
+  headers: Record<string, string>;
+}
+
+/**
+ * Reason a fetch was refused. `ssrf_blocked` specifically flags a target
+ * that resolved to a disallowed address so callers can audit-log it
+ * distinctly from a generic network failure.
+ */
+export class SsrfBlockedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'SsrfBlockedError';
+    Object.setPrototypeOf(this, SsrfBlockedError.prototype);
+  }
+}
+
+export class SsrfFetchError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'SsrfFetchError';
+    Object.setPrototypeOf(this, SsrfFetchError.prototype);
+  }
+}
+
+/**
+ * Normalise an IPv6 address to a comparable lower-case form by expanding
+ * `::`. We only need enough fidelity to range-check, so a light expansion
+ * is sufficient.
+ */
+function expandIpv6(addr: string): string {
+  let a = addr.toLowerCase();
+  // Strip zone id (e.g. fe80::1%eth0).
+  const pct = a.indexOf('%');
+  if (pct !== -1) a = a.slice(0, pct);
+  if (!a.includes('::')) return a;
+  const [head, tail] = a.split('::');
+  const headParts = head ? head.split(':') : [];
+  const tailParts = tail ? tail.split(':') : [];
+  const missing = 8 - headParts.length - tailParts.length;
+  const middle = Array.from({ length: Math.max(missing, 0) }, () => '0');
+  return [...headParts, ...middle, ...tailParts].map((p) => p || '0').join(':');
+}
+
+/**
+ * True when `ip` (an already-resolved literal, family 4 or 6) is a public,
+ * routable unicast address safe to connect to. Returns false for loopback,
+ * private, link-local, CGNAT, multicast, reserved, and cloud-metadata
+ * ranges.
+ */
+export function isPublicUnicastAddress(ip: string): boolean {
+  const family = isIP(ip);
+  if (family === 4) return isPublicIpv4(ip);
+  if (family === 6) return isPublicIpv6(ip);
+  return false;
+}
+
+function isPublicIpv4(ip: string): boolean {
+  const octets = ip.split('.').map((o) => Number.parseInt(o, 10));
+  if (octets.length !== 4 || octets.some((o) => Number.isNaN(o) || o < 0 || o > 255)) {
+    return false;
+  }
+  const [a, b] = octets;
+
+  // 0.0.0.0/8 — "this network" / unspecified.
+  if (a === 0) return false;
+  // 10.0.0.0/8 — private.
+  if (a === 10) return false;
+  // 127.0.0.0/8 — loopback.
+  if (a === 127) return false;
+  // 169.254.0.0/16 — link-local (incl. 169.254.169.254 cloud metadata).
+  if (a === 169 && b === 254) return false;
+  // 172.16.0.0/12 — private.
+  if (a === 172 && b >= 16 && b <= 31) return false;
+  // 192.168.0.0/16 — private.
+  if (a === 192 && b === 168) return false;
+  // 100.64.0.0/10 — CGNAT (RFC 6598).
+  if (a === 100 && b >= 64 && b <= 127) return false;
+  // 192.0.0.0/24 — IETF protocol assignments.
+  if (a === 192 && b === 0 && octets[2] === 0) return false;
+  // 198.18.0.0/15 — benchmarking.
+  if (a === 198 && (b === 18 || b === 19)) return false;
+  // 224.0.0.0/4 — multicast; 240.0.0.0/4 — reserved / broadcast.
+  if (a >= 224) return false;
+
+  return true;
+}
+
+function isPublicIpv6(ip: string): boolean {
+  const expanded = expandIpv6(ip);
+
+  // Unspecified (::) and loopback (::1).
+  if (expanded === '0:0:0:0:0:0:0:0' || expanded === '0:0:0:0:0:0:0:1') return false;
+
+  // IPv4-mapped (::ffff:a.b.c.d) and IPv4-compatible — re-check the embedded
+  // v4 address so `::ffff:169.254.169.254` cannot slip through.
+  const mapped = ip.toLowerCase().match(/::ffff:(\d+\.\d+\.\d+\.\d+)$/);
+  if (mapped) return isPublicIpv4(mapped[1]);
+
+  const firstHextet = Number.parseInt(expanded.split(':')[0] || '0', 16);
+  // fe80::/10 — link-local. (fe80–febf)
+  if (firstHextet >= 0xfe80 && firstHextet <= 0xfebf) return false;
+  // fc00::/7 — unique-local (fc00–fdff), incl. AWS fd00:ec2 metadata.
+  if (firstHextet >= 0xfc00 && firstHextet <= 0xfdff) return false;
+  // ff00::/8 — multicast.
+  if (firstHextet >= 0xff00) return false;
+
+  return true;
+}
+
+/**
+ * Perform an SSRF-guarded HTTPS GET. Resolves with status/headers/body on a
+ * completed (non-redirect) response; rejects with {@link SsrfBlockedError}
+ * for a disallowed target or {@link SsrfFetchError} for any other failure.
+ */
+export function ssrfSafeGet(
+  targetUrl: string,
+  options: SsrfSafeFetchOptions
+): Promise<SsrfSafeFetchResult> {
+  return new Promise((resolve, reject) => {
+    let parsed: URL;
+    try {
+      parsed = new URL(targetUrl);
+    } catch {
+      reject(new SsrfBlockedError('client_id is not a valid URL'));
+      return;
+    }
+
+    if (parsed.protocol !== 'https:') {
+      reject(new SsrfBlockedError('CIMD client_id must use the https scheme'));
+      return;
+    }
+    if (parsed.username || parsed.password) {
+      reject(new SsrfBlockedError('CIMD client_id must not embed credentials'));
+      return;
+    }
+
+    const allowPrivate = options.allowPrivateAddresses === true;
+
+    // When the URL host is itself an IP literal, node's connector dials it
+    // directly and never invokes the `lookup` hook below — so validate it
+    // here. (`URL.hostname` wraps IPv6 in brackets; strip them for isIP.)
+    const literalHost = parsed.hostname.replace(/^\[|\]$/g, '');
+    if (isIP(literalHost) && !allowPrivate && !isPublicUnicastAddress(literalHost)) {
+      reject(new SsrfBlockedError(`CIMD host is a non-public address (${literalHost})`));
+      return;
+    }
+
+    // Custom lookup: validate the resolved IP *and* hand the same IP to the
+    // socket. This is the TOCTOU-safe boundary — node never re-resolves.
+    //
+    // We always resolve every A/AAAA record ourselves and validate the whole
+    // set, then answer in the shape node's caller requested (`opts.all`
+    // toggles single-address vs array). The address(es) node ultimately
+    // dials are exactly the ones we validated, so there is no rebinding gap.
+    const guardedLookup = ((
+      hostname: string,
+      opts: { all?: boolean } | undefined,
+      cb: (
+        err: NodeJS.ErrnoException | null,
+        address: string | LookupAddress[],
+        family?: number
+      ) => void
+    ) => {
+      const wantsAll = typeof opts === 'object' && opts?.all === true;
+
+      const handle = (err: NodeJS.ErrnoException | null, addresses: LookupAddress[]) => {
+        if (err) {
+          cb(err, '', 0);
+          return;
+        }
+        if (!addresses || addresses.length === 0) {
+          cb(new Error('no addresses resolved'), '', 0);
+          return;
+        }
+        for (const a of addresses) {
+          if (!allowPrivate && !isPublicUnicastAddress(a.address)) {
+            cb(
+              new SsrfBlockedError(`CIMD host resolves to a non-public address (${a.address})`),
+              '',
+              0
+            );
+            return;
+          }
+        }
+        if (wantsAll) {
+          cb(null, addresses);
+        } else {
+          cb(null, addresses[0].address, addresses[0].family);
+        }
+      };
+
+      // IP literal: validate directly, no DNS round-trip.
+      const literalFamily = isIP(hostname);
+      if (literalFamily) {
+        handle(null, [{ address: hostname, family: literalFamily }]);
+        return;
+      }
+      dnsLookup(hostname, { all: true }, (err, addresses) =>
+        handle(err, addresses as LookupAddress[])
+      );
+    }) as unknown as typeof dnsLookup;
+
+    const req = httpsRequest(
+      parsed,
+      {
+        method: 'GET',
+        lookup: guardedLookup,
+        headers: {
+          accept: 'application/json',
+          'user-agent': 'qauth-cimd-resolver',
+        },
+        // `all: true` is required so our lookup callback receives every record.
+        // Node passes lookup options through from here.
+      },
+      (res) => {
+        const status = res.statusCode ?? 0;
+
+        // Never follow redirects — a 3xx Location could point at an internal
+        // address and bypass the IP guard.
+        if (status >= 300 && status < 400) {
+          res.destroy();
+          reject(new SsrfBlockedError(`CIMD fetch returned redirect (${status}); not followed`));
+          return;
+        }
+
+        const headers: Record<string, string> = {};
+        for (const [k, v] of Object.entries(res.headers)) {
+          if (v === undefined) continue;
+          headers[k.toLowerCase()] = Array.isArray(v) ? v.join(', ') : v;
+        }
+
+        let received = 0;
+        const chunks: Buffer[] = [];
+        res.on('data', (chunk: Buffer) => {
+          received += chunk.length;
+          if (received > options.maxBytes) {
+            res.destroy();
+            reject(new SsrfFetchError('CIMD document exceeds maximum allowed size'));
+            return;
+          }
+          chunks.push(chunk);
+        });
+        res.on('end', () => {
+          resolve({ status, body: Buffer.concat(chunks).toString('utf8'), headers });
+        });
+        res.on('error', (err) => reject(new SsrfFetchError(err.message)));
+      }
+    );
+
+    req.setTimeout(options.timeoutMs, () => {
+      req.destroy();
+      reject(new SsrfFetchError('CIMD fetch timed out'));
+    });
+    req.on('error', (err) => {
+      if (err instanceof SsrfBlockedError) {
+        reject(err);
+        return;
+      }
+      reject(new SsrfFetchError(err.message));
+    });
+    req.end();
+  });
+}

--- a/apps/auth-server/src/app/routes/oauth/authorize.test.ts
+++ b/apps/auth-server/src/app/routes/oauth/authorize.test.ts
@@ -1,6 +1,8 @@
 import type { FastifyInstance } from 'fastify';
 import { describe, expect, it, type Mock, vi } from 'vitest';
 
+const { ssrfSafeGet } = vi.hoisted(() => ({ ssrfSafeGet: vi.fn() }));
+
 vi.mock('../../../config/env', () => ({
   env: {
     AUTHORIZE_RATE_LIMIT: 60,
@@ -11,8 +13,25 @@ vi.mock('../../../config/env', () => ({
     SESSION_COOKIE_TTL: 3600,
     SESSION_COOKIE_SECURE: false,
     DYNAMIC_CLIENT_BADGE_DAYS: 30,
+    // CIMD config (consumed transitively via client-resolution → cimd).
+    CIMD_ENABLED: true,
+    CIMD_TRUST_POLICY: 'accept-any-https',
+    CIMD_TRUSTED_DOMAINS: [],
+    CIMD_CACHE_DEFAULT_TTL: 300,
+    CIMD_CACHE_MAX_TTL: 3600,
+    CIMD_MAX_DOCUMENT_BYTES: 65536,
+    CIMD_FETCH_TIMEOUT_MS: 5000,
+    CIMD_ALLOW_PRIVATE_ADDRESSES: false,
   },
 }));
+
+// Mock only the network layer so CIMD resolution runs against a fixture doc.
+vi.mock('../../helpers/ssrf-safe-fetch', async () => {
+  const actual = await vi.importActual<typeof import('../../helpers/ssrf-safe-fetch')>(
+    '../../helpers/ssrf-safe-fetch'
+  );
+  return { ...actual, ssrfSafeGet };
+});
 
 import authorizeRoute from './authorize';
 
@@ -316,5 +335,126 @@ describe('GET /oauth/authorize — session-cookie integration', () => {
       'https://api.example.com/v1',
       'https://api2.example.com/v1',
     ]);
+  });
+});
+
+describe('GET /oauth/authorize — CIMD (Client ID Metadata Documents)', () => {
+  const CIMD_ID = 'https://app.example.com/client-metadata.json';
+
+  function cimdDoc(redirectUris: string[]) {
+    return {
+      status: 200,
+      body: JSON.stringify({
+        client_id: CIMD_ID,
+        client_name: 'MCP Client',
+        redirect_uris: redirectUris,
+      }),
+      headers: { 'cache-control': 'max-age=600' },
+    };
+  }
+
+  function makeCimdFastify() {
+    const ctx: { handler?: (req: any, reply: any) => Promise<unknown> } = {};
+    const store = new Map<string, string>();
+    const fastify: any = {
+      withTypeProvider: () => ({
+        get: (_url: string, _opts: unknown, handler: any) => {
+          ctx.handler = handler;
+          return fastify;
+        },
+      }),
+      redis: {
+        get: vi.fn(async (k: string) => store.get(k) ?? null),
+        set: vi.fn(async (k: string, v: string) => {
+          store.set(k, v);
+          return 'OK';
+        }),
+      },
+      passwordHasher: { hashPassword: vi.fn(async () => 'argon2id$sentinel') },
+      repositories: {
+        realms: {
+          findByName: vi.fn().mockResolvedValue({ id: 'realm-1', name: 'master', enabled: true }),
+          create: vi.fn(),
+        },
+        oauthClients: {
+          // No pre-registered row → falls through to CIMD resolution.
+          findByClientId: vi.fn().mockResolvedValue(undefined),
+          upsertCimdClient: vi.fn(async (row: any) => ({
+            ...row,
+            id: '22222222-2222-2222-2222-222222222222',
+            audience: null,
+            dynamicRegisteredAt: null,
+          })),
+        },
+        oauthConsents: { findActive: vi.fn() },
+        authorizationCodes: { create: vi.fn().mockResolvedValue({ id: 'code-1' }) },
+        auditLogs: { create: vi.fn().mockResolvedValue(undefined) },
+      },
+      jwtUtils: { extractFromHeader: vi.fn(), verifyAccessToken: vi.fn() },
+      sessionUtils: { getSession: vi.fn() },
+      log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    };
+    return { fastify: fastify as FastifyInstance, ctx };
+  }
+
+  it('rejects when redirect_uri is not in the CIMD document (mismatch)', async () => {
+    ssrfSafeGet.mockReset();
+    ssrfSafeGet.mockResolvedValue(cimdDoc(['https://app.example.com/other-cb']));
+
+    const { fastify, ctx } = makeCimdFastify();
+    await authorizeRoute(fastify);
+
+    const { reply } = createReply();
+    await expect(
+      ctx.handler!(
+        {
+          query: {
+            response_type: 'code',
+            client_id: CIMD_ID,
+            redirect_uri: 'https://app.example.com/callback', // not in the doc
+            code_challenge: 'A'.repeat(43),
+            code_challenge_method: 'S256',
+            state: 'xyz',
+          },
+          url: `/oauth/authorize?response_type=code&client_id=${encodeURIComponent(CIMD_ID)}`,
+          headers: {},
+          ip: '127.0.0.1',
+        },
+        reply
+      )
+    ).rejects.toThrow(/redirect_uri/);
+  });
+
+  it('happy path: resolves CIMD client, materialises it, and proceeds to login/consent', async () => {
+    ssrfSafeGet.mockReset();
+    ssrfSafeGet.mockResolvedValue(cimdDoc(['https://app.example.com/callback']));
+
+    const { fastify, ctx } = makeCimdFastify();
+    await authorizeRoute(fastify);
+    (fastify.jwtUtils.extractFromHeader as unknown as Mock).mockReturnValue(null);
+    (fastify.sessionUtils.getSession as unknown as Mock).mockResolvedValue(null);
+
+    const { reply, state } = createReply();
+    await ctx.handler!(
+      {
+        query: {
+          response_type: 'code',
+          client_id: CIMD_ID,
+          redirect_uri: 'https://app.example.com/callback', // in the doc
+          code_challenge: 'A'.repeat(43),
+          code_challenge_method: 'S256',
+          state: 'xyz',
+        },
+        url: `/oauth/authorize?response_type=code&client_id=${encodeURIComponent(CIMD_ID)}`,
+        headers: {},
+        ip: '127.0.0.1',
+      },
+      reply
+    );
+
+    // The redirect_uri matched the document → resolution + materialisation
+    // succeeded, and with no session the flow proceeds to login.
+    expect(fastify.repositories.oauthClients.upsertCimdClient).toHaveBeenCalledOnce();
+    expect(state.redirected).toContain('/ui/login?return_to=');
   });
 });

--- a/apps/auth-server/src/app/routes/oauth/authorize.ts
+++ b/apps/auth-server/src/app/routes/oauth/authorize.ts
@@ -8,6 +8,7 @@ import { env } from '../../../config/env';
 import { AUTHORIZATION_CODE_TTL_MS } from '../../constants';
 import { resolveBrowserSession } from '../../helpers/browser-session';
 import { resolveAudience } from '../../helpers/client-auth';
+import { resolveClient } from '../../helpers/client-resolution';
 import { canSkipConsent, filterRequestedScopes } from '../../helpers/consent';
 import { getOrCreateSystemClient } from '../../helpers/oauth-client';
 import { buildRedirectUrl } from '../../helpers/oauth-redirect';
@@ -75,10 +76,12 @@ export default async function (fastify: FastifyInstance) {
 
       const realm = await getOrCreateDefaultRealm(fastify);
 
-      const client = await fastify.repositories.oauthClients.findByClientId(
-        realm.id,
-        query.client_id
-      );
+      // Client resolution priority (MCP 2025-11-25): pre-registered (DB) →
+      // CIMD (https-URL client_id, fetched + SSRF-guarded + validated, then
+      // idempotently materialised as a row) → unknown. A resolved CIMD
+      // client is a real persisted row, so the existing audit / auth-code /
+      // refresh-token foreign keys work unchanged. See client-resolution.ts.
+      const { client, reason } = await resolveClient(fastify, realm.id, query.client_id);
 
       if (!client) {
         await fastify.repositories.auditLogs.create({
@@ -89,11 +92,15 @@ export default async function (fastify: FastifyInstance) {
           success: false,
           ipAddress: request.ip,
           userAgent: request.headers['user-agent'] || null,
-          metadata: { error: 'invalid_client', client_id: query.client_id },
+          metadata: { error: reason ?? 'invalid_client', client_id: query.client_id },
         });
         throw new BadRequestError('invalid_client');
       }
 
+      // CIMD §: the authorization request's redirect_uri MUST exactly match
+      // one of the document's redirect_uris (this list came from the
+      // metadata document for a CIMD client, or the registered set for a
+      // pre-registered one). No wildcards.
       if (!client.redirectUris.includes(redirectUri)) {
         await fastify.repositories.auditLogs.create({
           userId: null,

--- a/apps/auth-server/src/app/routes/ui/consent.ts
+++ b/apps/auth-server/src/app/routes/ui/consent.ts
@@ -8,11 +8,14 @@ import { z } from 'zod';
 import { env } from '../../../config/env';
 import { AUTHORIZATION_CODE_TTL_MS } from '../../constants';
 import { resolveBrowserSession } from '../../helpers/browser-session';
+import { resolveClient } from '../../helpers/client-resolution';
 import {
   canSkipConsent,
   describeScope,
   filterRequestedScopes,
   isDynamicClientWithinBadgeWindow,
+  isLoopbackRedirect,
+  redirectHost,
 } from '../../helpers/consent';
 import { html, render, safe } from '../../helpers/html';
 import { buildRedirectUrl } from '../../helpers/oauth-redirect';
@@ -72,10 +75,19 @@ const consentFormSchema = z.object({
 
 type ConsentForm = z.infer<typeof consentFormSchema>;
 
-function buildAuthorizeUrl(query: Record<string, string | undefined>): string {
+function buildAuthorizeUrl(query: Record<string, string | string[] | undefined>): string {
   const u = new URL('/oauth/authorize', 'http://placeholder');
   for (const [k, v] of Object.entries(query)) {
-    if (v != null && v !== '') u.searchParams.set(k, v);
+    if (v == null) continue;
+    // RFC 8707: `resource` may be multi-valued — append one param per entry
+    // so every requested resource survives the login round-trip.
+    if (Array.isArray(v)) {
+      for (const entry of v) {
+        if (entry !== '') u.searchParams.append(k, entry);
+      }
+    } else if (v !== '') {
+      u.searchParams.set(k, v);
+    }
   }
   // Return only the path + query portion; login's return_to rejects absolute.
   return `${u.pathname}?${u.searchParams.toString()}`;
@@ -92,6 +104,12 @@ function consentPage(opts: {
   /** RFC 8707 resource indicators — emitted as one hidden input per URI. */
   resources: string[];
   userEmail: string;
+  /** Host portion of the redirect_uri, shown so the user can sanity-check the destination. */
+  redirectHost: string;
+  /** True when the redirect targets loopback/localhost (CIMD §6 impersonation warning). */
+  redirectIsLoopback: boolean;
+  /** True for CIMD-resolved clients (no operator pre-registration). */
+  isCimd: boolean;
 }): string {
   const scopeRows = opts.scopes.length
     ? opts.scopes.map((s) => html`<li><code>${s}</code> — ${describeScope(s)}</li>`)
@@ -107,6 +125,21 @@ function consentPage(opts: {
   const audienceBlock = opts.audience.length
     ? html`<p><strong>Tokens will be valid for:</strong> ${opts.audience.join(', ')}</p>`
     : safe('');
+
+  // CIMD §6: always show where the authorization code will be sent, and warn
+  // when that destination is the user's own machine (localhost) for a client
+  // the operator never pre-registered.
+  const redirectBlock = html`<p class="redirect">
+    <strong>You will be redirected to:</strong> <code>${opts.redirectHost}</code>
+  </p>`;
+
+  const loopbackWarning =
+    opts.redirectIsLoopback && opts.isCimd
+      ? html`<div class="warn">
+          This app will receive your authorization code on <code>${opts.redirectHost}</code>
+          (your own device). Only continue if you started this sign-in yourself.
+        </div>`
+      : safe('');
 
   const badge = opts.badgeDynamic
     ? html`<div class="badge">
@@ -183,6 +216,19 @@ function consentPage(opts: {
               margin: 16px 0;
               font-size: 13px;
             }
+            .warn {
+              background: #fdecea;
+              color: #8a1c12;
+              border: 1px solid #f1a59c;
+              border-radius: 6px;
+              padding: 10px 12px;
+              margin: 16px 0;
+              font-size: 13px;
+            }
+            .redirect {
+              font-size: 13px;
+              color: #374151;
+            }
             .actions {
               display: flex;
               gap: 12px;
@@ -224,12 +270,12 @@ function consentPage(opts: {
             <h1>${opts.clientName} wants to access your account</h1>
             ${homepage}
             <p class="as-user">Signed in as ${opts.userEmail}</p>
-            ${badge}
+            ${badge} ${loopbackWarning}
             <p><strong>Requested access:</strong></p>
             <ul class="scopes">
               ${scopeRows}
             </ul>
-            ${audienceBlock}
+            ${audienceBlock} ${redirectBlock}
             <label class="forever">
               <input type="checkbox" name="allow_forever" value="1" checked />
               Remember this decision
@@ -272,16 +318,20 @@ export default async function (fastify: FastifyInstance) {
       }
 
       const realm = await getOrCreateDefaultRealm(fastify);
-      const client = await fastify.repositories.oauthClients.findByClientId(
-        realm.id,
-        query.client_id
-      );
+      // Pre-registered → CIMD resolution (a CIMD client reaching consent was
+      // already materialised by /oauth/authorize, so findByClientId inside
+      // resolveClient hits it; if its document cache expired it is re-fetched
+      // and re-validated here).
+      const { client } = await resolveClient(fastify, realm.id, query.client_id);
       if (!client || !client.enabled) {
         throw new BadRequestError('invalid_client');
       }
       if (!client.redirectUris.includes(query.redirect_uri)) {
         throw new BadRequestError('redirect_uri not registered');
       }
+
+      const isCimd =
+        (client.metadata as Record<string, unknown> | null)?.registrationType === 'cimd';
 
       const scopes = filterRequestedScopes(query.scope, client);
 
@@ -334,6 +384,9 @@ export default async function (fastify: FastifyInstance) {
           // carries every requested resource URI back to the handler.
           resources: parseResourceFromUrl(request.url),
           userEmail: session.email,
+          redirectHost: redirectHost(query.redirect_uri),
+          redirectIsLoopback: isLoopbackRedirect(query.redirect_uri),
+          isCimd,
         })
       );
     }
@@ -405,10 +458,7 @@ export default async function (fastify: FastifyInstance) {
       );
 
       const realm = await getOrCreateDefaultRealm(fastify);
-      const client = await fastify.repositories.oauthClients.findByClientId(
-        realm.id,
-        body.client_id
-      );
+      const { client } = await resolveClient(fastify, realm.id, body.client_id);
       if (!client || !client.enabled) {
         throw new BadRequestError('invalid_client');
       }

--- a/apps/auth-server/src/app/routes/well-known.ts
+++ b/apps/auth-server/src/app/routes/well-known.ts
@@ -1,5 +1,6 @@
 import type { FastifyInstance } from 'fastify';
 
+import { env } from '../../config/env';
 import { buildAuthorizationServerMetadata, buildOpenIdConfiguration } from '../helpers/discovery';
 
 /**
@@ -22,7 +23,11 @@ const DISCOVERY_CACHE_CONTROL = 'public, max-age=3600';
  * during bootstrap and cache responses locally.
  */
 export default async function (fastify: FastifyInstance) {
-  const buildInput = () => ({ issuer: fastify.jwtUtils.getIssuer() });
+  const buildInput = () => ({
+    issuer: fastify.jwtUtils.getIssuer(),
+    // CIMD (MCP 2025-11-25): advertise on BOTH AS metadata and OIDC config.
+    clientIdMetadataDocumentSupported: env.CIMD_ENABLED,
+  });
 
   fastify.get(
     '/.well-known/oauth-authorization-server',

--- a/libs/infra/db/src/lib/repositories/oauth-clients.repository.ts
+++ b/libs/infra/db/src/lib/repositories/oauth-clients.repository.ts
@@ -103,6 +103,39 @@ export function createOAuthClientsRepository(defaultDb: DbClient): OAuthClientsR
     },
 
     /**
+     * Idempotently materialise a CIMD client keyed by (realm_id, client_id).
+     *
+     * Uses a single INSERT ... ON CONFLICT so concurrent authorize requests
+     * for the same metadata-document client_id collapse onto one row instead
+     * of racing on a find-then-create. On conflict we refresh only the
+     * document-derived fields (name / redirect_uris / grant+response types)
+     * and bump `updatedAt`; identity columns and the secret sentinel are
+     * left as-is.
+     */
+    async upsertCimdClient(data: NewOAuthClient, tx?: DbClient): Promise<OAuthClient> {
+      const invoker = tx ?? defaultDb;
+      const [client] = await invoker
+        .insert(oauthClients)
+        .values(data)
+        .onConflictDoUpdate({
+          target: [oauthClients.realmId, oauthClients.clientId],
+          set: {
+            name: data.name,
+            description: data.description,
+            redirectUris: data.redirectUris,
+            grantTypes: data.grantTypes,
+            responseTypes: data.responseTypes,
+            tokenEndpointAuthMethod: data.tokenEndpointAuthMethod,
+            metadata: data.metadata,
+            enabled: data.enabled,
+            updatedAt: Date.now(),
+          },
+        })
+        .returning();
+      return client;
+    },
+
+    /**
      * Update an OAuth client by ID
      *
      * @param id - OAuth client ID

--- a/libs/infra/db/src/types/repository.ts
+++ b/libs/infra/db/src/types/repository.ts
@@ -70,6 +70,19 @@ export interface OAuthClientsRepository extends BaseRepository<
     clientId: string,
     tx?: DbClient
   ): Promise<OAuthClient | undefined>;
+
+  /**
+   * Idempotently materialise a Client ID Metadata Document (CIMD) client.
+   *
+   * CIMD clients are keyed by their (realm_id, client_id) URL. On conflict
+   * the mutable, document-derived fields are refreshed from the latest
+   * validated metadata document; the row is otherwise left untouched. This
+   * is NOT open registration: the row is keyed by the URL itself, so
+   * re-resolving the same client_id updates one row rather than creating
+   * new ones — there is no record to spam. The row exists only to satisfy
+   * the auth-code / refresh-token / audit foreign keys.
+   */
+  upsertCimdClient(data: NewOAuthClient, tx?: DbClient): Promise<OAuthClient>;
 }
 
 /**

--- a/libs/server/config/src/lib/schemas/auth.ts
+++ b/libs/server/config/src/lib/schemas/auth.ts
@@ -204,6 +204,99 @@ export const authEnvSchema = z.object({
         .map((x) => x.trim())
         .filter((x) => x.length > 0)
     ),
+
+  // ------------------------------------------------------------------
+  // Client ID Metadata Documents (CIMD) — draft-ietf-oauth-client-id-
+  // metadata-document-00 / MCP Authorization rev 2025-11-25. When a
+  // `client_id` is an HTTPS URL, the AS fetches the metadata document on
+  // demand instead of consulting a persisted registration record.
+  // ------------------------------------------------------------------
+
+  /**
+   * Master switch for CIMD. When false, URL-formatted `client_id`s are
+   * treated like any other (unknown) client_id and rejected with
+   * `invalid_client`. Defaults to enabled per the MCP-first positioning
+   * (ADR-007 §1) — CIMD is the recommended client-registration mechanism.
+   */
+  CIMD_ENABLED: z
+    .enum(['true', 'false'])
+    .default('true')
+    .transform((v) => v === 'true'),
+
+  /**
+   * Domain trust policy applied to a CIMD `client_id` URL host after the
+   * SSRF / structural checks pass (CIMD §6 leaves this to deployment
+   * policy):
+   *   - `accept-any-https` — any https URL whose document validates is
+   *     accepted (most permissive; appropriate for open MCP servers).
+   *   - `allowlist` — only hosts in `CIMD_TRUSTED_DOMAINS` are accepted.
+   *     Any other host → `invalid_client`. Use for locked-down installs.
+   */
+  CIMD_TRUST_POLICY: z.enum(['accept-any-https', 'allowlist']).default('accept-any-https'),
+
+  /**
+   * Comma/space-separated host allowlist consulted when
+   * `CIMD_TRUST_POLICY=allowlist`. A leading `*.` permits subdomains
+   * (e.g. `*.example.com` matches `app.example.com` but not
+   * `example.com`). Empty + allowlist policy means "trust nothing".
+   */
+  CIMD_TRUSTED_DOMAINS: z
+    .string()
+    .default('')
+    .transform((s) =>
+      s
+        .split(/[\s,]+/)
+        .map((x) => x.trim().toLowerCase())
+        .filter((x) => x.length > 0)
+    ),
+
+  /**
+   * Default TTL (seconds) for a cached CIMD document when the upstream
+   * response carries no usable `Cache-Control: max-age` / `Expires`
+   * header. Bounds how long a stale document can be served.
+   */
+  CIMD_CACHE_DEFAULT_TTL: z.coerce
+    .number()
+    .int()
+    .min(0)
+    .default(5 * 60),
+
+  /**
+   * Hard upper bound (seconds) on any cached CIMD document, regardless of
+   * the upstream `max-age`. Prevents a misbehaving client document from
+   * pinning a registration in cache indefinitely.
+   */
+  CIMD_CACHE_MAX_TTL: z.coerce
+    .number()
+    .int()
+    .min(1)
+    .default(60 * 60),
+
+  /**
+   * Maximum CIMD document size in bytes. Bounds memory + abuse surface
+   * (CIMD documents are small JSON blobs).
+   */
+  CIMD_MAX_DOCUMENT_BYTES: z.coerce
+    .number()
+    .int()
+    .min(256)
+    .default(64 * 1024),
+
+  /**
+   * Per-fetch timeout (milliseconds) for retrieving a CIMD document.
+   */
+  CIMD_FETCH_TIMEOUT_MS: z.coerce.number().int().min(100).default(5000),
+
+  /**
+   * Allow CIMD fetches to non-public IP ranges (loopback, private,
+   * link-local). MUST stay false in production — it disables the core
+   * SSRF guard. Exists only so an integration/dev harness can point a
+   * CIMD client_id at a localhost fixture server.
+   */
+  CIMD_ALLOW_PRIVATE_ADDRESSES: z
+    .enum(['true', 'false'])
+    .default('false')
+    .transform((v) => v === 'true'),
 });
 
 /**


### PR DESCRIPTION
## T1 — CIMD (Client ID Metadata Documents) support (ADR-007, MCP auth 2025-11-25)

Closes #165.

Adopts CIMD (`draft-ietf-oauth-client-id-metadata-document-00`) as the recommended client-registration mechanism per the MCP Authorization spec rev 2025-11-25; client priority becomes pre-registered → CIMD → DCR.

- Advertises `client_id_metadata_document_supported: true` in both AS-metadata and OIDC config.
- Accepts URL-formatted `client_id` on `/oauth/authorize` + `/oauth/token`; fetches the document, validates `client_id` == URL exactly + required fields, validates `redirect_uri` against the document set.
- **SSRF-safe fetch** (`helpers/ssrf-safe-fetch.ts`): https-only, no redirects, size/timeout bounds, and a **DNS-pinned, TOCTOU-safe** IP check (validates the resolved A/AAAA record and dials that exact IP — no rebinding window); blocks loopback/link-local/`169.254.169.254`/RFC1918/CGNAT/IPv6-ULA/mapped-private ranges. Dev-only `CIMD_ALLOW_PRIVATE_ADDRESSES` escape hatch (default off).
- Redis caching honouring `Cache-Control`/`Expires`; consent screen shows redirect host + localhost warning; config-gated domain trust policy.
- RFC 7591 DCR retained as fallback. New `CIMD_*` env vars, all defaulted.

### Design note
CIMD clients are materialised as an **idempotent** row keyed by `(realm, client_id URL)` (`upsertCimdClient`), because `authorization_codes`/`refresh_tokens`/`audit_logs` carry NOT-NULL FKs to `oauth_clients.id`. The row is created only after a successful SSRF-guarded fetch + full validation, so the "no persistent records to abuse" property holds.

### Merge order / conflicts
- Merge **last** of the Wave 1 set. Two trivial conflicts to expect:
  - `routes/ui/consent.ts` — identical `buildAuthorizeUrl` fix also in the trust-floor PR.
  - `libs/infra/db/.../oauth-clients.repository.ts` + `types/repository.ts` — additive vs the clients PR's `listByDeveloper`.

212 auth-server tests pass (29 new); `nx affected` lint/typecheck/test green.
