### PR TITLE
docs: refresh after Wave 1 + security pass + major dependency upgrade

### DIFF
--- a/MVP-PRD.md
+++ b/MVP-PRD.md
@@ -576,24 +576,24 @@ Response:
 
 **Tasks**:
 
-- [ ] Create REST API for client management
+- [ ] Create REST API for client management — partial: `GET /api/clients` (list) shipped; create/update/delete/regenerate still pending
 - [ ] Create "New Client" form
 - [ ] Generate client_id and client_secret
 - [ ] Store client credentials securely (hash client_secret)
 - [ ] Display client details
 - [ ] Edit client (redirect URIs, name)
 - [ ] Delete/revoke client
-- [ ] List all clients for a developer
+- [x] List all clients for a developer — `GET /api/clients`, scoped by developer, secret never returned
 
 **REST API Endpoints**:
 
 ```typescript
-GET    /api/clients
-POST   /api/clients
-GET    /api/clients/:id
-PATCH  /api/clients/:id
-DELETE /api/clients/:id
-POST   /api/clients/:id/regenerate-secret
+GET    /api/clients                     # shipped
+POST   /api/clients                     # pending
+GET    /api/clients/:id                 # pending
+PATCH  /api/clients/:id                 # pending
+DELETE /api/clients/:id                 # pending
+POST   /api/clients/:id/regenerate-secret  # pending
 ```
 
 **UI Features**:
@@ -652,11 +652,11 @@ POST   /api/clients/:id/regenerate-secret
 
 **Deliverables**:
 
-- ✅ Developer portal (TanStack Start)
-- ✅ Self-service client registration
-- ✅ REST API for client management
-- ✅ API key management
-- ✅ Basic documentation
+- ⏳ Developer portal (TanStack Start) — scaffolded & typecheck-clean; pages still in progress
+- ⏳ Self-service client registration
+- ⏳ REST API for client management — partial: `GET /api/clients` (list) shipped; create/update/delete/regenerate pending
+- ⏳ API key management
+- ⏳ Basic documentation
 
 **What You Can Do After Phase 2**:
 
@@ -1209,7 +1209,7 @@ These features are NOT part of Phases 1–5:
 ### JWT Algorithm
 
 - **Decision**: EdDSA (Ed25519) for MVP
-- **Rationale**: Fast, secure, simple. Hybrid PQC later (Phase 7)
+- **Rationale**: Fast, secure, simple. Hybrid PQC later (Phase 5)
 
 ### JWT Expiration
 
