### PR TITLE
ci: align pnpm to 11.4.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
-          version: ^10.0.0
+          version: 11.4.0
           run_install: false
 
       # This enables task distribution via Nx Cloud

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "private": true,
   "engines": {
     "node": ">=24.7.0",
-    "pnpm": ">=10.0.0"
+    "pnpm": ">=11.0.0"
   },
   "scripts": {
     "prepare": "husky",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -104,3 +104,14 @@ catalog:
   tailwind-merge: '^3.5.0'
   clsx: '^2.1.1'
   class-variance-authority: '^0.7.1'
+# pnpm 11 requires an explicit build decision per dependency with a postinstall
+# script (it no longer infers them from onlyBuiltDependencies). Mirror the
+# approved set; cpu-features is an optional ssh2 native accel we don't build.
+allowBuilds:
+  '@swc/core': true
+  cpu-features: false
+  esbuild: true
+  nx: true
+  protobufjs: true
+  ssh2: true
+  unrs-resolver: true


### PR DESCRIPTION
CI's `pnpm/action-setup` pinned `^10.0.0` while the deps upgrade moved the toolchain (catalogs + lockfile) to **pnpm 11.4.0**. This aligns CI:

- `.github/workflows/ci.yml`: `version: ^10.0.0` → **`11.4.0`** (matches local + the pnpm that generated the lockfile)
- `package.json` `engines.pnpm`: `>=10.0.0` → **`>=11.0.0`**

No lockfile change — the v9.0 lockfile is pnpm-11-generated and already frozen-install-consistent. This PR's own CI run exercises `pnpm install --frozen-lockfile` under pnpm 11.4.0 end-to-end.