### PR TITLE
docs(api): API reference and client code examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -691,6 +691,8 @@ function Dashboard() {
 
 - [MCP Quickstart](./docs/mcp-quickstart.md) — run QAuth + a `mcp-guard`-protected MCP server and complete the full OAuth handshake end-to-end
 - [OAuth 2.1 Flow](./docs/oauth-flow.md) — every endpoint with copy-paste `curl` (PKCE, authorize, token, refresh, client_credentials, introspection)
+- [API Reference](./docs/api-reference.md) — hand-written contract for `/auth/*`, `/oauth/*`, discovery, and `/api/clients`
+- [Code Examples](./docs/code-examples.md) — copy-paste Node/TS and browser (PKCE) clients
 - [Docker Development Guide](./docs/docker.md) — local development with Docker
 
 **Reference:**
@@ -714,8 +716,6 @@ function Dashboard() {
 
 **Planned documentation** (future phases):
 
-- Standalone API Reference ([#99](https://github.com/qauth-labs/qauth/issues/99)) — incl. client-management endpoints (T2)
-- Node/TypeScript client code examples ([#100](https://github.com/qauth-labs/qauth/issues/100))
 - SDK Documentation (Phase 3)
 - Multi-tenancy Guide
 - Security Best Practices

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,27 +21,29 @@ interactive **Swagger UI at `/docs`** on any running instance.
 
 ## API reference
 
-QAuth serves a live OpenAPI / Swagger UI at **`/docs`** on the running
-instance — that is the authoritative, versioned reference for request/response
-shapes and error codes.
+| Guide                                   | What it covers                                                                                                                                                                                                         |
+| --------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [**API Reference**](./api-reference.md) | Hand-written contract for every endpoint: first-party auth (`/auth/*`), OAuth 2.1 (`/oauth/*`), discovery, and client management (`/api/clients`), with request/response shapes, status codes, and the error envelope. |
 
-- **OAuth / OIDC endpoints** — documented with examples in
-  [OAuth 2.1 Flow](./oauth-flow.md).
+The authoritative, always-current surface is the live OpenAPI / Swagger UI at
+**`/docs`** on the running instance. Also:
+
 - **Resource-server SDK** — [`@qauth-labs/mcp-guard`](../libs/fastify/plugins/mcp-guard/README.md)
   (Protected Resource Metadata, Bearer challenges, JWT/introspection validation).
-- **Auth & client-management endpoints** — a standalone, hand-written reference
-  ([issue #99](https://github.com/qauth-labs/qauth/issues/99)) is in progress; the
-  client-management (`/api/clients`) section lands with the T2 milestone.
+- The client-management write endpoints (`POST/PATCH/DELETE /api/clients`, regenerate-secret)
+  land with the T2 milestone — see the [API Reference](./api-reference.md#planned--gated-on-the-t2-milestone).
 
 ## Code examples
+
+| Guide                                   | What it covers                                                                                                                                                             |
+| --------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [**Code Examples**](./code-examples.md) | Copy-paste-ready clients — Node/TS (first-party register→login→protected call; machine `client_credentials`) and browser JS (`authorization_code` + PKCE with Web Crypto). |
 
 - [`memory-mcp` example server](../libs/fastify/plugins/mcp-guard/examples/memory-mcp/server.ts) —
   a runnable, `mcp-guard`-protected resource server (the resource half of the
   quickstart).
 - Copy-paste `curl` for every OAuth step in the [OAuth 2.1 Flow](./oauth-flow.md)
   guide.
-- A Node/TypeScript client walkthrough ([issue #100](https://github.com/qauth-labs/qauth/issues/100))
-  is planned.
 
 ## Architecture & decisions
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,0 +1,271 @@
+# API Reference
+
+Hand-written reference for QAuth's HTTP endpoints. The **authoritative, always-current**
+contract is the interactive **OpenAPI / Swagger UI at `/docs`** on any running
+instance — this page is a stable, linkable companion.
+
+For step-by-step flows with copy-paste `curl`, see the [OAuth 2.1 Flow](./oauth-flow.md)
+guide; for working client code, see [Code Examples](./code-examples.md).
+
+**Conventions**
+
+- Base URL / issuer: `http://localhost:3000` (your `JWT_ISSUER`).
+- First-party auth and client-management bodies are **JSON** (`application/json`)
+  with **camelCase** fields. OAuth wire endpoints (`/oauth/*`) use
+  **`application/x-www-form-urlencoded`** with **snake_case** per the RFCs.
+- Access tokens are **EdDSA (Ed25519)** JWTs; verify against
+  `GET /.well-known/jwks.json`.
+
+## Error model
+
+Errors share a single envelope:
+
+```json
+{ "error": "human-readable message", "statusCode": 400, "code": "OPTIONAL_CODE" }
+```
+
+Schema-validation failures use:
+
+```json
+{ "error": "Validation error", "code": "VALIDATION_ERROR", "statusCode": 400 }
+```
+
+OAuth endpoints additionally return the standard OAuth error codes documented in
+[OAuth 2.1 Flow → Errors](./oauth-flow.md#errors) (e.g. `invalid_grant`,
+`invalid_client`, `invalid_scope`, `invalid_target`).
+
+| Status | Meaning                                                   |
+| ------ | --------------------------------------------------------- |
+| `400`  | Malformed request / validation error                      |
+| `401`  | Missing, malformed, or invalid bearer token               |
+| `403`  | Authenticated but not permitted (e.g. insufficient scope) |
+| `404`  | Resource not found                                        |
+| `409`  | Conflict (e.g. email already registered)                  |
+| `429`  | Rate limited                                              |
+
+---
+
+## First-party authentication
+
+Email/password endpoints for **end users of your own application**. Third-party
+/ MCP clients use the [OAuth endpoints](#oauth-21) instead.
+
+### `POST /auth/register`
+
+Create a user account. A verification email is sent (the `mock` provider logs it).
+
+**Request** (`application/json`)
+
+| Field      | Type           | Required | Notes                                         |
+| ---------- | -------------- | -------- | --------------------------------------------- |
+| `email`    | string (email) | yes      |                                               |
+| `password` | string         | yes      | Strength enforced server-side (zxcvbn score). |
+| `realmId`  | string (uuid)  | no       | Defaults to the server's default realm.       |
+
+**`201 Created`**
+
+```json
+{
+  "id": "0190f7c2-...",
+  "email": "dev@example.com",
+  "emailVerified": false,
+  "realmId": "0190f7c0-...",
+  "createdAt": 1750000000000,
+  "updatedAt": null
+}
+```
+
+Errors: `400` (validation / weak password), `409` (email already registered),
+`429` (rate limited).
+
+### `POST /auth/login`
+
+Authenticate with email/password and receive tokens directly (first-party).
+
+**Request** (`application/json`): `{ "email": "...", "password": "..." }`
+
+**`200 OK`**
+
+```json
+{
+  "access_token": "eyJ…",
+  "refresh_token": "a1b2…(64 hex)",
+  "expires_in": 900,
+  "token_type": "Bearer"
+}
+```
+
+Errors: `400` (validation), `401` (invalid credentials), `429` (rate limited).
+Renew the access token with the [`refresh_token` grant](./oauth-flow.md#refresh-token-rotation)
+at `POST /oauth/token` — there is no separate refresh endpoint.
+
+### `POST /auth/logout`
+
+Revoke the caller's session/token.
+
+**Headers**: `Authorization: Bearer <access_token>` (required).
+
+**`200 OK`**: `{ "success": true, "message": "Successfully logged out" }`
+
+Errors: `401` (missing/invalid bearer).
+
+### `GET /auth/verify`
+
+Confirm an email address from the link in the verification email.
+
+**Query**: `token` — 64-char hex string.
+
+**`200 OK`**: `{ "message": "...", "email": "dev@example.com" }`
+
+Errors: `400` (malformed token), `404`/`400` (unknown or expired token).
+
+### `POST /auth/resend-verification`
+
+Re-send the verification email. Rate-limited per address (min-interval +
+per-window caps).
+
+**Request** (`application/json`): `{ "email": "dev@example.com" }`
+
+**`200 OK`**: `{ "message": "..." }` — returned even for unknown addresses
+(no account enumeration). Errors: `429` (too soon / over limit).
+
+---
+
+## OAuth 2.1
+
+Full request/response detail and a worked end-to-end walkthrough live in the
+[OAuth 2.1 Flow](./oauth-flow.md) guide. Contract summary:
+
+| Endpoint                                                                    | Method | Body type | Purpose                                                       |
+| --------------------------------------------------------------------------- | ------ | --------- | ------------------------------------------------------------- |
+| [`/oauth/authorize`](./oauth-flow.md#2-redirect-the-user-to-oauthauthorize) | GET    | query     | Start `authorization_code` + PKCE (browser)                   |
+| [`/oauth/token`](./oauth-flow.md#3-exchange-the-code-for-tokens)            | POST   | form      | `authorization_code` / `refresh_token` / `client_credentials` |
+| [`/oauth/introspect`](./oauth-flow.md#token-introspection-rfc-7662)         | POST   | form      | Token introspection (RFC 7662) — confidential clients only    |
+| [`/oauth/userinfo`](./oauth-flow.md#userinfo-oidc)                          | GET    | —         | OIDC UserInfo (Bearer)                                        |
+| [`/oauth/register`](./oauth-flow.md#dynamic-client-registration-rfc-7591)   | POST   | JSON      | Dynamic Client Registration (RFC 7591, open mode)             |
+
+Key contract facts:
+
+- `response_type` is `code` only; `code_challenge_method` is `S256` only (PKCE required).
+- Tokens carry `iss`, `aud` (RFC 8707 resource binding), `exp`, `iat`, and `scope`.
+- `client_credentials` tokens set `sub = client_id` and issue **no** refresh token.
+- Scopes are **deny-by-default** (client allowlist; DCR clients capped to the
+  realm's `DEFAULT_DYNAMIC_REGISTRATION_SCOPES`).
+
+### Token response (`POST /oauth/token`, `200 OK`)
+
+```json
+{
+  "access_token": "eyJ…",
+  "refresh_token": "a1b2…", // omitted for client_credentials
+  "expires_in": 900,
+  "token_type": "Bearer",
+  "scope": "openid profile email" // present when scopes granted
+}
+```
+
+### Introspection response (`POST /oauth/introspect`, `200 OK`)
+
+```json
+{
+  "active": true,
+  "sub": "...",
+  "client_id": "...",
+  "scope": "mcp:read",
+  "aud": "http://localhost:8088",
+  "iss": "http://localhost:3000",
+  "exp": 1750000000,
+  "iat": 1749999100,
+  "token_type": "Bearer"
+}
+```
+
+An inactive/expired/unknown/wrong-audience token returns `{ "active": false }`.
+
+### UserInfo response (`GET /oauth/userinfo`, `200 OK`)
+
+```json
+{ "sub": "...", "email": "dev@example.com", "email_verified": true }
+```
+
+---
+
+## Discovery
+
+Unauthenticated, cacheable (`Cache-Control: public, max-age=3600`).
+
+| Endpoint                                      | Returns                                      |
+| --------------------------------------------- | -------------------------------------------- |
+| `GET /.well-known/oauth-authorization-server` | OAuth 2.0 AS metadata (RFC 8414)             |
+| `GET /.well-known/openid-configuration`       | OIDC Discovery 1.0 (superset of the above)   |
+| `GET /.well-known/jwks.json`                  | JWKS — active EdDSA public key(s) (RFC 7517) |
+
+Prefer discovering endpoint URLs from these documents over hard-coding paths.
+The AS metadata advertises `resource_indicators_supported: true` and, when
+enabled, `client_id_metadata_document_supported: true` (CIMD).
+
+---
+
+## Client management (`/api/clients`)
+
+Developer-portal API for managing a developer's own OAuth clients. **JSON**,
+**camelCase**, and authenticated with a developer **`Authorization: Bearer`**
+access token (from [`POST /auth/login`](#post-authlogin)). Results are scoped to
+the token subject's `developer_id`; the client secret is **never** returned.
+
+### `GET /api/clients`
+
+List the authenticated developer's OAuth clients.
+
+**Headers**: `Authorization: Bearer <access_token>` (required).
+
+**`200 OK`**
+
+```json
+{
+  "clients": [
+    {
+      "id": "0190f7…",
+      "clientId": "my-app",
+      "name": "My App",
+      "description": null,
+      "redirectUris": ["http://localhost:5173/callback"],
+      "scopes": ["openid", "profile"],
+      "grantTypes": ["authorization_code", "refresh_token"],
+      "responseTypes": ["code"],
+      "tokenEndpointAuthMethod": "none",
+      "enabled": true,
+      "requirePkce": true,
+      "createdAt": 1750000000000,
+      "updatedAt": 1750000000000,
+      "lastUsedAt": null
+    }
+  ]
+}
+```
+
+A developer with no clients gets `{ "clients": [] }`. Errors: `401` (missing/invalid bearer).
+
+### Planned — gated on the T2 milestone
+
+The write operations are not yet implemented (tracked under
+[T2 — Agent-native authZ](https://github.com/qauth-labs/qauth/milestones)):
+
+| Endpoint                             | Method | Issue                                                |
+| ------------------------------------ | ------ | ---------------------------------------------------- |
+| `/api/clients`                       | POST   | [#86](https://github.com/qauth-labs/qauth/issues/86) |
+| `/api/clients/:id`                   | GET    | [#87](https://github.com/qauth-labs/qauth/issues/87) |
+| `/api/clients/:id`                   | PATCH  | [#88](https://github.com/qauth-labs/qauth/issues/88) |
+| `/api/clients/:id`                   | DELETE | [#89](https://github.com/qauth-labs/qauth/issues/89) |
+| `/api/clients/:id/regenerate-secret` | POST   | [#90](https://github.com/qauth-labs/qauth/issues/90) |
+
+Until they land, register clients via [Dynamic Client Registration](./oauth-flow.md#dynamic-client-registration-rfc-7591)
+(`POST /oauth/register`), CIMD, or the `seed-oauth-clients` script.
+
+---
+
+## See also
+
+- [OAuth 2.1 Flow](./oauth-flow.md) — worked flows with `curl`.
+- [Code Examples](./code-examples.md) — runnable Node/TS and browser clients.
+- [MCP Quickstart](./mcp-quickstart.md) — protect an MCP server end-to-end.

--- a/docs/code-examples.md
+++ b/docs/code-examples.md
@@ -1,0 +1,245 @@
+# Code Examples
+
+Copy-paste-ready client code for QAuth. All snippets target a local instance at
+`http://localhost:3000` (your `JWT_ISSUER`); override with an env var for other
+environments. See the [API Reference](./api-reference.md) for full endpoint
+contracts and the [OAuth 2.1 Flow](./oauth-flow.md) for the protocol details.
+
+> **Never hard-code secrets.** Client secrets and passwords below are read from
+> environment variables. Public clients (SPA / native / CLI) hold no secret and
+> authenticate with PKCE instead.
+
+---
+
+## Node.js / TypeScript
+
+Requires **Node 20+** (global `fetch`). Run any snippet with
+`npx tsx example.ts`.
+
+### 1. First-party: register → login → call a protected endpoint
+
+Mirrors the [first-party auth endpoints](./api-reference.md#first-party-authentication):
+create a user, log in for tokens, then call a Bearer-protected endpoint
+(`GET /api/clients`).
+
+```ts
+// first-party.ts
+const QAUTH = process.env.QAUTH_URL ?? 'http://localhost:3000';
+const email = process.env.QAUTH_EMAIL ?? 'dev@example.com';
+const password = process.env.QAUTH_PASSWORD ?? 'corr3ct-h0rse-batt3ry'; // demo only
+
+async function post(path: string, body: unknown, token?: string) {
+  const res = await fetch(`${QAUTH}${path}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+    body: JSON.stringify(body),
+  });
+  const json = await res.json().catch(() => ({}));
+  if (!res.ok) throw new Error(`${path} → ${res.status}: ${JSON.stringify(json)}`);
+  return json as any;
+}
+
+async function main() {
+  // 1. Register (idempotent-ish: ignore 409 if the user already exists).
+  try {
+    const user = await post('/auth/register', { email, password });
+    console.log('registered:', user.id, user.email);
+  } catch (err) {
+    if (!String(err).includes('409')) throw err;
+    console.log('user already exists, continuing');
+  }
+
+  // 2. Log in → tokens.
+  const { access_token, refresh_token, expires_in } = await post('/auth/login', {
+    email,
+    password,
+  });
+  console.log(`logged in; access token expires in ${expires_in}s`);
+
+  // 3. Call a protected endpoint with the bearer token.
+  const res = await fetch(`${QAUTH}/api/clients`, {
+    headers: { Authorization: `Bearer ${access_token}` },
+  });
+  const data = await res.json();
+  console.log(`GET /api/clients → ${res.status}`, data); // { clients: [] } for a new user
+
+  // 4. (Later) renew the access token without re-prompting:
+  const renewed = await fetch(`${QAUTH}/oauth/token`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({ grant_type: 'refresh_token', refresh_token }),
+  }).then((r) => r.json());
+  console.log('refreshed access token:', renewed.access_token?.slice(0, 12), '…');
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});
+```
+
+### 2. Machine-to-machine: `client_credentials` → call a resource
+
+For service clients (no user). The token is audience-bound (RFC 8707) and useless
+at any other resource server. Provision the client with the `seed-oauth-clients`
+script so it has the right `scopes` + `audience` (see the
+[MCP Quickstart](./mcp-quickstart.md#option-b--verify-the-handshake-with-curl-no-browser)).
+
+```ts
+// machine.ts
+const QAUTH = process.env.QAUTH_URL ?? 'http://localhost:3000';
+const RESOURCE = process.env.MCP_RESOURCE ?? 'http://localhost:8088';
+const clientId = process.env.CLIENT_ID!; // e.g. "memory-mcp-demo"
+const clientSecret = process.env.CLIENT_SECRET!; // from the seed script output
+
+async function getToken(scope: string): Promise<string> {
+  const basic = Buffer.from(`${clientId}:${clientSecret}`).toString('base64');
+  const res = await fetch(`${QAUTH}/oauth/token`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      Authorization: `Basic ${basic}`, // client_secret_basic
+    },
+    body: new URLSearchParams({
+      grant_type: 'client_credentials',
+      scope,
+      resource: RESOURCE, // binds the token `aud` to this resource
+    }),
+  });
+  if (!res.ok) throw new Error(`token → ${res.status}: ${await res.text()}`);
+  const { access_token } = await res.json();
+  return access_token;
+}
+
+async function main() {
+  const token = await getToken('mcp:read');
+  const res = await fetch(`${RESOURCE}/mcp/memory`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  console.log(`GET ${RESOURCE}/mcp/memory → ${res.status}`, await res.json());
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});
+```
+
+```bash
+CLIENT_ID=memory-mcp-demo CLIENT_SECRET=<from seed output> npx tsx machine.ts
+```
+
+---
+
+## Browser / JavaScript — Authorization Code + PKCE
+
+A public SPA client (no secret) using the Web Crypto API for PKCE. Register the
+client first with `token_endpoint_auth_method: "none"` and your `redirect_uri`
+(see the [OAuth Flow, step 0](./oauth-flow.md#0-prerequisites--a-client)).
+
+```js
+// auth.js — drop into a SPA; serves the redirect at /callback
+const QAUTH = 'http://localhost:3000';
+const CLIENT_ID = 'YOUR_PUBLIC_CLIENT_ID';
+const REDIRECT_URI = window.location.origin + '/callback';
+const SCOPE = 'openid profile email';
+const RESOURCE = 'http://localhost:8088'; // optional RFC 8707 audience binding
+
+// --- PKCE helpers (RFC 7636) ---
+function base64url(bytes) {
+  return btoa(String.fromCharCode(...new Uint8Array(bytes)))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+}
+function randomVerifier() {
+  return base64url(crypto.getRandomValues(new Uint8Array(48))); // 64 chars
+}
+async function challengeFrom(verifier) {
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(verifier));
+  return base64url(digest);
+}
+
+// --- 1. Begin login: redirect to /oauth/authorize ---
+async function login() {
+  const verifier = randomVerifier();
+  const state = base64url(crypto.getRandomValues(new Uint8Array(16)));
+  sessionStorage.setItem('pkce_verifier', verifier);
+  sessionStorage.setItem('oauth_state', state);
+
+  const params = new URLSearchParams({
+    response_type: 'code',
+    client_id: CLIENT_ID,
+    redirect_uri: REDIRECT_URI,
+    code_challenge: await challengeFrom(verifier),
+    code_challenge_method: 'S256',
+    scope: SCOPE,
+    state,
+    resource: RESOURCE,
+  });
+  window.location.assign(`${QAUTH}/oauth/authorize?${params}`);
+}
+
+// --- 2. Handle the redirect back at /callback ---
+async function handleCallback() {
+  const url = new URL(window.location.href);
+  const code = url.searchParams.get('code');
+  const returnedState = url.searchParams.get('state');
+  if (!code) return; // not a callback
+
+  if (returnedState !== sessionStorage.getItem('oauth_state')) {
+    throw new Error('state mismatch — possible CSRF');
+  }
+  const verifier = sessionStorage.getItem('pkce_verifier');
+
+  const res = await fetch(`${QAUTH}/oauth/token`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      grant_type: 'authorization_code',
+      code,
+      redirect_uri: REDIRECT_URI,
+      client_id: CLIENT_ID, // public client: no secret
+      code_verifier: verifier,
+      resource: RESOURCE,
+    }),
+  });
+  const tokens = await res.json();
+  if (!res.ok) throw new Error(`token → ${res.status}: ${JSON.stringify(tokens)}`);
+
+  sessionStorage.removeItem('pkce_verifier');
+  sessionStorage.removeItem('oauth_state');
+  return tokens; // { access_token, refresh_token, expires_in, token_type, scope }
+}
+
+// --- 3. Call a protected API with the access token ---
+async function callApi(accessToken) {
+  const res = await fetch(`${QAUTH}/oauth/userinfo`, {
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+  return res.json(); // { sub, email, email_verified }
+}
+
+// Wire up: run handleCallback() on /callback, login() on a button click.
+handleCallback().then((tokens) => {
+  if (tokens) callApi(tokens.access_token).then((u) => console.log('user:', u));
+});
+```
+
+> **Security notes.** Always validate `state` on return (CSRF). Keep the
+> `code_verifier` out of the URL and in `sessionStorage`. For production SPAs,
+> prefer storing tokens in memory and renewing via the
+> [`refresh_token` grant](./oauth-flow.md#refresh-token-rotation) over persisting
+> long-lived tokens.
+
+---
+
+## See also
+
+- [API Reference](./api-reference.md) — full endpoint contracts.
+- [OAuth 2.1 Flow](./oauth-flow.md) — protocol walkthrough with `curl`.
+- [`memory-mcp` example](../libs/fastify/plugins/mcp-guard/examples/memory-mcp/server.ts) —
+  a runnable resource server protected by `@qauth-labs/mcp-guard`.


### PR DESCRIPTION
Completes the **Phase 2.3 docs set** — the two remaining T1 follow-ups after the merged quickstart/flow guides (#179).

## Changes

- **`docs/api-reference.md`** (#99) — hand-written contract for every endpoint, a stable companion to the live Swagger UI at `/docs`:
  - First-party auth: `POST /auth/register` (201), `/auth/login` (200, returns tokens), `/auth/logout`, `GET /auth/verify`, `/auth/resend-verification`
  - OAuth 2.1: `authorize` / `token` (3 grants) / `introspect` / `userinfo` / `register` — contract summary linking to the flow guide
  - Discovery: the three `/.well-known/*` documents
  - Client management: `GET /api/clients` (implemented); `POST/PATCH/DELETE /api/clients` + `regenerate-secret` marked **pending T2** (#86–#90)
  - Shared error envelope `{ error, statusCode, code? }` + status-code table
- **`docs/code-examples.md`** (#100) — copy-paste-ready clients:
  - **Node/TS**: first-party `register → login → GET /api/clients`; machine `client_credentials → call a resource`
  - **Browser JS**: `authorization_code` + PKCE with the Web Crypto API (public client, `state` CSRF check)
- **`docs/README.md` / `README.md`** — both promoted to available guides; removed from "planned."

## Accuracy

Contract sourced directly from the auth-server route schemas (`schemas/auth.ts`, `schemas/clients.ts`, `schemas/oauth.ts`) and discovery builder. The flagship first-party example was **source-verified**: `requireJwt` validates the access token and uses `sub` as the developer id (no extra audience/scope gate), so a login token lists `{clients:[]}` for a new user. The `client_credentials` flow was validated end-to-end in #179. The browser PKCE flow is source-accurate (requires an interactive browser login to run).

Closes #99
Closes #100