### PR TITLE
docs: MCP quickstart, OAuth 2.1 flow guide, docs index (+ pnpm hook fix)

### DIFF
--- a/README.md
+++ b/README.md
@@ -687,10 +687,15 @@ function Dashboard() {
 
 ## 📚 Documentation
 
-**Available documentation:**
+**Guides** (start at the [docs index](./docs/README.md)):
+
+- [MCP Quickstart](./docs/mcp-quickstart.md) — run QAuth + a `mcp-guard`-protected MCP server and complete the full OAuth handshake end-to-end
+- [OAuth 2.1 Flow](./docs/oauth-flow.md) — every endpoint with copy-paste `curl` (PKCE, authorize, token, refresh, client_credentials, introspection)
+- [Docker Development Guide](./docs/docker.md) — local development with Docker
+
+**Reference:**
 
 - [Product Requirements Document](./MVP-PRD.md) — full phase breakdown, API specs, database schema
-- [Docker Development Guide](./docs/docker.md) — local development with Docker
 - [Architecture Decision Records](./docs/adr/README.md) — key architectural decisions
 - **API docs** (OpenAPI / Swagger UI) — served at `/docs` on the running instance
 
@@ -702,16 +707,16 @@ function Dashboard() {
 - [@qauth-labs/server-email](./libs/server/email/README.md) — email service with multiple providers
 - [@qauth-labs/server-password](./libs/server/password/README.md) — password hashing with Argon2id
 - [@qauth-labs/server-jwt](./libs/server/jwt/README.md) — JWT signing and verification
+- [@qauth-labs/mcp-guard](./libs/fastify/plugins/mcp-guard/README.md) — resource-server SDK for protecting MCP servers
 - [@qauth-labs/shared-errors](./libs/shared/errors/README.md) — centralized error handling
 - [@qauth-labs/shared-validation](./libs/shared/validation/README.md) — input validation utilities
 - [@qauth-labs/shared-testing](./libs/shared/testing/README.md) — test helpers and fixtures
 
 **Planned documentation** (future phases):
 
-- Quick Start Guide (external site)
-- API Reference
+- Standalone API Reference ([#99](https://github.com/qauth-labs/qauth/issues/99)) — incl. client-management endpoints (T2)
+- Node/TypeScript client code examples ([#100](https://github.com/qauth-labs/qauth/issues/100))
 - SDK Documentation (Phase 3)
-- Authentication Flow guide
 - Multi-tenancy Guide
 - Security Best Practices
 

--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -25,6 +25,7 @@ export default {
         'auth',
         'oauth',
         'oidc',
+        'mcp',
         'db',
         'api',
         'ui',

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,52 @@
+# QAuth Documentation
+
+QAuth is the open-source, self-hostable **OAuth 2.1 authorization server for MCP
+servers and AI agents** (see [ADR-007](./adr/007-mcp-first-positioning.md)). This
+is the entry point to the guides; the canonical, always-current API surface is the
+interactive **Swagger UI at `/docs`** on any running instance.
+
+## Getting started
+
+| Guide                                     | What it covers                                                                                                                                                                      |
+| ----------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [**MCP Quickstart**](./mcp-quickstart.md) | End-to-end: run QAuth, run a `mcp-guard`-protected MCP resource server, and complete the full discovery → register → `authorization_code` + PKCE → token handshake. **Start here.** |
+| [**Docker Guide**](./docker.md)           | Running the stack (auth-server + Postgres + Redis) in development and production; environment variables; CIMD configuration.                                                        |
+
+## OAuth 2.1 / OIDC
+
+| Guide                                                                          | What it covers                                                                                                                                                                                      |
+| ------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [**OAuth 2.1 Flow**](./oauth-flow.md)                                          | Every endpoint with copy-paste `curl`: PKCE generation, `/oauth/authorize`, token exchange, refresh-token rotation, `client_credentials`, introspection, UserInfo, and Dynamic Client Registration. |
+| [**ADR-006: OAuth grants & audience**](./adr/006-oauth-grants-and-audience.md) | Why `client_credentials` + `client_secret_basic` and per-client `aud` binding work the way they do.                                                                                                 |
+
+## API reference
+
+QAuth serves a live OpenAPI / Swagger UI at **`/docs`** on the running
+instance — that is the authoritative, versioned reference for request/response
+shapes and error codes.
+
+- **OAuth / OIDC endpoints** — documented with examples in
+  [OAuth 2.1 Flow](./oauth-flow.md).
+- **Resource-server SDK** — [`@qauth-labs/mcp-guard`](../libs/fastify/plugins/mcp-guard/README.md)
+  (Protected Resource Metadata, Bearer challenges, JWT/introspection validation).
+- **Auth & client-management endpoints** — a standalone, hand-written reference
+  ([issue #99](https://github.com/qauth-labs/qauth/issues/99)) is in progress; the
+  client-management (`/api/clients`) section lands with the T2 milestone.
+
+## Code examples
+
+- [`memory-mcp` example server](../libs/fastify/plugins/mcp-guard/examples/memory-mcp/server.ts) —
+  a runnable, `mcp-guard`-protected resource server (the resource half of the
+  quickstart).
+- Copy-paste `curl` for every OAuth step in the [OAuth 2.1 Flow](./oauth-flow.md)
+  guide.
+- A Node/TypeScript client walkthrough ([issue #100](https://github.com/qauth-labs/qauth/issues/100))
+  is planned.
+
+## Architecture & decisions
+
+- [Architecture Decision Records](./adr/README.md) — the design decisions behind
+  QAuth, including [ADR-007: MCP-First Positioning](./adr/007-mcp-first-positioning.md).
+- [MVP-PRD](../MVP-PRD.md) — product requirements, phase breakdown, schema.
+- [Milestones](https://github.com/qauth-labs/qauth/milestones) — current track
+  status (T0–T4).

--- a/docs/mcp-quickstart.md
+++ b/docs/mcp-quickstart.md
@@ -1,0 +1,327 @@
+# MCP Quickstart — QAuth as the OAuth 2.1 Authorization Server for an MCP server
+
+This guide takes you from nothing to a **working MCP authorization handshake** on
+your machine:
+
+1. Run **QAuth** — the OAuth 2.1 authorization server (AS).
+2. Run a **guarded MCP resource server** — the bundled `memory-mcp` example,
+   protected by [`@qauth-labs/mcp-guard`](../libs/fastify/plugins/mcp-guard/README.md).
+3. Obtain a valid, **audience-bound** access token and call the protected resource.
+
+By the end you will have reproduced the flow from
+[ADR-007](./adr/007-mcp-first-positioning.md): an MCP client, given only a server
+URL, discovers the authorization server, registers, runs `authorization_code` +
+PKCE, and calls the resource with a token QAuth minted and `mcp-guard` validated.
+
+```
+  ┌──────────────┐        ┌───────────────────────┐        ┌─────────────────────┐
+  │  MCP client  │        │  MCP resource server  │        │  QAuth  (AS)        │
+  │ (Claude Code,│        │  memory-mcp + mcp-guard│        │  :3000              │
+  │  curl, …)    │        │  :8088                 │        │                     │
+  └──────┬───────┘        └───────────┬───────────┘        └──────────┬──────────┘
+         │  GET /mcp/memory (no token)│                               │
+         │ ──────────────────────────▶│                               │
+         │  401 WWW-Authenticate:     │                               │
+         │  Bearer resource_metadata= │                               │
+         │ ◀──────────────────────────│                               │
+         │  GET /.well-known/oauth-protected-resource                 │
+         │ ──────────────────────────▶│                               │
+         │  { authorization_servers: ["http://localhost:3000"], … }   │
+         │ ◀──────────────────────────│                               │
+         │  discover AS, register, authorization_code + PKCE          │
+         │ ───────────────────────────────────────────────────────-─▶│
+         │  access_token (aud = http://localhost:8088, scope mcp:read)│
+         │ ◀───────────────────────────────────────────────────────-─│
+         │  GET /mcp/memory   Authorization: Bearer <token>           │
+         │ ──────────────────────────▶│  (mcp-guard verifies sig,     │
+         │  200 ✅                     │   iss, aud, scope)            │
+         │ ◀──────────────────────────│                               │
+```
+
+> **Scope of the bundled example.** `memory-mcp` is a minimal Fastify server that
+> demonstrates the **authorization** half — the 401 challenge, Protected Resource
+> Metadata, and token validation. It exposes plain HTTP routes (`/mcp/memory`)
+> rather than the full MCP JSON-RPC transport, so you verify it with `curl`. To
+> drive it from a real MCP client, wrap your own MCP server with `mcp-guard` the
+> same way (see [Step 3](#step-3--connect-an-mcp-client)); the OAuth handshake is
+> identical.
+
+---
+
+## Prerequisites
+
+- **Docker** 23.0+ and **Docker Compose** 2.0+ (BuildKit on by default)
+- **OpenSSL** (to generate the JWT signing key)
+- **Node.js 20+** with `pnpm` and `tsx` (to run the example resource server)
+- `curl` and `jq` for the walkthrough
+
+---
+
+## Step 1 — Run QAuth (the authorization server)
+
+QAuth signs tokens with **EdDSA (Ed25519)**. Generate a key pair and point the
+stack at it.
+
+```bash
+git clone https://github.com/qauth-labs/qauth.git
+cd qauth
+
+# 1. Generate the EdDSA signing key pair
+openssl genpkey -algorithm Ed25519 -out private.pem
+openssl pkey -in private.pem -pubout -out public.pem
+
+# 2. Create your .env from the example
+cp .env.docker.example .env
+```
+
+Edit `.env` and set the keys (include the `BEGIN/END` lines, wrapped in double
+quotes) and the issuer:
+
+```dotenv
+DB_PASSWORD=change_me
+
+JWT_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----
+...contents of private.pem...
+-----END PRIVATE KEY-----"
+
+JWT_PUBLIC_KEY="-----BEGIN PUBLIC KEY-----
+...contents of public.pem...
+-----END PUBLIC KEY-----"
+
+JWT_ISSUER=http://localhost:3000
+
+# Let dynamically-registered MCP clients request MCP scopes.
+# The default allows only OIDC-core scopes (openid profile email offline_access),
+# so an MCP client's `mcp:read`/`mcp:write` request would otherwise be denied.
+DEFAULT_DYNAMIC_REGISTRATION_SCOPES=openid profile email offline_access mcp:read mcp:write
+```
+
+Start the stack (auth-server + PostgreSQL 18 + Redis 7 + migrations) and verify:
+
+```bash
+docker compose up -d
+curl -s http://localhost:3000/health | jq
+```
+
+```json
+{ "status": "ok", "services": { "database": "connected", "redis": "connected" } }
+```
+
+Confirm the discovery document advertises the endpoints an MCP client needs:
+
+```bash
+curl -s http://localhost:3000/.well-known/oauth-authorization-server | jq
+```
+
+```jsonc
+{
+  "issuer": "http://localhost:3000",
+  "authorization_endpoint": "http://localhost:3000/oauth/authorize",
+  "token_endpoint": "http://localhost:3000/oauth/token",
+  "registration_endpoint": "http://localhost:3000/oauth/register",
+  "jwks_uri": "http://localhost:3000/.well-known/jwks.json",
+  "code_challenge_methods_supported": ["S256"],
+  "resource_indicators_supported": true,
+  "client_id_metadata_document_supported": true, // CIMD on by default
+}
+```
+
+> Interactive API docs (Swagger UI) are served at `http://localhost:3000/docs`.
+> See the [Docker guide](./docker.md) for development mode, CIMD settings, and
+> production considerations.
+
+---
+
+## Step 2 — Run a guarded MCP resource server
+
+The repo ships a runnable example — a tiny in-memory store protected by
+`mcp-guard` in local-JWT validation mode (it verifies tokens against QAuth's
+JWKS, no per-request call to the AS).
+
+```bash
+cd libs/fastify/plugins/mcp-guard
+
+QAUTH_ISSUER=http://localhost:3000 \
+MCP_RESOURCE=http://localhost:8088 \
+npx tsx examples/memory-mcp/server.ts
+```
+
+`MCP_RESOURCE` is this server's canonical URL — the `aud` value every accepted
+token must carry (RFC 8707). In a separate shell, confirm the two unauthenticated
+behaviours an MCP client relies on:
+
+```bash
+# Protected Resource Metadata (RFC 9728) — points clients at the AS:
+curl -s http://localhost:8088/.well-known/oauth-protected-resource | jq
+# → { "resource": "http://localhost:8088",
+#     "authorization_servers": ["http://localhost:3000"], … }
+
+# A protected call with no token → 401 + the Bearer challenge:
+curl -i http://localhost:8088/mcp/memory
+# → HTTP/1.1 401 Unauthorized
+#   WWW-Authenticate: Bearer resource_metadata="http://localhost:8088/.well-known/oauth-protected-resource"
+```
+
+This is the trigger that starts the whole handshake: a 401 with a pointer to the
+metadata document.
+
+---
+
+## Step 3 — Connect an MCP client
+
+### Option A — A real MCP client (e.g. Claude Code)
+
+Wrap your **actual** MCP server with `mcp-guard` exactly as the example does
+(register the plugin, guard routes with `app.requireBearer` /
+`app.requireScopes(...)`), then add it to your MCP client as an HTTP server:
+
+```bash
+# Exact syntax varies by client/version — check `claude mcp add --help`.
+claude mcp add --transport http memory http://localhost:8088/mcp
+```
+
+On first use the client will:
+
+1. call the server, get the **401** + `WWW-Authenticate` challenge,
+2. fetch **Protected Resource Metadata** and discover QAuth,
+3. **register** itself — via Client ID Metadata Documents (CIMD) or Dynamic
+   Client Registration (see [below](#client-registration-cimd-vs-dcr)),
+4. run **`authorization_code` + PKCE**, opening a browser for **login + consent**
+   at QAuth (you'll register/sign in and approve the `mcp:read` / `mcp:write`
+   scopes),
+5. retry the call with the issued token — `mcp-guard` validates it and returns `200`.
+
+Because the client passes the resource URL as the RFC 8707 `resource` parameter,
+the token's `aud` is bound to `http://localhost:8088` and is useless at any other
+resource server.
+
+### Option B — Verify the handshake with curl (no browser)
+
+To prove the token half end-to-end without an interactive client, mint a
+**`client_credentials`** (machine) token. This needs a client whose `scopes` and
+`audience` are set explicitly, which the seed script provisions.
+
+```bash
+# The seed script targets an existing realm. The default realm ("master") is
+# created lazily on first auth request, so warm it up with one throwaway
+# Dynamic Client Registration call (open mode — no token required):
+curl -s -X POST http://localhost:3000/oauth/register \
+  -H 'Content-Type: application/json' \
+  -d '{"client_name":"warmup","grant_types":["authorization_code"],"redirect_uris":["http://localhost/cb"],"token_endpoint_auth_method":"none"}' \
+  >/dev/null
+
+# Provision a machine client bound to the example's resource URL:
+cat > /tmp/mcp-demo-clients.json <<'JSON'
+{
+  "realm": "master",
+  "clients": [
+    {
+      "client_id": "memory-mcp-demo",
+      "name": "memory-mcp demo (client_credentials)",
+      "grant_types": ["client_credentials"],
+      "scopes": ["mcp:read", "mcp:write"],
+      "audience": ["http://localhost:8088"],
+      "token_endpoint_auth_method": "client_secret_basic"
+    }
+  ]
+}
+JSON
+
+# Seed it (prints the generated client_secret once — capture it):
+DATABASE_URL="postgresql://qauth:${DB_PASSWORD}@localhost:5432/qauth" \
+  pnpm nx run infra-db:db:seed-oauth-clients -- --manifest=/tmp/mcp-demo-clients.json
+```
+
+Exchange the credentials for an audience-bound token, then call the resource:
+
+```bash
+CLIENT_ID=memory-mcp-demo
+CLIENT_SECRET=<paste the secret printed above>
+
+ACCESS_TOKEN=$(curl -s -X POST http://localhost:3000/oauth/token \
+  -u "$CLIENT_ID:$CLIENT_SECRET" \
+  -H 'Content-Type: application/x-www-form-urlencoded' \
+  -d 'grant_type=client_credentials' \
+  -d 'scope=mcp:read' \
+  -d 'resource=http://localhost:8088' | jq -r .access_token)
+
+# Call the protected resource — mcp-guard verifies signature, issuer, aud, scope:
+curl -s http://localhost:8088/mcp/memory \
+  -H "Authorization: Bearer $ACCESS_TOKEN" | jq
+# → { "subject": "memory-mcp-demo", "client": "memory-mcp-demo", "items": {} }  ✅
+```
+
+A token carrying only `mcp:read` against the write route returns a **step-up**
+challenge — exactly what drives incremental consent in a real client:
+
+```bash
+curl -i -X PUT http://localhost:8088/mcp/memory/greeting \
+  -H "Authorization: Bearer $ACCESS_TOKEN" \
+  -H 'Content-Type: application/json' -d '{"value":"hi"}'
+# → HTTP/1.1 403 Forbidden
+#   WWW-Authenticate: Bearer error="insufficient_scope", scope="mcp:read mcp:write",
+#                     resource_metadata="http://localhost:8088/.well-known/oauth-protected-resource"
+```
+
+(Request `scope=mcp:read mcp:write` at the token endpoint to get a token that
+satisfies both routes.)
+
+---
+
+## Client registration: CIMD vs DCR
+
+QAuth supports two ways for an MCP client to obtain a `client_id`. Both are
+advertised in discovery.
+
+| Mechanism                                                | When QAuth uses it                                                | Best for                                                                                                                                                                                 |
+| -------------------------------------------------------- | ----------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **CIMD** — Client ID Metadata Documents (MCP 2025-11-25) | `client_id` is an **HTTPS URL** resolving to a metadata document  | Production clients with a stable, public metadata URL. No registration record is persisted (no open-DCR abuse surface).                                                                  |
+| **DCR** — Dynamic Client Registration (RFC 7591)         | `POST /oauth/register`, **open mode** (no `initial_access_token`) | Local development and clients without a public URL. Scopes are **capped to the realm allowlist** (`DEFAULT_DYNAMIC_REGISTRATION_SCOPES`) — this is why Step 1 adds `mcp:read mcp:write`. |
+
+- **CIMD** is on by default (`CIMD_ENABLED=true`). It requires the client's
+  `client_id` URL to be fetchable over HTTPS; the AS validates it (URL ==
+  `client_id`, redirect-URI checks, SSRF guards, size/TTL limits). For purely
+  local testing over `http://localhost`, CIMD is impractical — use DCR.
+- **DCR** open mode is rate-limited (3 registrations/hour/IP by default). Tighten
+  or gate it for any internet-facing deployment. See
+  [ADR-007 §1](./adr/007-mcp-first-positioning.md) and the
+  [Docker guide CIMD section](./docker.md#client-id-metadata-documents-cimd).
+
+---
+
+## How tokens stay scoped to one resource
+
+The no-passthrough guarantee rests on **audience binding** (RFC 8707):
+
+- The client sends `resource=<MCP server URL>` on authorize/token requests.
+- QAuth mints the access token with `aud` set to that resource and refuses to
+  widen it on refresh.
+- `mcp-guard` rejects any token whose `aud` does not include its own `resource`,
+  and never forwards the inbound token upstream.
+
+A token minted for resource A therefore cannot be replayed against resource B,
+even if both trust the same QAuth instance.
+
+---
+
+## Troubleshooting
+
+| Symptom                           | Likely cause / fix                                                                                                                                                                                       |
+| --------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `401` even with a token           | Token `aud` ≠ the server's `MCP_RESOURCE`. Ensure the `resource` you requested matches `MCP_RESOURCE` exactly.                                                                                           |
+| `invalid_scope` at `/oauth/token` | The client's `scopes` (machine client) or the realm allowlist (DCR client) doesn't include the requested scope. Re-check Step 1's `DEFAULT_DYNAMIC_REGISTRATION_SCOPES` or the seeded client's `scopes`. |
+| Seed script: realm not found      | The `master` realm hasn't been created yet — run the warm-up DCR call in Step 3 Option B first.                                                                                                          |
+| `mcp-guard` can't fetch JWKS      | `QAUTH_ISSUER` must be reachable from the resource server and serve `/.well-known/jwks.json`.                                                                                                            |
+| Port already in use               | Override `PORT` for the example, or remap `3000`/`5432`/`6379` in `docker-compose.yml`.                                                                                                                  |
+
+---
+
+## Next steps
+
+- [OAuth 2.1 Flow](./oauth-flow.md) — the `authorization_code` + PKCE flow in
+  detail, with copy-paste `curl` for every step (build your own client).
+- [`@qauth-labs/mcp-guard` README](../libs/fastify/plugins/mcp-guard/README.md) —
+  full configuration, `introspection` mode, and the framework-agnostic core.
+- [ADR-007: MCP-First Positioning](./adr/007-mcp-first-positioning.md) — why this
+  is QAuth's near-term product identity.
+- [Docker guide](./docker.md) — development mode, CIMD configuration, production.

--- a/docs/oauth-flow.md
+++ b/docs/oauth-flow.md
@@ -1,0 +1,317 @@
+# OAuth 2.1 Flow
+
+This page documents QAuth's OAuth 2.1 / OIDC endpoints with copy-paste `curl`
+for every step, so you can implement a client by hand. If your goal is to wire
+QAuth to an **MCP server**, start with the [MCP Quickstart](./mcp-quickstart.md) —
+this page is the lower-level reference it builds on.
+
+**Conventions used below**
+
+- Base URL / issuer: `http://localhost:3000` (your `JWT_ISSUER`).
+- Tokens are **EdDSA (Ed25519)** signed JWTs; verify them against
+  `GET /.well-known/jwks.json`.
+- PKCE is **required** and only `S256` is supported.
+- Request bodies to `/oauth/token` and `/oauth/introspect` are
+  `application/x-www-form-urlencoded` (RFC 6749 §3.2, RFC 7662 §2.1).
+
+Standards: RFC 6749 (OAuth 2.0) · OAuth 2.1 draft · RFC 7636 (PKCE) · RFC 8707
+(Resource Indicators) · RFC 7662 (Introspection) · RFC 8414 (AS Metadata) ·
+OIDC Core / Discovery 1.0 · RFC 9700 (OAuth 2.0 Security BCP).
+
+---
+
+## Endpoints at a glance
+
+| Endpoint                                  | Method | Purpose                                      |
+| ----------------------------------------- | ------ | -------------------------------------------- |
+| `/.well-known/oauth-authorization-server` | GET    | AS metadata (RFC 8414)                       |
+| `/.well-known/openid-configuration`       | GET    | OIDC discovery (superset)                    |
+| `/.well-known/jwks.json`                  | GET    | Public signing keys (RFC 7517)               |
+| `/oauth/authorize`                        | GET    | Start `authorization_code` + PKCE (browser)  |
+| `/oauth/token`                            | POST   | Exchange code / refresh / client credentials |
+| `/oauth/introspect`                       | POST   | Token introspection (RFC 7662)               |
+| `/oauth/userinfo`                         | GET    | OIDC UserInfo (Bearer)                       |
+| `/oauth/register`                         | POST   | Dynamic Client Registration (RFC 7591, open) |
+
+Discover these programmatically instead of hard-coding paths:
+
+```bash
+curl -s http://localhost:3000/.well-known/oauth-authorization-server | jq
+```
+
+---
+
+## Grant types
+
+| Grant                         | Subject (`sub`) | Refresh token?       | Use case                                   |
+| ----------------------------- | --------------- | -------------------- | ------------------------------------------ |
+| `authorization_code` (+ PKCE) | the end user    | yes                  | Apps acting **on behalf of a user**        |
+| `refresh_token`               | the end user    | yes (rotated)        | Renew an access token without re-prompting |
+| `client_credentials`          | the `client_id` | no (RFC 6749 §4.4.3) | **Machine-to-machine**, no user            |
+
+`response_type` is `code` only. There is no implicit or password grant
+(removed in OAuth 2.1).
+
+---
+
+## Authorization Code + PKCE (user context)
+
+### 0. Prerequisites — a client
+
+You need a registered client with the `authorization_code` grant, a registered
+`redirect_uri`, and the scopes you want in its allowlist. A **public** client
+(SPA / native / CLI) uses `token_endpoint_auth_method: none` and authenticates
+purely with PKCE — no secret. Register one with
+[Dynamic Client Registration](#dynamic-client-registration-rfc-7591):
+
+```bash
+curl -s -X POST http://localhost:3000/oauth/register \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "client_name": "My App",
+    "grant_types": ["authorization_code", "refresh_token"],
+    "response_types": ["code"],
+    "redirect_uris": ["http://localhost:5173/callback"],
+    "token_endpoint_auth_method": "none"
+  }' | jq
+# → { "client_id": "…", "token_endpoint_auth_method": "none", … }
+```
+
+> **Scopes are deny-by-default.** The authorize endpoint only grants scopes that
+> are in the client's allowlist. DCR-registered clients are capped to the realm
+> allowlist (`DEFAULT_DYNAMIC_REGISTRATION_SCOPES`); set that env var to include
+> any non-OIDC scopes (e.g. `mcp:read`) you intend to request.
+
+### 1. Generate a PKCE verifier and challenge (RFC 7636)
+
+```bash
+# code_verifier: 43–128 chars from [A-Za-z0-9._~-]
+code_verifier=$(openssl rand -base64 96 | tr -d '\n=+/' | cut -c1-64)
+
+# code_challenge = BASE64URL(SHA256(code_verifier))
+code_challenge=$(printf '%s' "$code_verifier" \
+  | openssl dgst -binary -sha256 \
+  | openssl base64 | tr '+/' '-_' | tr -d '=\n')
+
+echo "verifier=$code_verifier"
+echo "challenge=$code_challenge"
+```
+
+Keep `code_verifier` secret and in memory; you'll send it at the token step.
+
+### 2. Redirect the user to `/oauth/authorize`
+
+Open this URL **in a browser** (the user authenticates and consents at QAuth):
+
+```
+http://localhost:3000/oauth/authorize
+  ?response_type=code
+  &client_id=YOUR_CLIENT_ID
+  &redirect_uri=http://localhost:5173/callback
+  &code_challenge=CODE_CHALLENGE
+  &code_challenge_method=S256
+  &scope=openid%20profile%20email
+  &state=RANDOM_OPAQUE_VALUE
+  &resource=http://localhost:8088
+```
+
+| Parameter               | Required    | Notes                                                           |
+| ----------------------- | ----------- | --------------------------------------------------------------- |
+| `response_type`         | yes         | Must be `code`.                                                 |
+| `client_id`             | yes         | Your client.                                                    |
+| `redirect_uri`          | yes         | Must exactly match a registered URI.                            |
+| `code_challenge`        | yes         | From step 1.                                                    |
+| `code_challenge_method` | yes         | Must be `S256`.                                                 |
+| `scope`                 | no          | Space-separated; filtered to the client's allowlist.            |
+| `state`                 | recommended | Opaque CSRF value; echoed back verbatim.                        |
+| `nonce`                 | OIDC        | Bound into the ID token when issued.                            |
+| `resource`              | no          | RFC 8707 target(s); binds the token `aud`. Repeat for multiple. |
+
+QAuth flow: if there's no active session it shows the **login** page; then a
+**consent** screen for the requested scopes (skipped if a prior consent already
+covers them). On approval it redirects:
+
+```
+http://localhost:5173/callback?code=AUTH_CODE&state=RANDOM_OPAQUE_VALUE
+```
+
+Verify `state` matches what you sent before proceeding.
+
+### 3. Exchange the code for tokens
+
+```bash
+curl -s -X POST http://localhost:3000/oauth/token \
+  -H 'Content-Type: application/x-www-form-urlencoded' \
+  -d grant_type=authorization_code \
+  -d code=AUTH_CODE \
+  -d redirect_uri=http://localhost:5173/callback \
+  -d client_id=YOUR_CLIENT_ID \
+  -d code_verifier=$code_verifier \
+  -d resource=http://localhost:8088 | jq
+```
+
+```json
+{
+  "access_token": "eyJ…",
+  "refresh_token": "a1b2…(64 hex)",
+  "expires_in": 900,
+  "token_type": "Bearer",
+  "scope": "openid profile email"
+}
+```
+
+Notes:
+
+- **Confidential** clients additionally authenticate, either with HTTP Basic
+  (`-u "CLIENT_ID:CLIENT_SECRET"`, `client_secret_basic`) or by adding
+  `-d client_secret=…` (`client_secret_post`). Public clients send neither.
+- The authorization code is single-use and short-lived; the same
+  `redirect_uri` and a PKCE-matching `code_verifier` are mandatory.
+- `resource` here must be a **subset** of the resource set bound at authorize
+  time, or you get `invalid_target`. Omit it to inherit the code's binding.
+
+### 4. Call a protected resource
+
+```bash
+curl -s http://localhost:8088/mcp/memory \
+  -H "Authorization: Bearer ACCESS_TOKEN" | jq
+```
+
+A resource server (e.g. one using [`mcp-guard`](../libs/fastify/plugins/mcp-guard/README.md))
+verifies the signature against the JWKS and checks `iss`, `exp`, `aud`, and scope.
+
+---
+
+## Refresh Token (rotation)
+
+Renew an access token without re-prompting the user. QAuth **rotates** the
+refresh token on every use and detects replay (RFC 9700 §2.2.2): reusing a
+already-rotated token revokes the entire token family.
+
+```bash
+curl -s -X POST http://localhost:3000/oauth/token \
+  -H 'Content-Type: application/x-www-form-urlencoded' \
+  -d grant_type=refresh_token \
+  -d refresh_token=CURRENT_REFRESH_TOKEN \
+  -d client_id=YOUR_CLIENT_ID | jq
+```
+
+- The response contains a **new** `refresh_token` — store it and discard the old.
+- `scope` may be passed to **down-scope** only; requesting a scope not in the
+  original set returns `invalid_scope`. Omit it to keep the original scopes.
+- `resource` may **narrow** the audience but never widen it beyond the set bound
+  to the refresh token.
+- Confidential clients authenticate as in step 3; public clients send only
+  `client_id` (ownership is enforced by refresh-token binding).
+
+---
+
+## Client Credentials (machine-to-machine)
+
+No user, no browser. The token's `sub` is the `client_id` and no refresh token
+is issued.
+
+```bash
+curl -s -X POST http://localhost:3000/oauth/token \
+  -u "CLIENT_ID:CLIENT_SECRET" \
+  -H 'Content-Type: application/x-www-form-urlencoded' \
+  -d grant_type=client_credentials \
+  -d scope=mcp:read \
+  -d resource=http://localhost:8088 | jq
+```
+
+- The client must have the `client_credentials` grant and the requested scopes
+  in its `scopes` allowlist. **At least one scope is required** (a scopeless
+  machine token is rejected per RFC 9700).
+- `resource` must fall within the client's configured `audience` (or defaults to
+  the `client_id`); it sets the token `aud`.
+- Provision such clients with the seed script (it lets you set `scopes` and
+  `audience` explicitly) — see the
+  [MCP Quickstart, Option B](./mcp-quickstart.md#option-b--verify-the-handshake-with-curl-no-browser).
+
+---
+
+## Token Introspection (RFC 7662)
+
+Resource servers can validate opaque or near-real-time-revocable tokens by
+asking the AS. Requires **confidential** client authentication.
+
+```bash
+curl -s -X POST http://localhost:3000/oauth/introspect \
+  -u "CLIENT_ID:CLIENT_SECRET" \
+  -H 'Content-Type: application/x-www-form-urlencoded' \
+  -d token=ACCESS_TOKEN | jq
+```
+
+```json
+{
+  "active": true,
+  "sub": "…",
+  "client_id": "…",
+  "scope": "openid profile email",
+  "aud": "http://localhost:8088",
+  "iss": "http://localhost:3000",
+  "exp": 1750000000,
+  "iat": 1749999100,
+  "token_type": "Bearer"
+}
+```
+
+An inactive, expired, unknown, or wrong-audience token returns
+`{ "active": false }` with no other fields. For most resource servers, **local
+JWT verification against the JWKS is preferred** (no per-request round-trip);
+use introspection when you need immediate revocation.
+
+---
+
+## UserInfo (OIDC)
+
+Return the authenticated end user's claims for a user-context access token:
+
+```bash
+curl -s http://localhost:3000/oauth/userinfo \
+  -H "Authorization: Bearer ACCESS_TOKEN" | jq
+# → { "sub": "…", "email": "…", "email_verified": true }
+```
+
+---
+
+## Dynamic Client Registration (RFC 7591)
+
+`POST /oauth/register` is **open** (no `initial_access_token`) and rate-limited.
+See the example in [step 0](#0-prerequisites--a-client). Key fields:
+
+| Field                        | Notes                                                                  |
+| ---------------------------- | ---------------------------------------------------------------------- |
+| `redirect_uris`              | Required for `authorization_code`.                                     |
+| `grant_types`                | Subset of `authorization_code`, `refresh_token`, `client_credentials`. |
+| `token_endpoint_auth_method` | `none` (public/PKCE), `client_secret_basic`, or `client_secret_post`.  |
+| `scope`                      | Space-separated; **capped to the realm allowlist**.                    |
+
+For MCP clients, **CIMD** (an HTTPS-URL `client_id`) is the recommended
+alternative to DCR — see the [MCP Quickstart](./mcp-quickstart.md#client-registration-cimd-vs-dcr).
+
+---
+
+## Errors
+
+QAuth returns standard OAuth error codes (RFC 6749 §5.2):
+
+| Code                     | Meaning                                                                    |
+| ------------------------ | -------------------------------------------------------------------------- |
+| `invalid_request`        | Missing/malformed parameter.                                               |
+| `invalid_client`         | Client authentication failed or client unknown.                            |
+| `invalid_grant`          | Bad/expired code, bad PKCE verifier, or invalid/replayed refresh token.    |
+| `unauthorized_client`    | Client not allowed to use this grant.                                      |
+| `invalid_scope`          | Requested scope outside the allowlist (or empty for `client_credentials`). |
+| `invalid_target`         | RFC 8707 `resource` outside the grant's bound audience.                    |
+| `unsupported_grant_type` | Unknown `grant_type`.                                                      |
+
+---
+
+## See also
+
+- [MCP Quickstart](./mcp-quickstart.md) — end-to-end QAuth → MCP handshake.
+- [`@qauth-labs/mcp-guard`](../libs/fastify/plugins/mcp-guard/README.md) —
+  resource-server SDK that validates these tokens.
+- [ADR-006: OAuth grants and audience](./adr/006-oauth-grants-and-audience.md).

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,14 @@
 packages:
   - 'libs/**'
   - 'apps/**'
+# pnpm 11 defaults `verifyDepsBeforeRun` to "install": before any script/`pnpm exec`
+# it auto-installs when node_modules looks out of sync, and that reconcile can prune
+# devDeps — which needs a modules-dir purge. In non-TTY contexts (the husky pre-commit
+# hook, CI) the purge aborts with ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY. "warn"
+# keeps the "node_modules out of sync — run pnpm install" heads-up without ever
+# auto-installing or failing in non-interactive runs. (This setting is read from
+# pnpm-workspace.yaml in pnpm 11, not .npmrc.)
+verifyDepsBeforeRun: warn
 onlyBuiltDependencies:
   - '@swc/core'
   - 'esbuild'


### PR DESCRIPTION
## What

Turns the **already-shipped** MCP-auth surface (CIMD client registration + `@qauth-labs/mcp-guard`) into adoptable documentation — the [ADR-007](./docs/adr/007-mcp-first-positioning.md) "adoption lever." The code shipped a while ago; without docs, only the maintainer could wire QAuth to an MCP server.

Written **MCP-first**, not the pre-pivot "create account → get token" portal framing of the original issues.

## Changes

- **`docs/mcp-quickstart.md`** (#101) — end-to-end: run QAuth → run a `mcp-guard`-protected MCP resource server (the bundled `memory-mcp` example) → complete the full `401 → PRM → discovery → authorization_code + PKCE → token` handshake. Includes a fully scriptable `client_credentials` smoke test (no browser), CIMD-vs-DCR guidance, audience-binding explainer, and troubleshooting.
- **`docs/oauth-flow.md`** (#102) — every endpoint with copy-paste `curl`: PKCE generation, `/oauth/authorize`, token exchange, refresh-token rotation, `client_credentials`, introspection, UserInfo, DCR, and error codes.
- **`docs/README.md`** (#103) — docs hub with the four sections (Getting Started / OAuth Flow / API Reference / Code Examples) and cross-links.
- **`README.md`** — surfaces the guides in the Documentation section; adds `mcp-guard` to library docs; trims now-shipped items from "planned."

## Tooling fixes (separate commits)

- **`chore(deps)`** — `pnpm-workspace.yaml`: set **`verifyDepsBeforeRun: warn`**. pnpm 11 defaults this to `install`: before any script / `pnpm exec` (e.g. the husky pre-commit `pnpm exec lint-staged`) it auto-installs when `node_modules` looks out of sync. That reconcile can prune devDeps → modules-dir purge → in a **non-TTY** context (git hook, CI) it aborts with `ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY`, breaking the commit. `warn` keeps the heads-up without auto-installing/failing non-interactively. (In pnpm 11 this is read from `pnpm-workspace.yaml`, not `.npmrc` — verified behaviorally.)
- **`chore(config)`** — `commitlint.config.mjs`: add **`mcp`** to the `scope-enum` so MCP-specific commits (`docs(mcp)`, `feat(mcp)`) are valid, matching the ADR-007 MCP-first direction.

## Accuracy & validation

Endpoint contract sourced from the discovery builder (the authoritative URL source), not guessed. Every command was **verified end-to-end** against an isolated, throwaway stack:

| Step | Result |
| --- | --- |
| Discovery doc shape | matches (endpoints, `S256`, `resource_indicators_supported`, `client_id_metadata_document_supported`) |
| Warm-up DCR (realm bootstrap) | `201` |
| Seed `client_credentials` client | created |
| Token claims | `aud` bound to the resource, `scope=mcp:read`, `EdDSA` |
| PRM (no auth) | `resource` + `authorization_servers` |
| Protected call, no token | `401` + `WWW-Authenticate: Bearer resource_metadata=…` |
| Protected call + token | `200` (mcp-guard verified sig/iss/aud/scope) |
| Write with read-only token | `403 insufficient_scope` (step-up) |

## Follow-ups (not in this PR)

- #99 — standalone API reference (its `/api/clients` section is gated on the T2 milestone)
- #100 — Node/TypeScript client code examples

Refs #101, #102, #103