@@ -1400,12 +1400,12 @@ CREATE TABLE sessions (
 | `/.well-known/openid-configuration`  | GET    | OIDC discovery                                                                                                       | 3.2   |
 | `/.well-known/jwks.json`             | GET    | JWKS public keys                                                                                                     | 3.2   |
 | `/metrics`                           | GET    | Prometheus metrics                                                                                                   | 3.3   |
-| `/api/clients`                       | GET    | List OAuth clients                                                                                                   | 2.2   |
-| `/api/clients`                       | POST   | Create OAuth client                                                                                                  | 2.2   |
-| `/api/clients/:id`                   | GET    | Get client details                                                                                                   | 2.2   |
-| `/api/clients/:id`                   | PATCH  | Update client                                                                                                        | 2.2   |
-| `/api/clients/:id`                   | DELETE | Delete client                                                                                                        | 2.2   |
-| `/api/clients/:id/regenerate-secret` | POST   | Regenerate client secret                                                                                             | 2.2   |
+| `/api/clients`                       | GET    | List OAuth clients (shipped) — scoped by developer, secret never returned                                            | 2.2   |
+| `/api/clients`                       | POST   | Create OAuth client (pending)                                                                                        | 2.2   |
+| `/api/clients/:id`                   | GET    | Get client details (pending)                                                                                         | 2.2   |
+| `/api/clients/:id`                   | PATCH  | Update client (pending)                                                                                              | 2.2   |
+| `/api/clients/:id`                   | DELETE | Delete client (pending)                                                                                              | 2.2   |
+| `/api/clients/:id/regenerate-secret` | POST   | Regenerate client secret (pending)                                                                                  | 2.2   |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ const auth = new QAuth({
 
 ## 🔐 Post-Quantum Cryptography
 
-QAuth's PQC strategy is documented in [ADR-005](./docs/adr/005-pqc-hybrid-signing.md) and is **design-stage today**. Phase 1 signs JWTs with Ed25519; the hybrid transition is planned for Phase 5.
+QAuth's PQC strategy is documented in [ADR-005](./docs/adr/005-pqc-hybrid-signing.md). The post-quantum hybrid layer is **design-stage today**, but the crypto-agile foundation is **live now**: Phase 1 — current and shipping — signs JWTs with Ed25519 behind algorithm-agnostic interfaces. The ML-DSA hybrid transition is planned for Phase 5.
 
 ### Primary standard (target)
 
@@ -115,7 +115,7 @@ ML-DSA-65 signatures are 3,309 bytes vs. Ed25519's 64 bytes. QAuth's architectur
 
 **Migration timeline:**
 
-- **Phase 1** (in progress): Ed25519 / EdDSA for JWT signatures, plus crypto-agile interfaces
+- **Phase 1** (current / live now): Ed25519 / EdDSA for JWT signatures, plus crypto-agile interfaces
 - **Phase 5** (2027 target): Hybrid composite ML-DSA-65 + Ed25519 (JOSE WG draft adopted Jan 2026)
 - **Future**: FN-DSA (NIST FIPS 206, pending) evaluation — compact signatures (~666 B) may make self-contained PQC JWTs practical
 
@@ -134,6 +134,8 @@ A federated identity hub for the next generation of the internet:
 
 QAuth is **early and not yet production-ready**. An honest snapshot.
 
+Phase 1 core OAuth 2.1 / OIDC is architecturally complete and live-tested end-to-end; near-term work is MCP productization and agent-native features — so it is not yet production-ready.
+
 > **Near-term focus — MCP / AI-agent auth.** Building OAuth 2.1 properly produced a working **authorization server for MCP servers and AI agents**, validated end-to-end with Claude Code against a live MCP server. That is now the near-term direction; wallet federation and post-quantum signing are the long-term platform, sequenced after. See [ADR-007](./docs/adr/007-mcp-first-positioning.md).
 
 **✅ Working today**
@@ -146,12 +148,13 @@ QAuth is **early and not yet production-ready**. An honest snapshot.
 - Email/password registration + verification (Argon2id; Resend / SMTP / Mock), multi-tenancy via Realms
 - Developer portal: registration / login / verify + dashboard shell (server-side `__Host-` session)
 - PostgreSQL 18 + Redis 7 with Docker Compose; OpenAPI / Swagger UI at `/docs`
+- `@qauth-labs/mcp-guard` — resource-server SDK: RFC 9728 protected-resource metadata + 401 challenge + token validation
+- Client ID Metadata Documents (CIMD) as the primary client-registration path (MCP 2025-11-25); RFC 7591 dynamic registration kept as the documented fallback
+- Trust floor: real-DB (testcontainers) repository tests + logout endpoint test + CI typecheck/coverage gate
 
 **🚧 In progress / next (MCP-first tracks — see [ADR-007](./docs/adr/007-mcp-first-positioning.md))**
 
-- `@qauth-labs/mcp-guard` — resource-server SDK: RFC 9728 protected-resource metadata + 401 challenge + token validation
-- Client ID Metadata Documents (CIMD) as the primary client-registration path (MCP 2025-11-25); RFC 7591 dynamic registration kept as the documented fallback
-- Trust floor: real-DB repository tests + logout endpoint test + CI typecheck/coverage gate
+- Agent-native authZ: agent client type, RFC 8693 token-exchange delegation, scope modes, step-up scope challenges
 - Security hardening (CSRF, Helmet headers, secure cookies), structured logging (pino) + `/metrics`
 - OIDC conformance detail: ID token, nonce, scope/claims
 
@@ -161,6 +164,8 @@ QAuth is **early and not yet production-ready**. An honest snapshot.
 - Wallet federation (OID4VC / SIOPv2) — [ADR-004](./docs/adr/004-wallet-agnostic-federation.md)
 - Post-quantum hybrid signing + `@qauth-labs/crypto` — [ADR-005](./docs/adr/005-pqc-hybrid-signing.md)
 - SDKs (`@qauth-labs/core`, `@qauth-labs/react`, `@qauth-labs/node`), `auth-ui`, `admin-panel`
+
+> [ADR-006](./docs/adr/006-oauth-grants-and-audience.md) (OAuth grants — `client_credentials` / `client_secret_basic` + `aud` claim) is **implemented and shipping today**, not deferred; the grants and audience binding above ship in the auth server now.
 
 **Tracking:** [MVP milestone](https://github.com/qauth-labs/qauth/milestone/1) · [ADR index](./docs/adr/README.md) · [MVP-PRD](./MVP-PRD.md)
 
@@ -238,7 +243,7 @@ qauth/
 │   │                         #     password.provider.ts, wallet.provider.ts
 │   │                         #     Normalises upstream → VerifiedIdentity
 │   │
-│   ├── fastify/plugins/      ✅ db · cache · email · jwt · password · pkce
+│   ├── fastify/plugins/      ✅ db · cache · email · jwt · password · pkce · mcp-guard
 │   ├── infra/
 │   │   ├── db/               ✅ PostgreSQL 18 + Drizzle ORM, repository pattern
 │   │   └── cache/            ✅ Redis 7 connection + caching utilities
@@ -347,7 +352,7 @@ qauth/
 **Backend:**
 
 - **Runtime**: Node.js 24 LTS
-- **Language**: TypeScript
+- **Language**: TypeScript 6.0
 - **Framework**: Fastify
 - **API**: REST (OAuth 2.1 / OIDC)
 - **ORM**: Drizzle ORM
@@ -363,7 +368,7 @@ qauth/
 - **Framework**: React 19
 - **Router**: TanStack Router
 - **Data Fetching**: TanStack Query
-- **Build Tool**: Vite
+- **Build Tool**: Vite 8 (Rolldown)
 - **UI Primitives**: Radix UI
 - **Styling**: Tailwind CSS
 - **Tables**: TanStack Table
@@ -371,8 +376,9 @@ qauth/
 
 **Infrastructure:**
 
-- **Monorepo**: Nx 22.3+
-- **Package Manager**: pnpm
+- **Monorepo**: Nx 23
+- **Package Manager**: pnpm 11
+- **Linting**: ESLint 10
 - **Containerization**: Docker
 - **Orchestration**: Kubernetes ready (manifests planned, Phase 3)
 - **Observability**: OpenTelemetry (planned, Phase 3)

--- a/docs/adr/003-credential-provider-interface.md
+++ b/docs/adr/003-credential-provider-interface.md
@@ -4,6 +4,8 @@
 **Date:** 2026-03-11
 **Authors:** QAuth Team
 
+> **Implementation status (2026-06-24):** Accepted as design; not yet implemented. Per [ADR-007](./007-mcp-first-positioning.md) (MCP-first), the CredentialProvider/federation work is deferred to Phase 4 (long-term).
+
 ## Context
 
 Phase 1 authentication logic (password verification, email claim extraction) is implemented directly in the auth service routes. Login looks up a user by email, verifies the password hash, and builds JWT claims from the user record. This works for a single authentication method, but it cannot accommodate multiple methods without expanding the service layer with provider-specific conditionals.

--- a/docs/adr/004-wallet-agnostic-federation.md
+++ b/docs/adr/004-wallet-agnostic-federation.md
@@ -4,6 +4,8 @@
 **Date:** 2026-03-11
 **Authors:** QAuth Team
 
+> **Implementation status (2026-06-24):** Accepted as design; not implemented. Deferred per [ADR-007](./007-mcp-first-positioning.md) to the long-term platform; gated on the [ADR-002](./002-identifier-abstraction.md) migration.
+
 ## Context
 
 The eIDAS 2.0 regulation (EU 2024/1183) requires EU member states to provide EUDI-compliant digital identity wallets by December 2026. By December 2027, regulated EU businesses across banking, healthcare, transport, energy, and telecommunications must accept EUDI Wallet authentication. The EU's Web 4.0 strategy (COM(2023) 442) identifies portable, user-controlled digital identity as foundational infrastructure.

--- a/docs/adr/005-pqc-hybrid-signing.md
+++ b/docs/adr/005-pqc-hybrid-signing.md
@@ -4,6 +4,8 @@
 **Date:** 2026-03-18
 **Authors:** QAuth Team
 
+> **Implementation status (2026-06-24):** Accepted as design; not implemented. Phase 1 signs JWTs with Ed25519; the hybrid ML-DSA transition is Phase 5 (long-term per [ADR-007](./007-mcp-first-positioning.md)).
+
 ## Context
 
 Post-quantum cryptography (PQC) standardization has materially advanced. NIST finalized FIPS 203 (ML-KEM), FIPS 204 (ML-DSA), and FIPS 205 (SLH-DSA) in August 2024, and FIPS 206 (FN-DSA) is expected to finalize in the 2026-2027 period.

--- a/docs/adr/007-mcp-first-positioning.md
+++ b/docs/adr/007-mcp-first-positioning.md
@@ -4,6 +4,8 @@
 **Date:** 2026-06-23
 **Authors:** QAuth Team
 
+> **Implementation status (2026-06-24):** The near-term MCP track has **shipped**. CIMD client registration is live (config-gated via `CIMD_*`, with SSRF guards and an optional domain trust policy); `@qauth-labs/mcp-guard` ships as the resource-server SDK (PRM discovery, `401`/`403` challenges, JWKS/introspection token validation); the agent-facing `GET /api/clients` developer surface exists; and the T0 trust floor is in place — testcontainers-backed repository tests plus a CI gate running `lint typecheck test build` and a repo-wide coverage threshold. The long-term federation/PQC items below remain accepted designs only (see [ADR-002](./002-identifier-abstraction.md) / [ADR-003](./003-credential-provider-interface.md) / [ADR-004](./004-wallet-agnostic-federation.md) / [ADR-005](./005-pqc-hybrid-signing.md)).
+
 ## Context
 
 The OAuth 2.1 work integrated in PR #156 (`integration/oauth-mcp-stack`) was built, in its own words, for _"first-class MCP / third-party client support."_ It delivered, together and in one release:

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -151,7 +151,7 @@ docker exec -it qauth-postgres psql -U qauth -d qauth
 
 ### Redis
 
-- **Image**: `redis:7-alpine`
+- **Image**: `redis:7-alpine` (Redis 7)
 - **Port**: 6379 (mapped to host)
 
 Connect via redis-cli:
@@ -259,6 +259,23 @@ See `.env.docker.example` for all available variables. Key variables:
 | `LOG_LEVEL`       | No       | `info` (default); use `debug` for development      |
 
 For **development** with `docker-compose.dev.yml`, set `NODE_ENV=development` and `LOG_LEVEL=debug` in `.env`.
+
+### Client ID Metadata Documents (CIMD)
+
+CIMD is the recommended MCP client-registration mechanism (see [ADR-007](./adr/007-mcp-first-positioning.md)). When a `client_id` is an HTTPS URL, the auth-server fetches and validates the client's metadata document on demand instead of persisting a registration record. All settings have safe defaults — none are required to run.
+
+| Variable                       | Required | Default              | Description                                                                                                   |
+| ------------------------------ | -------- | -------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `CIMD_ENABLED`                 | No       | `true`               | Master switch. When `false`, URL-formatted `client_id`s are rejected with `invalid_client`.                   |
+| `CIMD_TRUST_POLICY`            | No       | `accept-any-https`   | `accept-any-https` (any validating HTTPS document) or `allowlist` (only hosts in `CIMD_TRUSTED_DOMAINS`).     |
+| `CIMD_TRUSTED_DOMAINS`         | No       | _(empty)_            | Comma/space-separated host allowlist for `allowlist` policy. A leading `*.` permits subdomains.               |
+| `CIMD_CACHE_DEFAULT_TTL`       | No       | `300`                | Cache TTL (seconds) when the document carries no usable `Cache-Control`/`Expires`.                            |
+| `CIMD_CACHE_MAX_TTL`           | No       | `3600`               | Hard upper bound (seconds) on any cached document, regardless of upstream `max-age`.                          |
+| `CIMD_MAX_DOCUMENT_BYTES`      | No       | `65536`              | Maximum document size in bytes.                                                                               |
+| `CIMD_FETCH_TIMEOUT_MS`        | No       | `5000`               | Per-fetch timeout in milliseconds.                                                                            |
+| `CIMD_ALLOW_PRIVATE_ADDRESSES` | No       | `false`              | Allow fetches to non-public IPs (loopback/private/link-local). **Keep `false` in production** — it disables the SSRF guard; for dev/integration harnesses only. |
+
+> **Note:** `.env.docker.example` does not yet list the `CIMD_*` variables. They are optional and default-safe, so the stack runs without them; add them to `.env` only to override the defaults above.
 
 ## Troubleshooting
 

--- a/libs/fastify/plugins/mcp-guard/README.md
+++ b/libs/fastify/plugins/mcp-guard/README.md
@@ -1,5 +1,8 @@
 # @qauth-labs/mcp-guard
 
+> Targets the **MCP Authorization** specification, **revision 2025-11-25**, and
+> **RFC 9728** (OAuth 2.0 Protected Resource Metadata).
+
 The resource-server (RS) side SDK for protecting an **MCP server** with a
 self-hosted **[QAuth](../../../../README.md)** OAuth 2.1 authorization server.
 

--- a/libs/fastify/plugins/mcp-guard/src/index.ts
+++ b/libs/fastify/plugins/mcp-guard/src/index.ts
@@ -9,7 +9,7 @@
  *   `requireScopes` preHandlers.
  * - {@link McpGuard} — the framework-agnostic core, for non-Fastify hosts.
  *
- * See the package README and `examples/mcp-guard-memory` for usage.
+ * See the package README and `examples/memory-mcp` for usage.
  */
 
 // Fastify adapter (default + named).

--- a/libs/infra/db/README.md
+++ b/libs/infra/db/README.md
@@ -199,6 +199,11 @@ await db.transaction(async (tx) => {
 - **`realmsRepository`**: Realm CRUD operations
   - `create()`, `findById()`, `findByIdOrThrow()`, `findByName()`, `update()`, `delete()`
 
+- **`oauthClientsRepository`** (`createOAuthClientsRepository`): OAuth client CRUD operations
+  - `create()`, `findById()`, `findByIdOrThrow()`, `findByClientId()`, `listByDeveloper()`, `upsertCimdClient()`, `update()`, `delete()`
+  - `listByDeveloper(developerId, tx?)`: lists a developer's own clients, scoped strictly by `developer_id` and ordered newest-first. Dynamically registered (RFC 7591 / DCR) clients carry a null `developer_id` and are excluded.
+  - `upsertCimdClient(data, tx?)`: idempotent `INSERT ... ON CONFLICT` for Client ID Metadata Document (CIMD) clients keyed by `(realm_id, client_id)`. On conflict it refreshes only the document-derived fields (name, description, redirect URIs, grant/response types, auth method, metadata, enabled) and bumps `updatedAt`; identity columns and the secret sentinel are left untouched, so concurrent authorize requests for the same metadata-document `client_id` collapse onto a single row instead of racing a find-then-create.
+
 - **`auditLogsRepository`**: Audit log operations
   - `create()`, `findByUserId()`, `findByRealmId()`, `findByRealmAndUserId()`
 

--- a/libs/server/pkce/README.md
+++ b/libs/server/pkce/README.md
@@ -1,7 +1,124 @@
-# server-pkce
+# @qauth-labs/server-pkce
 
-This library was generated with [Nx](https://nx.dev).
+PKCE (Proof Key for Code Exchange, [RFC 7636](https://www.rfc-editor.org/rfc/rfc7636))
+primitives for the QAuth OAuth 2.1 authorization-code flow.
 
-## Running unit tests
+## Overview
 
-Run `nx test server-pkce` to execute the unit tests via [Vitest](https://vitest.dev/).
+OAuth 2.1 makes PKCE mandatory for the authorization-code grant. This library
+provides small, dependency-free helpers (built on Node's `node:crypto`) for the
+`S256` PKCE method:
+
+- generate a cryptographically random **code verifier**,
+- derive the corresponding **code challenge** (`BASE64URL(SHA256(verifier))`),
+- validate verifier format per RFC 7636,
+- and verify a verifier against a stored challenge using a **timing-safe**
+  comparison.
+
+Only the `S256` method is supported (the OAuth 2.1 / BCP recommendation); the
+plaintext method is intentionally not implemented.
+
+## Installation
+
+This library is part of the QAuth monorepo and is automatically available to
+other projects within the workspace.
+
+```typescript
+import { generatePkcePair } from '@qauth-labs/server-pkce';
+```
+
+## Usage
+
+### Generate a PKCE pair (client side)
+
+```typescript
+import { generatePkcePair } from '@qauth-labs/server-pkce';
+
+const { codeVerifier, codeChallenge } = generatePkcePair();
+
+// Store codeVerifier locally (e.g. session); send the challenge on /authorize:
+//   GET /oauth/authorize?...&code_challenge=<codeChallenge>&code_challenge_method=S256
+// Then send codeVerifier to /oauth/token when exchanging the authorization code.
+```
+
+### Verify a verifier against a stored challenge (server side)
+
+At authorize time the server stores `code_challenge`. At token time the client
+presents `code_verifier`; the server verifies it:
+
+```typescript
+import { verifyCodeChallenge } from '@qauth-labs/server-pkce';
+
+const ok = verifyCodeChallenge(presentedVerifier, storedChallenge);
+if (!ok) {
+  // Reject the token request (invalid_grant)
+}
+```
+
+### Lower-level helpers
+
+```typescript
+import {
+  generateCodeVerifier,
+  generateCodeChallenge,
+  isValidCodeVerifierFormat,
+} from '@qauth-labs/server-pkce';
+
+const verifier = generateCodeVerifier(); // 43-char base64url string
+const challenge = generateCodeChallenge(verifier); // BASE64URL(SHA256(verifier))
+
+isValidCodeVerifierFormat(verifier); // true
+isValidCodeVerifierFormat('short'); // false (must be 43–128 chars of [A-Za-z0-9._~-])
+```
+
+## API
+
+### `generatePkcePair(): PkcePair`
+
+Generates a fresh verifier + matching `S256` challenge. Returns
+`{ codeVerifier, codeChallenge }`.
+
+### `generateCodeVerifier(): string`
+
+Generates a cryptographically random code verifier: 32 random octets (256 bits)
+encoded as base64url, yielding a 43-character string.
+
+### `generateCodeChallenge(verifier: string): string`
+
+Computes the `S256` code challenge: `BASE64URL(SHA256(ASCII(verifier)))`, a
+43-character base64url string. **Throws** `Error('Invalid code verifier format')`
+if `verifier` is not a valid RFC 7636 verifier.
+
+### `verifyCodeChallenge(verifier: string, storedChallenge: string): boolean`
+
+Verifies `verifier` against a previously stored challenge using a timing-safe
+comparison (`crypto.timingSafeEqual`). Returns `false` (does **not** throw) for an
+invalid verifier format or a length mismatch.
+
+### `isValidCodeVerifierFormat(verifier: unknown): boolean`
+
+Validates that `verifier` is a string of 43–128 characters from the RFC 7636
+unreserved set `[A-Za-z0-9._~-]`. Returns `false` for non-strings and `null`/`undefined`.
+
+### `PkcePair` (type)
+
+```typescript
+interface PkcePair {
+  /** Cryptographically random string (43 chars base64url); sent to the token endpoint. */
+  codeVerifier: string;
+  /** BASE64URL(SHA256(codeVerifier)); sent in the authorize request as code_challenge. */
+  codeChallenge: string;
+}
+```
+
+## Development
+
+### Running unit tests
+
+```bash
+pnpm nx test server-pkce
+```
+
+## License
+
+Apache-2.0

--- a/libs/shared/errors/README.md
+++ b/libs/shared/errors/README.md
@@ -215,6 +215,15 @@ function isUniqueConstraintError(error: unknown): boolean;
 
 **Returns**: `true` if the error is a PostgreSQL unique constraint violation (error code `23505`), `false` otherwise.
 
+> **Note — don't read `error.code` directly.** Since drizzle-orm `>=0.30`, the raw
+> `pg` error is wrapped in a `DrizzleQueryError`, so the SQLSTATE `code` and the
+> `constraint`/`detail`/`severity` fields live on `error.cause`, not the top-level
+> error. `isUniqueConstraintError` and `extractConstraintName` walk the `.cause`
+> chain (skipping any unrelated wrappers that carry their own non-SQLSTATE `code`,
+> such as Fastify `FST_ERR_*`) to find the real Postgres error. Always go through
+> these helpers rather than inspecting `error.code` yourself — the value you want
+> may be several links down the cause chain.
+
 **Example**:
 
 ```typescript

--- a/libs/shared/testing/README.md
+++ b/libs/shared/testing/README.md
@@ -9,6 +9,7 @@ The `@qauth-labs/shared-testing` library provides:
 - **Fastify Test Helpers**: Utilities for building and managing test Fastify instances
 - **Supertest Helpers**: Utilities for making HTTP requests in tests
 - **Test Fixtures**: Reusable test data factories for users, realms, and other entities
+- **Docker Integration Testing**: A disposable PostgreSQL testcontainer for repository integration tests
 - **Type-Safe API**: Full TypeScript support
 
 ## Installation
@@ -22,6 +23,9 @@ import {
   createTestRequest,
   createUserFixture,
   createRealmFixture,
+  startPostgresContainer,
+  isDockerAvailable,
+  POSTGRES_IMAGE,
 } from '@qauth-labs/shared-testing';
 ```
 
@@ -232,6 +236,66 @@ const realm = createRealmFixture({
 });
 ```
 
+### Docker Integration Testing
+
+For repository/integration suites that need a real database, the library exposes
+a disposable PostgreSQL [testcontainer](https://testcontainers.com/). It starts a
+throwaway `postgres:18-alpine` container (the same image as docker-compose;
+PostgreSQL 18 is required for native `uuidv7()`), waits until Postgres is genuinely
+ready, and hands you a connection string to run migrations and tests against.
+
+#### `startPostgresContainer(): Promise<StartedPostgres>`
+
+Starts a disposable PostgreSQL 18 container and resolves once it is accepting
+connections. Requires a running Docker daemon. The returned `StartedPostgres` has:
+
+- `connectionString: string` — node-postgres / Drizzle compatible URL
+- `port: number` — the host port mapped to the container's `5432`
+- `stop(): Promise<void>` — stop and remove the container
+
+#### `isDockerAvailable(): Promise<boolean>`
+
+Best-effort probe for a reachable Docker daemon. Call it first so suites can
+`describe.skip` (instead of failing) on CI lanes or sandboxes where Docker is
+absent.
+
+#### `POSTGRES_IMAGE`
+
+The pinned image string (`'postgres:18-alpine'`), exported so callers can assert
+on or reuse it.
+
+**Example:**
+
+```typescript
+import { describe, it, beforeAll, afterAll, expect } from 'vitest';
+import {
+  startPostgresContainer,
+  isDockerAvailable,
+  type StartedPostgres,
+} from '@qauth-labs/shared-testing';
+
+const dockerAvailable = await isDockerAvailable();
+
+describe.skipIf(!dockerAvailable)('OAuth clients repository (integration)', () => {
+  let pg: StartedPostgres;
+
+  beforeAll(async () => {
+    pg = await startPostgresContainer();
+    // Connect with pg/Drizzle and apply migrations against pg.connectionString…
+    // e.g. process.env.DATABASE_URL = pg.connectionString;
+  }, 120_000); // pulling/booting the image can take a while on a cold cache
+
+  afterAll(async () => {
+    await pg.stop();
+  });
+
+  it('persists a row', async () => {
+    // run repository code against pg.connectionString
+    expect(pg.port).toBeGreaterThan(0);
+  });
+});
+```
+
 ## Complete Example
 
 ```typescript
@@ -326,6 +390,22 @@ Creates multiple user fixtures.
 
 Creates a single realm fixture with optional overrides.
 
+### Docker Integration Testing
+
+#### `startPostgresContainer(): Promise<StartedPostgres>`
+
+Starts a disposable `postgres:18-alpine` container for integration tests and
+resolves once it is ready. Returns `{ connectionString, port, stop() }`.
+
+#### `isDockerAvailable(): Promise<boolean>`
+
+Resolves `true` when a Docker daemon is reachable, `false` otherwise (use to skip
+integration suites gracefully).
+
+#### `POSTGRES_IMAGE: string`
+
+The pinned Postgres image (`'postgres:18-alpine'`).
+
 ## Development
 
 ### Running Tests
@@ -354,6 +434,7 @@ This library is used by test suites across the QAuth monorepo. It provides commo
 - `fastify`: Fast HTTP server framework
 - `supertest`: HTTP assertion library
 - `vitest`: Test runner
+- `testcontainers`: Disposable Docker containers for integration tests (Postgres harness)
 
 ## License
 

--- a/libs/ui/README.md
+++ b/libs/ui/README.md
@@ -1,3 +1,130 @@
-# ui
+# @qauth-labs/ui
 
-This library was generated with [Nx](https://nx.dev).
+Shared React UI primitives for QAuth front-ends (the developer portal and other
+in-repo apps). A small set of unstyled-by-convention, Tailwind-styled building
+blocks with consistent props and `className` overrides.
+
+## Overview
+
+`@qauth-labs/ui` provides headless-ish React primitives styled with Tailwind CSS:
+
+- **Button** — variant/size-aware button
+- **Card** family — `Card`, `CardHeader`, `CardTitle`, `CardDescription`, `CardContent`
+- **Input** — text input with `aria-invalid` error styling
+- **Label** — form label
+- **FormField** — label + control + error/helper-text wrapper
+
+All components forward standard DOM props and accept a `className` that is merged
+with the component's base styles (via `clsx` + `tailwind-merge`), so callers can
+override or extend styling without fighting specificity. `Card*`, `Input`, and
+`Label` forward refs.
+
+> **Peer requirements:** React and a Tailwind CSS build are expected in the
+> consuming app (the component class names assume Tailwind is processing them).
+
+## Installation
+
+This library is part of the QAuth monorepo and is automatically available to
+other projects within the workspace.
+
+```tsx
+import { Button, Card, CardHeader, CardTitle, Input, Label, FormField } from '@qauth-labs/ui';
+```
+
+## Usage
+
+### Button
+
+```tsx
+import { Button } from '@qauth-labs/ui';
+
+<Button onClick={handleSave}>Save</Button>
+<Button variant="outline" size="sm">Cancel</Button>
+<Button variant="link">Learn more</Button>
+<Button disabled>Submitting…</Button>
+```
+
+`ButtonProps` extends `React.ButtonHTMLAttributes<HTMLButtonElement>` and adds:
+
+- `variant?: 'default' | 'outline' | 'ghost' | 'link'` (default `'default'`)
+- `size?: 'default' | 'sm' | 'lg'` (default `'default'`)
+
+### Card
+
+```tsx
+import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@qauth-labs/ui';
+
+<Card>
+  <CardHeader>
+    <CardTitle>Register an application</CardTitle>
+    <CardDescription>Create OAuth client credentials.</CardDescription>
+  </CardHeader>
+  <CardContent>{/* … */}</CardContent>
+</Card>;
+```
+
+Each `Card*` component is a `forwardRef` wrapper over the matching HTML element
+(`div`/`h3`/`p`) and accepts that element's standard attributes plus `className`.
+
+### Input and Label
+
+```tsx
+import { Input, Label } from '@qauth-labs/ui';
+
+<Label htmlFor="email">Email</Label>
+<Input id="email" type="email" placeholder="you@example.com" />
+
+// Error state: set aria-invalid to drive the red focus/border styling.
+<Input id="email" aria-invalid="true" />
+```
+
+`InputProps` is `InputHTMLAttributes<HTMLInputElement>`; `LabelProps` is
+`LabelHTMLAttributes<HTMLLabelElement>`. Both forward refs.
+
+### FormField
+
+A layout wrapper that renders a `Label`, the control you pass as `children`, and
+either an error or helper message beneath it. When `error` is set it takes
+precedence over `helperText` and renders in the error color.
+
+```tsx
+import { FormField, Input } from '@qauth-labs/ui';
+
+<FormField label="Email" htmlFor="email" error={errors.email} helperText="We'll never share it.">
+  <Input id="email" type="email" aria-invalid={errors.email ? 'true' : undefined} />
+</FormField>;
+```
+
+`FormFieldProps`:
+
+- `label: string`
+- `htmlFor: string`
+- `error?: string`
+- `helperText?: string`
+- `children: ReactNode`
+
+## API
+
+| Export                                                              | Kind      | Notes                                             |
+| ------------------------------------------------------------------- | --------- | ------------------------------------------------- |
+| `Button`                                                            | component | `variant` / `size` + all button attributes        |
+| `ButtonProps`                                                       | type      | Props for `Button`                                |
+| `Card`, `CardHeader`, `CardTitle`, `CardDescription`, `CardContent` | component | `forwardRef` element wrappers                     |
+| `Input`                                                             | component | `forwardRef`; `aria-invalid` drives error styling |
+| `InputProps`                                                        | type      | `= InputHTMLAttributes<HTMLInputElement>`         |
+| `Label`                                                             | component | `forwardRef`                                      |
+| `LabelProps`                                                        | type      | `= LabelHTMLAttributes<HTMLLabelElement>`         |
+| `FormField`                                                         | component | Label + control + error/helper wrapper            |
+| `FormFieldProps`                                                    | type      | Props for `FormField`                             |
+
+## Development
+
+### Running unit tests
+
+```bash
+pnpm nx test ui
+```
+
+## License
+
+Apache-2.0


### PR DESCRIPTION
Refreshes documentation to match `main` after this cycle's work (Wave 1 features, the Dependabot security pass, and the major dependency upgrade). Docs-only — every API/version claim was verified against the actual source/catalog by the audit+fix agents.

## README.md
- Reclassified shipped work (`@qauth-labs/mcp-guard`, **CIMD**, **T0 trust floor**) from "🚧 in progress" → "✅ working today"; added `mcp-guard` to the plugins list.
- Version pins refreshed: **Nx 23, TypeScript 6.0, Vite 8 (Rolldown), ESLint 10, pnpm 11** (PostgreSQL 18 / Redis 7 confirmed).
- Clarified **ADR-006 is implemented** (not deferred); tightened PQC phrasing (Ed25519 live now, hybrid = Phase 5); added a "Phase 1 complete ≠ production-ready" note.

## MVP-PRD.md
- Fixed PQC phase typo (**Phase 7 → 5**).
- Marked `GET /api/clients` shipped vs the pending POST/PATCH/DELETE/regenerate (§2.2, Phase-2 deliverables, Appendix B) — verified only `GET /` is registered in `routes/clients`.

## docs/adr/*
- Added dated (2026-06-24) implementation-status notes to **ADR-003/004/005** (deferred per ADR-007) and **ADR-007** (records CIMD / mcp-guard / `GET /api/clients` / T0 as shipped). Decision bodies untouched.

## docs/docker.md
- Added a **CIMD env-vars table** (all 8 `CIMD_*` vars verified against `libs/server/config/.../schemas/auth.ts`), noting `.env.docker.example` omits them; made Redis-7 prose explicit.

## libs/*/README.md
- **infra-db**: documented `oauthClientsRepository` incl. the new `listByDeveloper` + `upsertCimdClient`.
- **shared-testing**: new "Docker integration testing" section (`startPostgresContainer`, `isDockerAvailable`, `POSTGRES_IMAGE`).
- **shared-errors**: noted the `.cause`-chain unwrapping behavior (drizzle wraps pg errors).
- **pkce** + **ui**: replaced Nx boilerplate stubs with real API docs (verified against `src` exports).
- **mcp-guard**: noted it targets MCP Authorization rev **2025-11-25** (+ RFC 9728).
- `mcp-guard/src/index.ts`: fixed a stale JSDoc example path (`mcp-guard-memory` → `memory-mcp`).

## Intentionally NOT included
- **Archive markers for `.cursor/plans/` and `local-docs/`** — those dirs are **gitignored** (local-only, never committed), so they aren't repo documents; force-tracking marker files into ignored dirs would contradict that. No action needed there.

## Out-of-scope follow-up (not in this PR)
- CI's `setup-pnpm` still pins `pnpm ^10` while the catalog/toolchain moved to **pnpm 11** — a minor CI version drift worth aligning separately.
