### PR TITLE
feat(api): client-management CRUD endpoints (#86–#90)

### DIFF
--- a/apps/auth-server/src/app/routes/clients/clients.test.ts
+++ b/apps/auth-server/src/app/routes/clients/clients.test.ts
@@ -11,6 +11,9 @@ vi.mock('../../../config/env', () => ({
     EMAIL_FROM_ADDRESS: 'noreply@example.com',
     EMAIL_BASE_URL: 'http://localhost:3000',
     DEFAULT_REALM_NAME: 'master',
+    REGISTER_CLIENT_RATE_LIMIT: 30,
+    REGISTER_CLIENT_RATE_WINDOW: 60,
+    DEFAULT_DYNAMIC_REGISTRATION_SCOPES: ['openid', 'profile', 'email', 'offline_access'],
   },
 }));
 
@@ -19,6 +22,13 @@ import clientsRoute, { autoPrefix } from './index';
 type RouteHandler = (request: FastifyRequest, reply: FastifyReply) => Promise<unknown>;
 interface RouteOptions {
   preHandler?: (request: FastifyRequest, reply: FastifyReply) => Promise<void>;
+  config?: {
+    rateLimit?: {
+      max?: number;
+      timeWindow?: number;
+      keyGenerator?: (req: { ip?: string }) => string;
+    };
+  };
 }
 interface RegisteredRoute {
   handler: RouteHandler;
@@ -92,7 +102,21 @@ function makeFastify() {
         delete: vi.fn(),
       },
       realms: {
-        findByName: vi.fn(async () => ({ id: 'realm-1', name: 'default', enabled: true })),
+        // Realm already carries a seeded allowlist so scope-cap tests are
+        // deterministic and don't depend on the env-seeding write path.
+        findByName: vi.fn(async () => ({
+          id: 'realm-1',
+          name: 'default',
+          enabled: true,
+          dynamicRegistrationAllowedScopes: ['openid', 'profile', 'email', 'offline_access'],
+        })),
+        findById: vi.fn(async () => ({
+          id: 'realm-1',
+          name: 'default',
+          enabled: true,
+          dynamicRegistrationAllowedScopes: ['openid', 'profile', 'email', 'offline_access'],
+        })),
+        update: vi.fn(),
         create: vi.fn(),
       },
       auditLogs: {
@@ -662,5 +686,266 @@ describe('POST /api/clients/:id/regenerate-secret — #90', () => {
       NotFoundError
     );
     expect(fastify.repositories.oauthClients.update).not.toHaveBeenCalled();
+  });
+});
+
+describe('per-route rate limiting on argon2id endpoints', () => {
+  it('caps POST / (create) per-IP at the REGISTER_CLIENT budget', async () => {
+    const { fastify, ctx } = makeFastify();
+    await clientsRoute(fastify);
+
+    const rl = route(ctx, 'POST /').options.config?.rateLimit;
+    expect(rl).toBeDefined();
+    expect(rl?.max).toBe(30);
+    expect(rl?.timeWindow).toBe(60 * 1000);
+    // Keyed by IP so one developer's burst can't exhaust everyone's budget.
+    expect(rl?.keyGenerator?.({ ip: '203.0.113.7' })).toBe('203.0.113.7');
+    expect(rl?.keyGenerator?.({})).toBe('unknown');
+  });
+
+  it('caps POST /:id/regenerate-secret per-IP at the REGISTER_CLIENT budget', async () => {
+    const { fastify, ctx } = makeFastify();
+    await clientsRoute(fastify);
+
+    const rl = route(ctx, 'POST /:id/regenerate-secret').options.config?.rateLimit;
+    expect(rl).toBeDefined();
+    expect(rl?.max).toBe(30);
+    expect(rl?.timeWindow).toBe(60 * 1000);
+    expect(rl?.keyGenerator?.({ ip: '203.0.113.7' })).toBe('203.0.113.7');
+  });
+
+  it('does not rate-limit the read-only GET routes', async () => {
+    const { fastify, ctx } = makeFastify();
+    await clientsRoute(fastify);
+
+    expect(route(ctx, 'GET /').options.config?.rateLimit).toBeUndefined();
+    expect(route(ctx, 'GET /:id').options.config?.rateLimit).toBeUndefined();
+  });
+});
+
+describe('scope allowlist enforcement (#86/#88)', () => {
+  it('rejects create when a requested scope is outside the realm allowlist', async () => {
+    const { fastify, ctx } = makeFastify();
+    await clientsRoute(fastify);
+
+    const request = authedRequest({
+      body: {
+        name: 'Over-scoped',
+        redirectUris: ['https://app.example.com/cb'],
+        // `memory:admin` is not in the realm allowlist.
+        scopes: ['openid', 'memory:admin'],
+        tokenEndpointAuthMethod: 'client_secret_post',
+      },
+    });
+    const { reply } = createReply();
+
+    await expect(route(ctx, 'POST /').handler(request, reply)).rejects.toThrow(BadRequestError);
+    // Rejected before hashing or persisting.
+    expect(fastify.passwordHasher.hashPassword).not.toHaveBeenCalled();
+    expect(fastify.repositories.oauthClients.create).not.toHaveBeenCalled();
+  });
+
+  it('allows create when every requested scope is within the realm allowlist', async () => {
+    const { fastify, ctx } = makeFastify();
+    await clientsRoute(fastify);
+
+    (fastify.repositories.oauthClients.create as unknown as Mock).mockImplementation(
+      async (data: Record<string, unknown>) => makeClientRow({ ...data })
+    );
+
+    const request = authedRequest({
+      body: {
+        name: 'OK',
+        redirectUris: ['https://app.example.com/cb'],
+        scopes: ['openid', 'email'],
+        tokenEndpointAuthMethod: 'client_secret_post',
+      },
+    });
+    const { reply, state } = createReply();
+
+    await route(ctx, 'POST /').handler(request, reply);
+    expect(state.statusCode).toBe(201);
+  });
+
+  it('rejects a PATCH that widens scopes beyond the realm allowlist', async () => {
+    const { fastify, ctx } = makeFastify();
+    await clientsRoute(fastify);
+
+    (fastify.repositories.oauthClients.findById as unknown as Mock).mockResolvedValue(
+      makeClientRow({ developerId: DEV_A })
+    );
+
+    const request = authedRequest({
+      params: { id: '0190a000-0000-7000-8000-000000000001' },
+      body: { scopes: ['openid', 'akinon:write'] },
+    });
+    const { reply } = createReply();
+
+    await expect(route(ctx, 'PATCH /:id').handler(request, reply)).rejects.toThrow(BadRequestError);
+    expect(fastify.repositories.oauthClients.update).not.toHaveBeenCalled();
+  });
+});
+
+describe('redirect_uris required for user-involving grants (#86/#88)', () => {
+  it('rejects create of an authorization_code client with no redirect_uris', async () => {
+    const { fastify, ctx } = makeFastify();
+    await clientsRoute(fastify);
+
+    const request = authedRequest({
+      body: {
+        name: 'No redirects',
+        redirectUris: [],
+        grantTypes: ['authorization_code', 'refresh_token'],
+        responseTypes: ['code'],
+        tokenEndpointAuthMethod: 'client_secret_post',
+      },
+    });
+    const { reply } = createReply();
+
+    await expect(route(ctx, 'POST /').handler(request, reply)).rejects.toThrow(BadRequestError);
+    expect(fastify.repositories.oauthClients.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects a PATCH that empties redirect_uris on an authorization_code client', async () => {
+    const { fastify, ctx } = makeFastify();
+    await clientsRoute(fastify);
+
+    (fastify.repositories.oauthClients.findById as unknown as Mock).mockResolvedValue(
+      makeClientRow({
+        developerId: DEV_A,
+        grantTypes: ['authorization_code', 'refresh_token'],
+        responseTypes: ['code'],
+        redirectUris: ['https://app.example.com/cb'],
+      })
+    );
+
+    const request = authedRequest({
+      params: { id: '0190a000-0000-7000-8000-000000000001' },
+      body: { redirectUris: [] },
+    });
+    const { reply } = createReply();
+
+    await expect(route(ctx, 'PATCH /:id').handler(request, reply)).rejects.toThrow(BadRequestError);
+    expect(fastify.repositories.oauthClients.update).not.toHaveBeenCalled();
+  });
+
+  it('allows a client_credentials-only client with no redirect_uris', async () => {
+    const { fastify, ctx } = makeFastify();
+    await clientsRoute(fastify);
+
+    (fastify.repositories.oauthClients.create as unknown as Mock).mockImplementation(
+      async (data: Record<string, unknown>) => makeClientRow({ ...data })
+    );
+
+    const request = authedRequest({
+      body: {
+        name: 'Service',
+        redirectUris: [],
+        grantTypes: ['client_credentials'],
+        responseTypes: [],
+        tokenEndpointAuthMethod: 'client_secret_post',
+      },
+    });
+    const { reply, state } = createReply();
+
+    await route(ctx, 'POST /').handler(request, reply);
+    expect(state.statusCode).toBe(201);
+  });
+});
+
+describe('audit logging is best-effort (one-time secret must survive #86/#90)', () => {
+  it('still returns the created client + secret when the audit write throws', async () => {
+    const { fastify, ctx } = makeFastify();
+    await clientsRoute(fastify);
+
+    (fastify.repositories.oauthClients.create as unknown as Mock).mockImplementation(
+      async (data: Record<string, unknown>) => makeClientRow({ ...data })
+    );
+    (fastify.repositories.auditLogs.create as unknown as Mock).mockRejectedValue(
+      new Error('audit sink down')
+    );
+
+    const request = authedRequest({
+      body: {
+        name: 'Resilient',
+        redirectUris: ['https://app.example.com/cb'],
+        tokenEndpointAuthMethod: 'client_secret_post',
+      },
+    });
+    const { reply, state } = createReply();
+
+    const body = (await route(ctx, 'POST /').handler(request, reply)) as Record<string, unknown>;
+
+    expect(state.statusCode).toBe(201);
+    expect(typeof body.clientSecret).toBe('string');
+    // The failure was swallowed and logged, not propagated.
+    expect(fastify.log.warn).toHaveBeenCalled();
+  });
+
+  it('still returns the rotated secret when the audit write throws', async () => {
+    const { fastify, ctx } = makeFastify();
+    await clientsRoute(fastify);
+
+    (fastify.repositories.oauthClients.findById as unknown as Mock).mockResolvedValue(
+      makeClientRow({ developerId: DEV_A, tokenEndpointAuthMethod: 'client_secret_post' })
+    );
+    (fastify.repositories.oauthClients.update as unknown as Mock).mockImplementation(
+      async (_id: string, data: Record<string, unknown>) =>
+        makeClientRow({ developerId: DEV_A, ...data })
+    );
+    (fastify.repositories.auditLogs.create as unknown as Mock).mockRejectedValue(
+      new Error('audit sink down')
+    );
+
+    const request = authedRequest({ params: { id: '0190a000-0000-7000-8000-000000000001' } });
+    const { reply } = createReply();
+
+    const body = (await route(ctx, 'POST /:id/regenerate-secret').handler(
+      request,
+      reply
+    )) as Record<string, unknown>;
+
+    expect(typeof body.clientSecret).toBe('string');
+    expect((body.clientSecret as string).length).toBe(64);
+    expect(fastify.log.warn).toHaveBeenCalled();
+  });
+});
+
+describe('PATCH silently drops immutable fields (#88, Nit 8)', () => {
+  it('never forwards developerId / clientId / clientSecretHash to the repository', async () => {
+    const { fastify, ctx } = makeFastify();
+    await clientsRoute(fastify);
+
+    (fastify.repositories.oauthClients.findById as unknown as Mock).mockResolvedValue(
+      makeClientRow({ developerId: DEV_A })
+    );
+    (fastify.repositories.oauthClients.update as unknown as Mock).mockImplementation(
+      async (_id: string, data: Record<string, unknown>) =>
+        makeClientRow({ developerId: DEV_A, ...data })
+    );
+
+    // Attempt a mass-assignment: the Zod schema strips unknown keys, and the
+    // handler only forwards the known mutable allowlist, so these are dropped.
+    const request = authedRequest({
+      params: { id: '0190a000-0000-7000-8000-000000000001' },
+      body: {
+        name: 'Renamed',
+        developerId: DEV_B,
+        clientId: 'attacker-chosen',
+        clientSecretHash: 'argon2id$attacker',
+      },
+    });
+    const { reply } = createReply();
+
+    // Handler is invoked with the raw body (Zod stripping is not exercised in
+    // this unit harness), so assert the handler's own allowlist drops them.
+    await route(ctx, 'PATCH /:id').handler(request, reply);
+
+    const updateArg = (fastify.repositories.oauthClients.update as unknown as Mock).mock
+      .calls[0][1];
+    expect(updateArg).toEqual({ name: 'Renamed' });
+    expect(updateArg.developerId).toBeUndefined();
+    expect(updateArg.clientId).toBeUndefined();
+    expect(updateArg.clientSecretHash).toBeUndefined();
   });
 });

--- a/apps/auth-server/src/app/routes/clients/clients.test.ts
+++ b/apps/auth-server/src/app/routes/clients/clients.test.ts
@@ -1,14 +1,36 @@
-import { JWTInvalidError } from '@qauth-labs/shared-errors';
+import { BadRequestError, JWTInvalidError, NotFoundError } from '@qauth-labs/shared-errors';
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { describe, expect, it, type Mock, vi } from 'vitest';
 
+// The create route transitively imports `helpers/realm` → `config/env`, which
+// validates required env at module load. Stub it so the unit run needs no real
+// environment (matches `routes/oauth/register.test.ts`).
+vi.mock('../../../config/env', () => ({
+  env: {
+    DATABASE_URL: 'postgresql://test:test@localhost:5432/test',
+    EMAIL_FROM_ADDRESS: 'noreply@example.com',
+    EMAIL_BASE_URL: 'http://localhost:3000',
+    DEFAULT_REALM_NAME: 'master',
+  },
+}));
+
 import clientsRoute, { autoPrefix } from './index';
 
+type RouteHandler = (request: FastifyRequest, reply: FastifyReply) => Promise<unknown>;
+interface RouteOptions {
+  preHandler?: (request: FastifyRequest, reply: FastifyReply) => Promise<void>;
+}
+interface RegisteredRoute {
+  handler: RouteHandler;
+  options: RouteOptions;
+}
+
 interface TestContext {
-  handler?: (request: FastifyRequest, reply: FastifyReply) => Promise<unknown>;
-  options?: {
-    preHandler?: (request: FastifyRequest, reply: FastifyReply) => Promise<void>;
-  };
+  // The list route (GET /) — preserved for the original #85 tests.
+  handler?: RouteHandler;
+  options?: RouteOptions;
+  // Every registered route keyed by `METHOD path`, e.g. `POST /` or `GET /:id`.
+  routes: Map<string, RegisteredRoute>;
 }
 
 // `oauth_clients.developer_id` is a UUID column and a user token's `sub` is a
@@ -17,10 +39,16 @@ const DEV_A = '0190a000-0000-7000-8000-00000000000a';
 const DEV_B = '0190a000-0000-7000-8000-00000000000b';
 
 function createReply() {
-  const state: { statusCode?: number; body?: unknown } = {};
+  const state: { statusCode?: number; body?: unknown; headers: Record<string, string> } = {
+    headers: {},
+  };
   const reply: any = {
     code(n: number) {
       state.statusCode = n;
+      return reply;
+    },
+    header(name: string, value: string) {
+      state.headers[name.toLowerCase()] = value;
       return reply;
     },
     send(body: unknown) {
@@ -32,24 +60,64 @@ function createReply() {
 }
 
 function makeFastify() {
-  const ctx: TestContext = {};
+  const ctx: TestContext = { routes: new Map() };
+  const register = (method: string) => (url: string, opts: RouteOptions, handler: RouteHandler) => {
+    ctx.routes.set(`${method} ${url}`, { handler, options: opts });
+    // Preserve the original single-handler contract for the GET / route so
+    // the issue-#85 list tests keep working unchanged.
+    if (method === 'GET' && url === '/') {
+      ctx.handler = handler;
+      ctx.options = opts;
+    }
+    return chain;
+  };
+  const chain: any = {
+    get: register('GET'),
+    post: register('POST'),
+    patch: register('PATCH'),
+    delete: register('DELETE'),
+  };
   const fastify: any = {
-    withTypeProvider: () => ({
-      get: (_url: string, opts: TestContext['options'], handler: TestContext['handler']) => {
-        ctx.handler = handler;
-        ctx.options = opts;
-        return fastify;
-      },
-    }),
+    withTypeProvider: () => chain,
     requireJwt: vi.fn(),
+    passwordHasher: {
+      hashPassword: vi.fn(async (secret: string) => `argon2id$hash-of-${secret.slice(0, 8)}`),
+    },
     repositories: {
       oauthClients: {
         listByDeveloper: vi.fn(),
+        findById: vi.fn(),
+        create: vi.fn(),
+        update: vi.fn(),
+        delete: vi.fn(),
+      },
+      realms: {
+        findByName: vi.fn(async () => ({ id: 'realm-1', name: 'default', enabled: true })),
+        create: vi.fn(),
+      },
+      auditLogs: {
+        create: vi.fn(async () => undefined),
       },
     },
     log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
   };
   return { fastify: fastify as FastifyInstance, ctx };
+}
+
+/** Look up a registered route handler by `METHOD path`. */
+function route(ctx: TestContext, key: string): RegisteredRoute {
+  const r = ctx.routes.get(key);
+  if (!r) throw new Error(`route not registered: ${key}`);
+  return r;
+}
+
+function authedRequest(overrides: Record<string, unknown> = {}): FastifyRequest {
+  return {
+    jwtPayload: { sub: DEV_A },
+    headers: { authorization: 'Bearer token', 'user-agent': 'vitest' },
+    ip: '127.0.0.1',
+    ...overrides,
+  } as unknown as FastifyRequest;
 }
 
 /**
@@ -212,5 +280,387 @@ describe('GET /api/clients route', () => {
 
     await expect(ctx.handler!(request, reply)).rejects.toThrow(JWTInvalidError);
     expect(fastify.repositories.oauthClients.listByDeveloper).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /api/clients (create) — #86', () => {
+  it('requires a developer Bearer access token', async () => {
+    const { fastify, ctx } = makeFastify();
+    await clientsRoute(fastify);
+    expect(route(ctx, 'POST /').options.preHandler).toBe(fastify.requireJwt);
+  });
+
+  it('generates client_id + secret, hashes the secret, persists, and returns the plaintext once', async () => {
+    const { fastify, ctx } = makeFastify();
+    await clientsRoute(fastify);
+
+    (fastify.repositories.oauthClients.create as unknown as Mock).mockImplementation(
+      async (data: Record<string, unknown>) =>
+        makeClientRow({
+          ...data,
+          id: '0190a000-0000-7000-8000-0000000000c1',
+        })
+    );
+
+    const request = authedRequest({
+      body: {
+        name: 'My App',
+        redirectUris: ['https://app.example.com/cb'],
+        scopes: ['openid'],
+        tokenEndpointAuthMethod: 'client_secret_post',
+      },
+    });
+    const { reply, state } = createReply();
+
+    const body = (await route(ctx, 'POST /').handler(request, reply)) as Record<string, unknown>;
+
+    // 201 + plaintext secret present exactly here.
+    expect(state.statusCode).toBe(201);
+    expect(typeof body.clientSecret).toBe('string');
+    expect((body.clientSecret as string).length).toBe(64); // 32 bytes hex
+
+    // developer_id is taken from the token subject, never the body.
+    const created = (fastify.repositories.oauthClients.create as unknown as Mock).mock.calls[0][0];
+    expect(created.developerId).toBe(DEV_A);
+    expect(created.clientId).toMatch(/^[0-9a-f-]{36}$/);
+    expect(created.requirePkce).toBe(true);
+    // Only the hash is persisted — never the plaintext.
+    expect(created.clientSecretHash).not.toBe(body.clientSecret);
+    expect(created.clientSecretHash).toContain('argon2id$');
+
+    // Response is not cacheable (carries a secret).
+    expect(state.headers['cache-control']).toBe('no-store');
+
+    // The hash must never appear in the response body.
+    expect(JSON.stringify(body)).not.toContain('clientSecretHash');
+  });
+
+  it('omits client_secret for a public client (token_endpoint_auth_method=none)', async () => {
+    const { fastify, ctx } = makeFastify();
+    await clientsRoute(fastify);
+
+    (fastify.repositories.oauthClients.create as unknown as Mock).mockImplementation(
+      async (data: Record<string, unknown>) => makeClientRow({ ...data })
+    );
+
+    const request = authedRequest({
+      body: {
+        name: 'Public SPA',
+        redirectUris: ['https://spa.example.com/cb'],
+        tokenEndpointAuthMethod: 'none',
+      },
+    });
+    const { reply } = createReply();
+
+    const body = (await route(ctx, 'POST /').handler(request, reply)) as Record<string, unknown>;
+
+    expect(body.clientSecret).toBeUndefined();
+    // A sentinel hash is still stored so the NOT NULL column is satisfied.
+    const created = (fastify.repositories.oauthClients.create as unknown as Mock).mock.calls[0][0];
+    expect(created.clientSecretHash).toContain('argon2id$');
+  });
+
+  it('rejects an invalid (non-loopback http) redirect_uri before persisting', async () => {
+    const { fastify, ctx } = makeFastify();
+    await clientsRoute(fastify);
+
+    const request = authedRequest({
+      body: { name: 'Bad', redirectUris: ['http://evil.example.com/cb'] },
+    });
+    const { reply } = createReply();
+
+    await expect(route(ctx, 'POST /').handler(request, reply)).rejects.toThrow(BadRequestError);
+    expect(fastify.repositories.oauthClients.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects an inconsistent grant/response-type combination', async () => {
+    const { fastify, ctx } = makeFastify();
+    await clientsRoute(fastify);
+
+    const request = authedRequest({
+      body: {
+        name: 'Inconsistent',
+        redirectUris: [],
+        grantTypes: ['client_credentials'],
+        responseTypes: ['code'],
+        tokenEndpointAuthMethod: 'client_secret_post',
+      },
+    });
+    const { reply } = createReply();
+
+    await expect(route(ctx, 'POST /').handler(request, reply)).rejects.toThrow(BadRequestError);
+    expect(fastify.repositories.oauthClients.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects a client_credentials public client', async () => {
+    const { fastify, ctx } = makeFastify();
+    await clientsRoute(fastify);
+
+    const request = authedRequest({
+      body: {
+        name: 'Service',
+        redirectUris: [],
+        grantTypes: ['client_credentials'],
+        tokenEndpointAuthMethod: 'none',
+      },
+    });
+    const { reply } = createReply();
+
+    await expect(route(ctx, 'POST /').handler(request, reply)).rejects.toThrow(BadRequestError);
+  });
+
+  it('rejects a client_credentials token subject (non-UUID) from creating clients', async () => {
+    const { fastify, ctx } = makeFastify();
+    await clientsRoute(fastify);
+
+    const request = authedRequest({
+      jwtPayload: { sub: 'app-123' },
+      body: { name: 'X', redirectUris: [] },
+    });
+    const { reply } = createReply();
+
+    await expect(route(ctx, 'POST /').handler(request, reply)).rejects.toThrow(JWTInvalidError);
+    expect(fastify.repositories.oauthClients.create).not.toHaveBeenCalled();
+  });
+});
+
+describe('GET /api/clients/:id (get one) — #87', () => {
+  it('returns the owned client with safe fields only', async () => {
+    const { fastify, ctx } = makeFastify();
+    await clientsRoute(fastify);
+
+    (fastify.repositories.oauthClients.findById as unknown as Mock).mockResolvedValue(
+      makeClientRow({ developerId: DEV_A })
+    );
+
+    const request = authedRequest({ params: { id: '0190a000-0000-7000-8000-000000000001' } });
+    const { reply } = createReply();
+
+    const body = (await route(ctx, 'GET /:id').handler(request, reply)) as Record<string, unknown>;
+
+    expect(body.id).toBe('0190a000-0000-7000-8000-000000000001');
+    const serialized = JSON.stringify(body);
+    expect(serialized).not.toContain('clientSecretHash');
+    expect(serialized).not.toContain('argon2id$super-secret-hash');
+  });
+
+  it('returns 404 (NotFoundError) for a client owned by another developer', async () => {
+    const { fastify, ctx } = makeFastify();
+    await clientsRoute(fastify);
+
+    (fastify.repositories.oauthClients.findById as unknown as Mock).mockResolvedValue(
+      makeClientRow({ developerId: DEV_B })
+    );
+
+    const request = authedRequest({ params: { id: '0190a000-0000-7000-8000-000000000001' } });
+    const { reply } = createReply();
+
+    await expect(route(ctx, 'GET /:id').handler(request, reply)).rejects.toThrow(NotFoundError);
+  });
+
+  it('returns 404 for a non-existent client', async () => {
+    const { fastify, ctx } = makeFastify();
+    await clientsRoute(fastify);
+
+    (fastify.repositories.oauthClients.findById as unknown as Mock).mockResolvedValue(undefined);
+
+    const request = authedRequest({ params: { id: '0190a000-0000-7000-8000-000000000099' } });
+    const { reply } = createReply();
+
+    await expect(route(ctx, 'GET /:id').handler(request, reply)).rejects.toThrow(NotFoundError);
+  });
+
+  it('returns 404 without a DB hit for a non-UUID subject', async () => {
+    const { fastify, ctx } = makeFastify();
+    await clientsRoute(fastify);
+
+    const request = authedRequest({
+      jwtPayload: { sub: 'app-123' },
+      params: { id: '0190a000-0000-7000-8000-000000000001' },
+    });
+    const { reply } = createReply();
+
+    await expect(route(ctx, 'GET /:id').handler(request, reply)).rejects.toThrow(NotFoundError);
+    expect(fastify.repositories.oauthClients.findById).not.toHaveBeenCalled();
+  });
+});
+
+describe('PATCH /api/clients/:id (update) — #88', () => {
+  it('updates only the provided fields of an owned client', async () => {
+    const { fastify, ctx } = makeFastify();
+    await clientsRoute(fastify);
+
+    (fastify.repositories.oauthClients.findById as unknown as Mock).mockResolvedValue(
+      makeClientRow({ developerId: DEV_A })
+    );
+    (fastify.repositories.oauthClients.update as unknown as Mock).mockImplementation(
+      async (_id: string, data: Record<string, unknown>) =>
+        makeClientRow({ developerId: DEV_A, ...data })
+    );
+
+    const request = authedRequest({
+      params: { id: '0190a000-0000-7000-8000-000000000001' },
+      body: { name: 'Renamed', enabled: false },
+    });
+    const { reply } = createReply();
+
+    const body = (await route(ctx, 'PATCH /:id').handler(request, reply)) as Record<
+      string,
+      unknown
+    >;
+
+    const updateArg = (fastify.repositories.oauthClients.update as unknown as Mock).mock
+      .calls[0][1];
+    expect(updateArg).toEqual({ name: 'Renamed', enabled: false });
+    expect(body.name).toBe('Renamed');
+    expect(JSON.stringify(body)).not.toContain('clientSecretHash');
+  });
+
+  it('validates the effective grant/response combination against persisted values', async () => {
+    const { fastify, ctx } = makeFastify();
+    await clientsRoute(fastify);
+
+    // Persisted client uses authorization_code + code. Dropping the grant to
+    // refresh_token only while keeping the persisted `code` response type is
+    // inconsistent and must be rejected.
+    (fastify.repositories.oauthClients.findById as unknown as Mock).mockResolvedValue(
+      makeClientRow({
+        developerId: DEV_A,
+        grantTypes: ['authorization_code', 'refresh_token'],
+        responseTypes: ['code'],
+      })
+    );
+
+    const request = authedRequest({
+      params: { id: '0190a000-0000-7000-8000-000000000001' },
+      body: { grantTypes: ['refresh_token'] },
+    });
+    const { reply } = createReply();
+
+    await expect(route(ctx, 'PATCH /:id').handler(request, reply)).rejects.toThrow(BadRequestError);
+    expect(fastify.repositories.oauthClients.update).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 for a client owned by another developer (no update)', async () => {
+    const { fastify, ctx } = makeFastify();
+    await clientsRoute(fastify);
+
+    (fastify.repositories.oauthClients.findById as unknown as Mock).mockResolvedValue(
+      makeClientRow({ developerId: DEV_B })
+    );
+
+    const request = authedRequest({
+      params: { id: '0190a000-0000-7000-8000-000000000001' },
+      body: { name: 'Hijack' },
+    });
+    const { reply } = createReply();
+
+    await expect(route(ctx, 'PATCH /:id').handler(request, reply)).rejects.toThrow(NotFoundError);
+    expect(fastify.repositories.oauthClients.update).not.toHaveBeenCalled();
+  });
+});
+
+describe('DELETE /api/clients/:id — #89', () => {
+  it('deletes an owned client and returns 204', async () => {
+    const { fastify, ctx } = makeFastify();
+    await clientsRoute(fastify);
+
+    (fastify.repositories.oauthClients.findById as unknown as Mock).mockResolvedValue(
+      makeClientRow({ developerId: DEV_A })
+    );
+    (fastify.repositories.oauthClients.delete as unknown as Mock).mockResolvedValue(true);
+
+    const request = authedRequest({ params: { id: '0190a000-0000-7000-8000-000000000001' } });
+    const { reply, state } = createReply();
+
+    await route(ctx, 'DELETE /:id').handler(request, reply);
+
+    expect(state.statusCode).toBe(204);
+    expect(fastify.repositories.oauthClients.delete).toHaveBeenCalledWith(
+      '0190a000-0000-7000-8000-000000000001'
+    );
+  });
+
+  it("returns 404 for another developer's client without deleting", async () => {
+    const { fastify, ctx } = makeFastify();
+    await clientsRoute(fastify);
+
+    (fastify.repositories.oauthClients.findById as unknown as Mock).mockResolvedValue(
+      makeClientRow({ developerId: DEV_B })
+    );
+
+    const request = authedRequest({ params: { id: '0190a000-0000-7000-8000-000000000001' } });
+    const { reply } = createReply();
+
+    await expect(route(ctx, 'DELETE /:id').handler(request, reply)).rejects.toThrow(NotFoundError);
+    expect(fastify.repositories.oauthClients.delete).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /api/clients/:id/regenerate-secret — #90', () => {
+  it('issues a new secret, stores only the hash, and returns the plaintext once', async () => {
+    const { fastify, ctx } = makeFastify();
+    await clientsRoute(fastify);
+
+    (fastify.repositories.oauthClients.findById as unknown as Mock).mockResolvedValue(
+      makeClientRow({ developerId: DEV_A, tokenEndpointAuthMethod: 'client_secret_post' })
+    );
+    (fastify.repositories.oauthClients.update as unknown as Mock).mockImplementation(
+      async (_id: string, data: Record<string, unknown>) =>
+        makeClientRow({ developerId: DEV_A, ...data })
+    );
+
+    const request = authedRequest({ params: { id: '0190a000-0000-7000-8000-000000000001' } });
+    const { reply, state } = createReply();
+
+    const body = (await route(ctx, 'POST /:id/regenerate-secret').handler(
+      request,
+      reply
+    )) as Record<string, unknown>;
+
+    expect(typeof body.clientSecret).toBe('string');
+    expect((body.clientSecret as string).length).toBe(64);
+
+    const updateArg = (fastify.repositories.oauthClients.update as unknown as Mock).mock
+      .calls[0][1];
+    expect(updateArg.clientSecretHash).toContain('argon2id$');
+    // Only the hash is persisted, never the plaintext.
+    expect(updateArg.clientSecretHash).not.toBe(body.clientSecret);
+    expect(state.headers['cache-control']).toBe('no-store');
+    expect(JSON.stringify(body)).not.toContain('clientSecretHash');
+  });
+
+  it('rejects regeneration for a public client (no secret to rotate)', async () => {
+    const { fastify, ctx } = makeFastify();
+    await clientsRoute(fastify);
+
+    (fastify.repositories.oauthClients.findById as unknown as Mock).mockResolvedValue(
+      makeClientRow({ developerId: DEV_A, tokenEndpointAuthMethod: 'none' })
+    );
+
+    const request = authedRequest({ params: { id: '0190a000-0000-7000-8000-000000000001' } });
+    const { reply } = createReply();
+
+    await expect(route(ctx, 'POST /:id/regenerate-secret').handler(request, reply)).rejects.toThrow(
+      BadRequestError
+    );
+    expect(fastify.repositories.oauthClients.update).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 for another developer's client", async () => {
+    const { fastify, ctx } = makeFastify();
+    await clientsRoute(fastify);
+
+    (fastify.repositories.oauthClients.findById as unknown as Mock).mockResolvedValue(
+      makeClientRow({ developerId: DEV_B, tokenEndpointAuthMethod: 'client_secret_post' })
+    );
+
+    const request = authedRequest({ params: { id: '0190a000-0000-7000-8000-000000000001' } });
+    const { reply } = createReply();
+
+    await expect(route(ctx, 'POST /:id/regenerate-secret').handler(request, reply)).rejects.toThrow(
+      NotFoundError
+    );
+    expect(fastify.repositories.oauthClients.update).not.toHaveBeenCalled();
   });
 });

--- a/apps/auth-server/src/app/routes/clients/index.ts
+++ b/apps/auth-server/src/app/routes/clients/index.ts
@@ -5,6 +5,7 @@ import type { FastifyInstance } from 'fastify';
 import { ZodTypeProvider } from 'fastify-type-provider-zod';
 import { z } from 'zod';
 
+import { env } from '../../../config/env';
 import { validateRedirectUri } from '../../helpers/dynamic-client-registration';
 import { getOrCreateDefaultRealm } from '../../helpers/realm';
 import {
@@ -147,25 +148,30 @@ async function resolveOwnedClient(
 }
 
 /**
- * Enforce OAuth 2.1 / RFC 7591 grant_type ⇄ response_type consistency, the
- * same invariants `validateAndNormalize` applies to dynamic registration:
+ * Enforce OAuth 2.1 / RFC 7591 grant_type ⇄ response_type ⇄ redirect_uri
+ * consistency, the same invariants `validateAndNormalize` applies to dynamic
+ * registration:
  *
  * - `authorization_code` requires the `code` response type.
  * - `response_types` without `authorization_code` is unsupported.
  * - `client_credentials` cannot be a public client (`none`) — a public client
  *   holds no secret and so cannot authenticate at the token endpoint
  *   (RFC 6749 §4.4).
+ * - A user-involving grant (`authorization_code` / `refresh_token`) requires at
+ *   least one `redirect_uri`; without one the client can never complete a
+ *   user-agent flow (mirrors DCR's `redirect_uris is required …` rejection).
  *
  * Throws `BadRequestError` (→ HTTP 400) on any violation. Each call site has
- * already resolved the effective grant/response/auth values (request value or
- * persisted value for partial updates).
+ * already resolved the effective grant/response/auth/redirect values (request
+ * value or persisted value for partial updates).
  */
 function assertGrantResponseConsistency(input: {
   grantTypes: string[];
   responseTypes: string[];
   tokenEndpointAuthMethod: string;
+  redirectUris: string[];
 }): void {
-  const { grantTypes, responseTypes, tokenEndpointAuthMethod } = input;
+  const { grantTypes, responseTypes, tokenEndpointAuthMethod, redirectUris } = input;
 
   if (grantTypes.includes('authorization_code') && !responseTypes.includes('code')) {
     throw new BadRequestError('authorization_code grant requires the "code" response type');
@@ -177,6 +183,55 @@ function assertGrantResponseConsistency(input: {
     throw new BadRequestError(
       'client_credentials grant requires a confidential client (token_endpoint_auth_method must not be "none")'
     );
+  }
+  const userInvolving =
+    grantTypes.includes('authorization_code') || grantTypes.includes('refresh_token');
+  if (userInvolving && redirectUris.length === 0) {
+    throw new BadRequestError(
+      'redirect_uris is required for grants that involve a user-agent (authorization_code / refresh_token)'
+    );
+  }
+}
+
+/**
+ * Resolve the realm's effective dynamic-registration scope allowlist, seeding
+ * it from `DEFAULT_DYNAMIC_REGISTRATION_SCOPES` on first use exactly as
+ * `/oauth/register` does. The REST create/update paths reuse this same policy
+ * so a developer cannot self-grant a scope through the management API that the
+ * realm would refuse at dynamic registration — keeping the two
+ * client-creation paths consistent. Seeding is best-effort: a racing write
+ * never blocks the request.
+ */
+async function resolveRealmAllowedScopes(
+  fastify: FastifyInstance,
+  realm: { id: string; dynamicRegistrationAllowedScopes?: string[] | null }
+): Promise<string[]> {
+  let allowedScopes = realm.dynamicRegistrationAllowedScopes ?? [];
+  if (allowedScopes.length === 0 && env.DEFAULT_DYNAMIC_REGISTRATION_SCOPES.length > 0) {
+    allowedScopes = [...env.DEFAULT_DYNAMIC_REGISTRATION_SCOPES];
+    try {
+      await fastify.repositories.realms.update(realm.id, {
+        dynamicRegistrationAllowedScopes: allowedScopes,
+      });
+    } catch (err) {
+      fastify.log.warn(
+        { err, realmId: realm.id },
+        'Failed to persist default dynamic_registration_allowed_scopes'
+      );
+    }
+  }
+  return allowedScopes;
+}
+
+/**
+ * Cap requested `scopes` against the realm allowlist, rejecting anything
+ * outside it (RFC 7591 `invalid_client_metadata` equivalent). Empty allowlist
+ * means no custom scopes are permitted. Throws `BadRequestError` → HTTP 400.
+ */
+function assertScopesAllowed(requested: string[], realmAllowedScopes: string[]): void {
+  const disallowed = requested.filter((s) => !realmAllowedScopes.includes(s));
+  if (disallowed.length > 0) {
+    throw new BadRequestError(`scope not permitted: ${disallowed.join(' ')}`);
   }
 }
 
@@ -191,6 +246,32 @@ async function generateClientSecret(
   const plaintext = randomBytes(32).toString('hex');
   const hash = await fastify.passwordHasher.hashPassword(plaintext);
   return { plaintext, hash };
+}
+
+/**
+ * Audit log shape for a client-management event (subset of the audit_logs
+ * repository's create payload).
+ */
+type ClientAuditEntry = Parameters<FastifyInstance['repositories']['auditLogs']['create']>[0];
+
+/**
+ * Write an audit entry best-effort: a logging failure MUST NOT propagate.
+ *
+ * This matters most on the secret-bearing paths (create / regenerate): the
+ * client row (or rotated secret hash) is already committed, so throwing here
+ * would 500 *after* the only copy of the plaintext secret was generated,
+ * leaving the developer with a client they can never authenticate. We log the
+ * failure and continue so the one-time secret still reaches the response.
+ */
+async function auditBestEffort(fastify: FastifyInstance, entry: ClientAuditEntry): Promise<void> {
+  try {
+    await fastify.repositories.auditLogs.create(entry);
+  } catch (err) {
+    fastify.log.warn(
+      { err, event: entry.event, oauthClientId: entry.oauthClientId },
+      'Failed to write client-management audit log (non-fatal)'
+    );
+  }
 }
 
 export default async function (fastify: FastifyInstance) {
@@ -242,6 +323,18 @@ export default async function (fastify: FastifyInstance) {
         body: createClientRequestSchema,
         response: { 201: createClientResponseSchema },
       },
+      config: {
+        // Create runs an argon2id hash on every call (confidential clients hash
+        // the real secret; public clients hash a sentinel), so an authenticated
+        // caller could otherwise burn CPU at the global default rate. Cap it
+        // per-IP at the same budget as /oauth/register, whose comment notes the
+        // hash makes "a burst-proof cap mandatory".
+        rateLimit: {
+          max: env.REGISTER_CLIENT_RATE_LIMIT,
+          timeWindow: env.REGISTER_CLIENT_RATE_WINDOW * 1000,
+          keyGenerator: (req) => req.ip || 'unknown',
+        },
+      },
     },
     async (request, reply) => {
       const developerId = requireDeveloperId(request);
@@ -257,13 +350,28 @@ export default async function (fastify: FastifyInstance) {
       const grantTypes = body.grantTypes ?? ['authorization_code', 'refresh_token'];
       const responseTypes = body.responseTypes ?? ['code'];
       const tokenEndpointAuthMethod = body.tokenEndpointAuthMethod ?? 'none';
+      // Zod applies `.default([])`, but default defensively so the handler is
+      // also correct when invoked without the schema layer (unit tests).
+      const redirectUris = body.redirectUris ?? [];
+      const scopes = body.scopes ?? [];
 
-      for (const uri of body.redirectUris) {
+      for (const uri of redirectUris) {
         validateRedirectUri(uri);
       }
-      assertGrantResponseConsistency({ grantTypes, responseTypes, tokenEndpointAuthMethod });
+      assertGrantResponseConsistency({
+        grantTypes,
+        responseTypes,
+        tokenEndpointAuthMethod,
+        redirectUris,
+      });
 
       const realm = await getOrCreateDefaultRealm(fastify);
+
+      // Cap requested scopes against the realm policy *before* hashing — a
+      // policy-violating request must not pay the argon2id cost or persist.
+      const allowedScopes = await resolveRealmAllowedScopes(fastify, realm);
+      assertScopesAllowed(scopes, allowedScopes);
+
       const clientId = randomUUID();
 
       // Confidential clients get a real secret; public clients
@@ -289,8 +397,8 @@ export default async function (fastify: FastifyInstance) {
         clientSecretHash,
         name: body.name,
         description: body.description ?? null,
-        redirectUris: body.redirectUris,
-        scopes: body.scopes,
+        redirectUris,
+        scopes,
         grantTypes,
         responseTypes,
         tokenEndpointAuthMethod,
@@ -301,7 +409,9 @@ export default async function (fastify: FastifyInstance) {
         developerId,
       });
 
-      await fastify.repositories.auditLogs.create({
+      // Best-effort: the client (and its secret hash) is already committed, so
+      // a failing audit write must not 500 and lose the one-time plaintext.
+      await auditBestEffort(fastify, {
         userId: developerId,
         oauthClientId: created.id,
         event: 'oauth.client.created',
@@ -375,18 +485,34 @@ export default async function (fastify: FastifyInstance) {
       // Validate the *effective* configuration: take each field from the
       // request when present, else fall back to the persisted value. This
       // catches an update that would leave the client in an inconsistent
-      // state (e.g. removing authorization_code while keeping response_types).
+      // state (e.g. removing authorization_code while keeping response_types,
+      // or dropping the last redirect_uri from an authorization_code client).
       const grantTypes = body.grantTypes ?? existing.grantTypes;
       const responseTypes = body.responseTypes ?? existing.responseTypes;
       const tokenEndpointAuthMethod =
         body.tokenEndpointAuthMethod ?? existing.tokenEndpointAuthMethod;
+      const redirectUris = body.redirectUris ?? existing.redirectUris;
 
       if (body.redirectUris) {
         for (const uri of body.redirectUris) {
           validateRedirectUri(uri);
         }
       }
-      assertGrantResponseConsistency({ grantTypes, responseTypes, tokenEndpointAuthMethod });
+      assertGrantResponseConsistency({
+        grantTypes,
+        responseTypes,
+        tokenEndpointAuthMethod,
+        redirectUris,
+      });
+
+      // Cap newly requested scopes against the client's realm policy, the same
+      // allowlist dynamic registration enforces — a developer must not widen
+      // scopes via PATCH beyond what the realm permits.
+      if (body.scopes !== undefined) {
+        const realm = await fastify.repositories.realms.findById(existing.realmId);
+        const allowedScopes = realm ? await resolveRealmAllowedScopes(fastify, realm) : [];
+        assertScopesAllowed(body.scopes, allowedScopes);
+      }
 
       const updated = await fastify.repositories.oauthClients.update(id, {
         ...(body.name !== undefined ? { name: body.name } : {}),
@@ -401,7 +527,7 @@ export default async function (fastify: FastifyInstance) {
         ...(body.enabled !== undefined ? { enabled: body.enabled } : {}),
       });
 
-      await fastify.repositories.auditLogs.create({
+      await auditBestEffort(fastify, {
         userId: developerId,
         oauthClientId: updated.id,
         event: 'oauth.client.updated',
@@ -439,7 +565,7 @@ export default async function (fastify: FastifyInstance) {
 
       await fastify.repositories.oauthClients.delete(id);
 
-      await fastify.repositories.auditLogs.create({
+      await auditBestEffort(fastify, {
         userId: developerId,
         oauthClientId: existing.id,
         event: 'oauth.client.deleted',
@@ -468,6 +594,15 @@ export default async function (fastify: FastifyInstance) {
         params: clientIdParamsSchema,
         response: { 200: regenerateSecretResponseSchema },
       },
+      config: {
+        // Regeneration always runs an argon2id hash, so it carries the same
+        // CPU-DoS profile as create — cap it per-IP at the same budget.
+        rateLimit: {
+          max: env.REGISTER_CLIENT_RATE_LIMIT,
+          timeWindow: env.REGISTER_CLIENT_RATE_WINDOW * 1000,
+          keyGenerator: (req) => req.ip || 'unknown',
+        },
+      },
     },
     async (request, reply) => {
       const developerId = requireDeveloperId(request);
@@ -490,7 +625,10 @@ export default async function (fastify: FastifyInstance) {
         clientSecretHash: hash,
       });
 
-      await fastify.repositories.auditLogs.create({
+      // Best-effort: the new secret hash is already committed and the old one
+      // invalidated, so a failing audit write must not 500 and lose the
+      // one-time plaintext (the client would be locked out of its own secret).
+      await auditBestEffort(fastify, {
         userId: developerId,
         oauthClientId: updated.id,
         event: 'oauth.client.secret_regenerated',

--- a/apps/auth-server/src/app/routes/clients/index.ts
+++ b/apps/auth-server/src/app/routes/clients/index.ts
@@ -1,9 +1,22 @@
-import { JWTInvalidError } from '@qauth-labs/shared-errors';
+import { randomBytes, randomUUID } from 'node:crypto';
+
+import { BadRequestError, JWTInvalidError, NotFoundError } from '@qauth-labs/shared-errors';
 import type { FastifyInstance } from 'fastify';
 import { ZodTypeProvider } from 'fastify-type-provider-zod';
 import { z } from 'zod';
 
-import { listClientsResponseSchema } from '../../schemas/clients';
+import { validateRedirectUri } from '../../helpers/dynamic-client-registration';
+import { getOrCreateDefaultRealm } from '../../helpers/realm';
+import {
+  clientSchema,
+  type CreateClientRequest,
+  createClientRequestSchema,
+  createClientResponseSchema,
+  listClientsResponseSchema,
+  regenerateSecretResponseSchema,
+  type UpdateClientRequest,
+  updateClientRequestSchema,
+} from '../../schemas/clients';
 
 /**
  * The shape of a single `oauth_clients` row as returned by the repository.
@@ -38,9 +51,16 @@ type OAuthClientRow = Awaited<
  *
  * `request.jwtPayload.sub` is the developer's `users.id`. Ownership is scoped
  * strictly by `oauth_clients.developer_id`, so a developer can only ever see
- * and manage their own clients.
+ * and manage their own clients. A client that exists but is owned by another
+ * developer is reported as **404** (not 403) so the API never leaks the
+ * existence of clients the caller does not own.
  *
- *   GET /api/clients — list the authenticated developer's OAuth clients
+ *   GET    /api/clients                       — list the developer's clients (#85)
+ *   POST   /api/clients                       — create a client (#86)
+ *   GET    /api/clients/:id                   — get one owned client (#87)
+ *   PATCH  /api/clients/:id                   — update mutable fields (#88)
+ *   DELETE /api/clients/:id                   — delete a client (#89)
+ *   POST   /api/clients/:id/regenerate-secret — issue a new secret (#90)
  */
 
 // `@fastify/autoload` mounts this module under `/api/clients` regardless of
@@ -81,6 +101,98 @@ function toClientResponse(client: OAuthClientRow) {
   };
 }
 
+// Path param for the single-client routes. The `id` column is a UUID; a
+// malformed id can never match a row, but validating here yields a clean 400
+// instead of letting a non-UUID reach Postgres (22P02 → 500).
+const clientIdParamsSchema = z.object({ id: z.uuid() });
+
+/**
+ * Pull the developer's `users.id` off the verified JWT. `requireJwt` populates
+ * `jwtPayload`, but we guard `sub` explicitly so we never act with an
+ * undefined owner (defense-in-depth, matching the list route).
+ */
+function requireDeveloperId(request: { jwtPayload?: { sub?: string } }): string {
+  const sub = request.jwtPayload?.sub;
+  if (!sub) {
+    throw new JWTInvalidError('Missing JWT payload');
+  }
+  return sub;
+}
+
+/**
+ * Resolve a client the caller is allowed to act on, or throw `NotFoundError`.
+ *
+ * Ownership is enforced here for every per-client route (#87/#88/#89/#90):
+ *
+ * - A non-UUID subject (e.g. a `client_credentials` token whose `sub` is a
+ *   `client_id`) can never own a UUID-keyed row → 404 without a DB hit.
+ * - A row owned by a different developer is reported as **404, not 403**, so
+ *   the API never confirms the existence of clients the caller does not own
+ *   (avoids enumeration; OWASP API1/A01 BOLA).
+ */
+async function resolveOwnedClient(
+  fastify: FastifyInstance,
+  developerId: string,
+  id: string
+): Promise<OAuthClientRow> {
+  if (!uuidSubjectSchema.safeParse(developerId).success) {
+    throw new NotFoundError('OAuthClient', id);
+  }
+
+  const client = await fastify.repositories.oauthClients.findById(id);
+  if (!client || client.developerId !== developerId) {
+    throw new NotFoundError('OAuthClient', id);
+  }
+  return client;
+}
+
+/**
+ * Enforce OAuth 2.1 / RFC 7591 grant_type ⇄ response_type consistency, the
+ * same invariants `validateAndNormalize` applies to dynamic registration:
+ *
+ * - `authorization_code` requires the `code` response type.
+ * - `response_types` without `authorization_code` is unsupported.
+ * - `client_credentials` cannot be a public client (`none`) — a public client
+ *   holds no secret and so cannot authenticate at the token endpoint
+ *   (RFC 6749 §4.4).
+ *
+ * Throws `BadRequestError` (→ HTTP 400) on any violation. Each call site has
+ * already resolved the effective grant/response/auth values (request value or
+ * persisted value for partial updates).
+ */
+function assertGrantResponseConsistency(input: {
+  grantTypes: string[];
+  responseTypes: string[];
+  tokenEndpointAuthMethod: string;
+}): void {
+  const { grantTypes, responseTypes, tokenEndpointAuthMethod } = input;
+
+  if (grantTypes.includes('authorization_code') && !responseTypes.includes('code')) {
+    throw new BadRequestError('authorization_code grant requires the "code" response type');
+  }
+  if (!grantTypes.includes('authorization_code') && responseTypes.length > 0) {
+    throw new BadRequestError('response_types without authorization_code grant is not supported');
+  }
+  if (tokenEndpointAuthMethod === 'none' && grantTypes.includes('client_credentials')) {
+    throw new BadRequestError(
+      'client_credentials grant requires a confidential client (token_endpoint_auth_method must not be "none")'
+    );
+  }
+}
+
+/**
+ * Generate a fresh 32-byte (256-bit) client secret and its argon2id hash.
+ * Returns both so the plaintext can be surfaced exactly once in the response
+ * while only the hash is ever persisted. The plaintext is never logged.
+ */
+async function generateClientSecret(
+  fastify: FastifyInstance
+): Promise<{ plaintext: string; hash: string }> {
+  const plaintext = randomBytes(32).toString('hex');
+  const hash = await fastify.passwordHasher.hashPassword(plaintext);
+  return { plaintext, hash };
+}
+
 export default async function (fastify: FastifyInstance) {
   fastify.withTypeProvider<ZodTypeProvider>().get(
     '/',
@@ -114,6 +226,284 @@ export default async function (fastify: FastifyInstance) {
       const rows = await fastify.repositories.oauthClients.listByDeveloper(developerId);
 
       return reply.send({ clients: rows.map(toClientResponse) });
+    }
+  );
+
+  // ── POST /api/clients — create a client (#86) ───────────────────────────
+  fastify.withTypeProvider<ZodTypeProvider>().post(
+    '/',
+    {
+      preHandler: fastify.requireJwt,
+      schema: {
+        description:
+          'Create an OAuth client owned by the authenticated developer. The server generates the client_id and (for confidential clients) a client_secret; the plaintext secret is returned in THIS response only and never again. Requires a developer Bearer access token. (Phase 2.2, issue #86.)',
+        tags: ['Clients'],
+        security: [{ bearerAuth: [] }],
+        body: createClientRequestSchema,
+        response: { 201: createClientResponseSchema },
+      },
+    },
+    async (request, reply) => {
+      const developerId = requireDeveloperId(request);
+
+      // `developer_id` is a UUID column; a non-UUID subject (client_credentials
+      // token) cannot own a client and must not be allowed to create one.
+      if (!uuidSubjectSchema.safeParse(developerId).success) {
+        throw new JWTInvalidError('A user access token is required to create clients');
+      }
+
+      const body = request.body as CreateClientRequest;
+
+      const grantTypes = body.grantTypes ?? ['authorization_code', 'refresh_token'];
+      const responseTypes = body.responseTypes ?? ['code'];
+      const tokenEndpointAuthMethod = body.tokenEndpointAuthMethod ?? 'none';
+
+      for (const uri of body.redirectUris) {
+        validateRedirectUri(uri);
+      }
+      assertGrantResponseConsistency({ grantTypes, responseTypes, tokenEndpointAuthMethod });
+
+      const realm = await getOrCreateDefaultRealm(fastify);
+      const clientId = randomUUID();
+
+      // Confidential clients get a real secret; public clients
+      // (auth method `none`) store a non-verifiable sentinel hash so the
+      // NOT NULL column is satisfied without minting a usable secret — and so
+      // the hash length never leaks the client type (matches /oauth/register).
+      const isPublic = tokenEndpointAuthMethod === 'none';
+      let plaintextSecret: string | undefined;
+      let clientSecretHash: string;
+      if (isPublic) {
+        clientSecretHash = await fastify.passwordHasher.hashPassword(
+          randomBytes(32).toString('hex')
+        );
+      } else {
+        const secret = await generateClientSecret(fastify);
+        plaintextSecret = secret.plaintext;
+        clientSecretHash = secret.hash;
+      }
+
+      const created = await fastify.repositories.oauthClients.create({
+        realmId: realm.id,
+        clientId,
+        clientSecretHash,
+        name: body.name,
+        description: body.description ?? null,
+        redirectUris: body.redirectUris,
+        scopes: body.scopes,
+        grantTypes,
+        responseTypes,
+        tokenEndpointAuthMethod,
+        // Project-wide default: require PKCE for all clients (OAuth 2.1 §4.1.3
+        // / RFC 9700). Public clients MUST; confidential clients SHOULD.
+        requirePkce: true,
+        enabled: true,
+        developerId,
+      });
+
+      await fastify.repositories.auditLogs.create({
+        userId: developerId,
+        oauthClientId: created.id,
+        event: 'oauth.client.created',
+        eventType: 'client',
+        success: true,
+        ipAddress: request.ip,
+        userAgent: request.headers['user-agent'] || null,
+        metadata: {
+          clientId,
+          isPublic,
+          grantTypes,
+          tokenEndpointAuthMethod,
+        },
+      });
+
+      // Response carries the plaintext secret once — MUST NOT be cached.
+      reply.header('Cache-Control', 'no-store').header('Pragma', 'no-cache');
+      return reply.code(201).send({
+        ...toClientResponse(created),
+        ...(plaintextSecret ? { clientSecret: plaintextSecret } : {}),
+      });
+    }
+  );
+
+  // ── GET /api/clients/:id — get one owned client (#87) ───────────────────
+  fastify.withTypeProvider<ZodTypeProvider>().get(
+    '/:id',
+    {
+      preHandler: fastify.requireJwt,
+      schema: {
+        description:
+          "Get one of the authenticated developer's OAuth clients by id. Returns 404 if the client does not exist or is owned by another developer (no existence enumeration). Never returns the client secret. (Phase 2.2, issue #87.)",
+        tags: ['Clients'],
+        security: [{ bearerAuth: [] }],
+        params: clientIdParamsSchema,
+        response: { 200: clientSchema },
+      },
+    },
+    async (request, reply) => {
+      const developerId = requireDeveloperId(request);
+      const { id } = request.params as { id: string };
+
+      const client = await resolveOwnedClient(fastify, developerId, id);
+
+      return reply.send(toClientResponse(client));
+    }
+  );
+
+  // ── PATCH /api/clients/:id — update mutable fields (#88) ─────────────────
+  fastify.withTypeProvider<ZodTypeProvider>().patch(
+    '/:id',
+    {
+      preHandler: fastify.requireJwt,
+      schema: {
+        description:
+          "Update mutable fields of one of the developer's OAuth clients (name, description, redirectUris, scopes, grantTypes, responseTypes, tokenEndpointAuthMethod, enabled). client_id and client_secret are immutable here. Returns 404 if the client does not exist or is owned by another developer. (Phase 2.2, issue #88.)",
+        tags: ['Clients'],
+        security: [{ bearerAuth: [] }],
+        params: clientIdParamsSchema,
+        body: updateClientRequestSchema,
+        response: { 200: clientSchema },
+      },
+    },
+    async (request, reply) => {
+      const developerId = requireDeveloperId(request);
+      const { id } = request.params as { id: string };
+      const body = request.body as UpdateClientRequest;
+
+      const existing = await resolveOwnedClient(fastify, developerId, id);
+
+      // Validate the *effective* configuration: take each field from the
+      // request when present, else fall back to the persisted value. This
+      // catches an update that would leave the client in an inconsistent
+      // state (e.g. removing authorization_code while keeping response_types).
+      const grantTypes = body.grantTypes ?? existing.grantTypes;
+      const responseTypes = body.responseTypes ?? existing.responseTypes;
+      const tokenEndpointAuthMethod =
+        body.tokenEndpointAuthMethod ?? existing.tokenEndpointAuthMethod;
+
+      if (body.redirectUris) {
+        for (const uri of body.redirectUris) {
+          validateRedirectUri(uri);
+        }
+      }
+      assertGrantResponseConsistency({ grantTypes, responseTypes, tokenEndpointAuthMethod });
+
+      const updated = await fastify.repositories.oauthClients.update(id, {
+        ...(body.name !== undefined ? { name: body.name } : {}),
+        ...(body.description !== undefined ? { description: body.description } : {}),
+        ...(body.redirectUris !== undefined ? { redirectUris: body.redirectUris } : {}),
+        ...(body.scopes !== undefined ? { scopes: body.scopes } : {}),
+        ...(body.grantTypes !== undefined ? { grantTypes: body.grantTypes } : {}),
+        ...(body.responseTypes !== undefined ? { responseTypes: body.responseTypes } : {}),
+        ...(body.tokenEndpointAuthMethod !== undefined
+          ? { tokenEndpointAuthMethod: body.tokenEndpointAuthMethod }
+          : {}),
+        ...(body.enabled !== undefined ? { enabled: body.enabled } : {}),
+      });
+
+      await fastify.repositories.auditLogs.create({
+        userId: developerId,
+        oauthClientId: updated.id,
+        event: 'oauth.client.updated',
+        eventType: 'client',
+        success: true,
+        ipAddress: request.ip,
+        userAgent: request.headers['user-agent'] || null,
+        metadata: { clientId: updated.clientId, fields: Object.keys(body) },
+      });
+
+      return reply.send(toClientResponse(updated));
+    }
+  );
+
+  // ── DELETE /api/clients/:id — delete a client (#89) ─────────────────────
+  fastify.withTypeProvider<ZodTypeProvider>().delete(
+    '/:id',
+    {
+      preHandler: fastify.requireJwt,
+      schema: {
+        description:
+          "Delete one of the developer's OAuth clients. Returns 404 if the client does not exist or is owned by another developer. After deletion the client can no longer authenticate. (Phase 2.2, issue #89.)",
+        tags: ['Clients'],
+        security: [{ bearerAuth: [] }],
+        params: clientIdParamsSchema,
+        response: { 204: z.null() },
+      },
+    },
+    async (request, reply) => {
+      const developerId = requireDeveloperId(request);
+      const { id } = request.params as { id: string };
+
+      // Ownership-check before deleting: delete-by-id alone cannot enforce it.
+      const existing = await resolveOwnedClient(fastify, developerId, id);
+
+      await fastify.repositories.oauthClients.delete(id);
+
+      await fastify.repositories.auditLogs.create({
+        userId: developerId,
+        oauthClientId: existing.id,
+        event: 'oauth.client.deleted',
+        eventType: 'client',
+        success: true,
+        ipAddress: request.ip,
+        userAgent: request.headers['user-agent'] || null,
+        metadata: { clientId: existing.clientId },
+      });
+
+      reply.code(204);
+      return reply.send(null);
+    }
+  );
+
+  // ── POST /api/clients/:id/regenerate-secret — issue a new secret (#90) ──
+  fastify.withTypeProvider<ZodTypeProvider>().post(
+    '/:id/regenerate-secret',
+    {
+      preHandler: fastify.requireJwt,
+      schema: {
+        description:
+          "Issue a new client_secret for one of the developer's OAuth clients. The previous secret is invalidated immediately and the new plaintext secret is returned in THIS response only. Returns 404 if the client does not exist or is owned by another developer; 400 for a public client that has no secret. (Phase 2.2, issue #90.)",
+        tags: ['Clients'],
+        security: [{ bearerAuth: [] }],
+        params: clientIdParamsSchema,
+        response: { 200: regenerateSecretResponseSchema },
+      },
+    },
+    async (request, reply) => {
+      const developerId = requireDeveloperId(request);
+      const { id } = request.params as { id: string };
+
+      const existing = await resolveOwnedClient(fastify, developerId, id);
+
+      // A public client (auth method `none`) holds no usable secret, so
+      // regeneration is meaningless and would mint a credential the client
+      // cannot present. Reject rather than silently confidential-ising it.
+      if (existing.tokenEndpointAuthMethod === 'none') {
+        throw new BadRequestError(
+          'Cannot regenerate a secret for a public client (token_endpoint_auth_method is "none")'
+        );
+      }
+
+      const { plaintext, hash } = await generateClientSecret(fastify);
+
+      const updated = await fastify.repositories.oauthClients.update(id, {
+        clientSecretHash: hash,
+      });
+
+      await fastify.repositories.auditLogs.create({
+        userId: developerId,
+        oauthClientId: updated.id,
+        event: 'oauth.client.secret_regenerated',
+        eventType: 'client',
+        success: true,
+        ipAddress: request.ip,
+        userAgent: request.headers['user-agent'] || null,
+        metadata: { clientId: updated.clientId },
+      });
+
+      // Response carries the plaintext secret once — MUST NOT be cached.
+      reply.header('Cache-Control', 'no-store').header('Pragma', 'no-cache');
+      return reply.send({ ...toClientResponse(updated), clientSecret: plaintext });
     }
   );
 }

--- a/apps/auth-server/src/app/schemas/clients.ts
+++ b/apps/auth-server/src/app/schemas/clients.ts
@@ -50,3 +50,118 @@ export const listClientsResponseSchema = z.object({
  * Response type for `GET /api/clients`.
  */
 export type ListClientsResponse = z.infer<typeof listClientsResponseSchema>;
+
+/**
+ * The OAuth grant types this server supports (mirrors the `grant_type`
+ * pg enum in `@qauth-labs/infra-db`). `password`/`implicit` were removed in
+ * OAuth 2.1, so they are intentionally absent.
+ */
+export const grantTypeSchema = z.enum([
+  'authorization_code',
+  'refresh_token',
+  'client_credentials',
+]);
+
+/**
+ * Supported response types. OAuth 2.1 only retains `code` (implicit removed).
+ */
+export const responseTypeSchema = z.enum(['code']);
+
+/**
+ * Supported token-endpoint client-authentication methods (mirrors the
+ * `token_endpoint_auth_method` pg enum).
+ */
+export const tokenEndpointAuthMethodSchema = z.enum([
+  'client_secret_post',
+  'client_secret_basic',
+  'private_key_jwt',
+  'none',
+]);
+
+/**
+ * Request body for `POST /api/clients` (issue #86).
+ *
+ * The developer never supplies `client_id` or `client_secret` — both are
+ * server-generated. `developerId`/`realmId` are derived from the access token
+ * and the default realm, never the request body (prevents mass-assignment).
+ *
+ * `redirectUris` and the grant/response-type combination are validated for
+ * RFC 7591/OAuth 2.1 consistency in the route handler (shared with the update
+ * path). Defaults mirror the dynamic-client-registration policy:
+ * authorization_code + refresh_token, `code`, public client (PKCE).
+ */
+export const createClientRequestSchema = z.object({
+  name: z.string().min(1).max(255),
+  description: z.string().max(2000).nullish(),
+  redirectUris: z.array(z.url()).default([]),
+  scopes: z.array(z.string()).default([]),
+  grantTypes: z.array(grantTypeSchema).nonempty().optional(),
+  responseTypes: z.array(responseTypeSchema).optional(),
+  tokenEndpointAuthMethod: tokenEndpointAuthMethodSchema.optional(),
+});
+
+/**
+ * Request type for `POST /api/clients`.
+ */
+export type CreateClientRequest = z.infer<typeof createClientRequestSchema>;
+
+/**
+ * Response body for `POST /api/clients` — the only place (besides
+ * regenerate-secret) the plaintext `client_secret` is ever returned. The
+ * developer must persist it now; it is unrecoverable afterwards because only
+ * the argon2id hash is stored. Public clients
+ * (`tokenEndpointAuthMethod === 'none'`) get no `clientSecret`.
+ */
+export const createClientResponseSchema = clientSchema.extend({
+  clientSecret: z.string().optional(),
+});
+
+/**
+ * Response type for `POST /api/clients`.
+ */
+export type CreateClientResponse = z.infer<typeof createClientResponseSchema>;
+
+/**
+ * Request body for `PATCH /api/clients/:id` (issue #88).
+ *
+ * Every field is optional (partial update). Identity and secret columns
+ * (`clientId`, `clientSecretHash`, `developerId`, `realmId`) are intentionally
+ * absent — they can never be mutated through this endpoint. At least one field
+ * must be present.
+ */
+export const updateClientRequestSchema = z
+  .object({
+    name: z.string().min(1).max(255),
+    description: z.string().max(2000).nullable(),
+    redirectUris: z.array(z.url()),
+    scopes: z.array(z.string()),
+    grantTypes: z.array(grantTypeSchema).nonempty(),
+    responseTypes: z.array(responseTypeSchema),
+    tokenEndpointAuthMethod: tokenEndpointAuthMethodSchema,
+    enabled: z.boolean(),
+  })
+  .partial()
+  .refine((body) => Object.keys(body).length > 0, {
+    message: 'At least one field must be provided',
+  });
+
+/**
+ * Request type for `PATCH /api/clients/:id`.
+ */
+export type UpdateClientRequest = z.infer<typeof updateClientRequestSchema>;
+
+/**
+ * Response body for `POST /api/clients/:id/regenerate-secret` (issue #90).
+ *
+ * Returns the safe projection plus the freshly issued plaintext `clientSecret`
+ * exactly once. Regeneration is only meaningful for confidential clients, so
+ * `clientSecret` is always present here.
+ */
+export const regenerateSecretResponseSchema = clientSchema.extend({
+  clientSecret: z.string(),
+});
+
+/**
+ * Response type for `POST /api/clients/:id/regenerate-secret`.
+ */
+export type RegenerateSecretResponse = z.infer<typeof regenerateSecretResponseSchema>;

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -246,20 +246,92 @@ List the authenticated developer's OAuth clients.
 
 A developer with no clients gets `{ "clients": [] }`. Errors: `401` (missing/invalid bearer).
 
-### Planned — gated on the T2 milestone
+> **Ownership & 404 semantics.** Every per-client route is scoped to the token
+> subject's `developer_id`. A client that exists but is owned by another
+> developer is reported as **`404 Not Found`** (not `403`) so the API never
+> confirms the existence of clients the caller does not own.
 
-The write operations are not yet implemented (tracked under
-[T2 — Agent-native authZ](https://github.com/qauth-labs/qauth/milestones)):
+### `POST /api/clients`
 
-| Endpoint                             | Method | Issue                                                |
-| ------------------------------------ | ------ | ---------------------------------------------------- |
-| `/api/clients`                       | POST   | [#86](https://github.com/qauth-labs/qauth/issues/86) |
-| `/api/clients/:id`                   | GET    | [#87](https://github.com/qauth-labs/qauth/issues/87) |
-| `/api/clients/:id`                   | PATCH  | [#88](https://github.com/qauth-labs/qauth/issues/88) |
-| `/api/clients/:id`                   | DELETE | [#89](https://github.com/qauth-labs/qauth/issues/89) |
-| `/api/clients/:id/regenerate-secret` | POST   | [#90](https://github.com/qauth-labs/qauth/issues/90) |
+Create an OAuth client owned by the authenticated developer. The server
+generates the `clientId` (UUID) and, for confidential clients, a 32-byte
+`clientSecret`. **The plaintext `clientSecret` is returned in this response
+only** — only its argon2id hash is stored, so it is unrecoverable afterwards.
 
-Until they land, register clients via [Dynamic Client Registration](./oauth-flow.md#dynamic-client-registration-rfc-7591)
+**Headers**: `Authorization: Bearer <access_token>` (required).
+
+**Body** (all besides `name` optional):
+
+| Field                     | Type     | Default                                  | Notes                                                                               |
+| ------------------------- | -------- | ---------------------------------------- | ----------------------------------------------------------------------------------- |
+| `name`                    | string   | —                                        | Required, 1–255 chars.                                                              |
+| `description`             | string   | `null`                                   |                                                                                     |
+| `redirectUris`            | string[] | `[]`                                     | Each validated (OAuth 2.1 §10.3 — `https` or loopback).                             |
+| `scopes`                  | string[] | `[]`                                     |                                                                                     |
+| `grantTypes`              | string[] | `["authorization_code","refresh_token"]` | `authorization_code` / `refresh_token` / `client_credentials`.                      |
+| `responseTypes`           | string[] | `["code"]`                               | OAuth 2.1 only supports `code`.                                                     |
+| `tokenEndpointAuthMethod` | string   | `"none"`                                 | `none` (public) / `client_secret_post` / `client_secret_basic` / `private_key_jwt`. |
+
+**`201 Created`** (`Cache-Control: no-store`)
+
+```json
+{
+  "id": "0190f7…",
+  "clientId": "0190f7a0-…-uuid",
+  "name": "My App",
+  "description": null,
+  "redirectUris": ["https://app.example.com/cb"],
+  "scopes": ["openid"],
+  "grantTypes": ["authorization_code", "refresh_token"],
+  "responseTypes": ["code"],
+  "tokenEndpointAuthMethod": "client_secret_post",
+  "enabled": true,
+  "requirePkce": true,
+  "createdAt": 1750000000000,
+  "updatedAt": 1750000000000,
+  "lastUsedAt": null,
+  "clientSecret": "a1b2c3…(64 hex chars, shown once)"
+}
+```
+
+Public clients (`tokenEndpointAuthMethod: "none"`) get **no** `clientSecret`.
+Errors: `400` (invalid `redirectUri` or inconsistent grant/response types),
+`401` (missing/invalid bearer, or a non-user token).
+
+### `GET /api/clients/:id`
+
+Get one of the developer's clients. Safe fields only — never the secret.
+
+**`200 OK`** — the same shape as a `GET /api/clients` list item.
+Errors: `401`; `404` (not found or not owned).
+
+### `PATCH /api/clients/:id`
+
+Partially update a client. Any subset of: `name`, `description`,
+`redirectUris`, `scopes`, `grantTypes`, `responseTypes`,
+`tokenEndpointAuthMethod`, `enabled`. `clientId` and the secret are
+**immutable** here. The _effective_ grant/response-type combination (request
+value or persisted value) is re-validated for consistency.
+
+**`200 OK`** — the updated client (safe fields, no secret).
+Errors: `400` (validation / inconsistent config), `401`, `404`.
+
+### `DELETE /api/clients/:id`
+
+Delete a client. After deletion the client can no longer authenticate.
+
+**`204 No Content`**. Errors: `401`; `404` (not found or not owned).
+
+### `POST /api/clients/:id/regenerate-secret`
+
+Issue a new `clientSecret`. The previous secret is invalidated immediately;
+**the new plaintext secret is returned in this response only.**
+
+**`200 OK`** (`Cache-Control: no-store`) — the client (safe fields) plus a
+`clientSecret` string. Errors: `400` (public client — no secret to rotate),
+`401`, `404`.
+
+Clients may also be registered via [Dynamic Client Registration](./oauth-flow.md#dynamic-client-registration-rfc-7591)
 (`POST /oauth/register`), CIMD, or the `seed-oauth-clients` script.
 
 ---

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -262,15 +262,19 @@ only** — only its argon2id hash is stored, so it is unrecoverable afterwards.
 
 **Body** (all besides `name` optional):
 
-| Field                     | Type     | Default                                  | Notes                                                                               |
-| ------------------------- | -------- | ---------------------------------------- | ----------------------------------------------------------------------------------- |
-| `name`                    | string   | —                                        | Required, 1–255 chars.                                                              |
-| `description`             | string   | `null`                                   |                                                                                     |
-| `redirectUris`            | string[] | `[]`                                     | Each validated (OAuth 2.1 §10.3 — `https` or loopback).                             |
-| `scopes`                  | string[] | `[]`                                     |                                                                                     |
-| `grantTypes`              | string[] | `["authorization_code","refresh_token"]` | `authorization_code` / `refresh_token` / `client_credentials`.                      |
-| `responseTypes`           | string[] | `["code"]`                               | OAuth 2.1 only supports `code`.                                                     |
-| `tokenEndpointAuthMethod` | string   | `"none"`                                 | `none` (public) / `client_secret_post` / `client_secret_basic` / `private_key_jwt`. |
+| Field                     | Type     | Default                                  | Notes                                                                                                                                         |
+| ------------------------- | -------- | ---------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`                    | string   | —                                        | Required, 1–255 chars.                                                                                                                        |
+| `description`             | string   | `null`                                   |                                                                                                                                               |
+| `redirectUris`            | string[] | `[]`                                     | Each validated (OAuth 2.1 §10.3 — `https` or loopback). **Required (≥1) for user-involving grants** (`authorization_code` / `refresh_token`). |
+| `scopes`                  | string[] | `[]`                                     | Capped to the realm's allowed-scopes policy (same allowlist as dynamic registration); a scope outside it is rejected.                         |
+| `grantTypes`              | string[] | `["authorization_code","refresh_token"]` | `authorization_code` / `refresh_token` / `client_credentials`.                                                                                |
+| `responseTypes`           | string[] | `["code"]`                               | OAuth 2.1 only supports `code`.                                                                                                               |
+| `tokenEndpointAuthMethod` | string   | `"none"`                                 | `none` (public) / `client_secret_post` / `client_secret_basic` / `private_key_jwt`.                                                           |
+
+**Rate limit**: per-IP, shared budget with `POST /oauth/register`
+(`REGISTER_CLIENT_RATE_LIMIT` / `REGISTER_CLIENT_RATE_WINDOW`) — create runs an
+argon2id hash on every call, so the cap is mandatory (`429` on exceed).
 
 **`201 Created`** (`Cache-Control: no-store`)
 
@@ -295,8 +299,9 @@ only** — only its argon2id hash is stored, so it is unrecoverable afterwards.
 ```
 
 Public clients (`tokenEndpointAuthMethod: "none"`) get **no** `clientSecret`.
-Errors: `400` (invalid `redirectUri` or inconsistent grant/response types),
-`401` (missing/invalid bearer, or a non-user token).
+Errors: `400` (invalid `redirectUri`, inconsistent grant/response types, missing
+`redirectUris` for a user-involving grant, or a scope outside the realm policy),
+`401` (missing/invalid bearer, or a non-user token), `429` (rate limited).
 
 ### `GET /api/clients/:id`
 
@@ -309,16 +314,22 @@ Errors: `401`; `404` (not found or not owned).
 
 Partially update a client. Any subset of: `name`, `description`,
 `redirectUris`, `scopes`, `grantTypes`, `responseTypes`,
-`tokenEndpointAuthMethod`, `enabled`. `clientId` and the secret are
-**immutable** here. The _effective_ grant/response-type combination (request
-value or persisted value) is re-validated for consistency.
+`tokenEndpointAuthMethod`, `enabled`. `clientId`, the secret, and
+`developerId` are **immutable** here (unknown/immutable keys are ignored). The
+_effective_ configuration (request value or persisted value) is re-validated:
+grant/response-type consistency, a redirect URI for user-involving grants, and
+the realm scope cap when `scopes` is changed.
 
 **`200 OK`** — the updated client (safe fields, no secret).
-Errors: `400` (validation / inconsistent config), `401`, `404`.
+Errors: `400` (validation / inconsistent config / disallowed scope / missing
+redirect for a user-involving grant), `401`, `404`.
 
 ### `DELETE /api/clients/:id`
 
-Delete a client. After deletion the client can no longer authenticate.
+Delete a client. After deletion the client can no longer authenticate at the
+token endpoint and cannot start new authorization flows. Note: already-issued
+**access tokens are stateless JWTs** and remain valid until they expire;
+short access-token lifetimes bound this window.
 
 **`204 No Content`**. Errors: `401`; `404` (not found or not owned).
 
@@ -329,7 +340,7 @@ Issue a new `clientSecret`. The previous secret is invalidated immediately;
 
 **`200 OK`** (`Cache-Control: no-store`) — the client (safe fields) plus a
 `clientSecret` string. Errors: `400` (public client — no secret to rotate),
-`401`, `404`.
+`401`, `404`, `429` (rate limited — argon2id, same per-IP budget as create).
 
 Clients may also be registered via [Dynamic Client Registration](./oauth-flow.md#dynamic-client-registration-rfc-7591)
 (`POST /oauth/register`), CIMD, or the `seed-oauth-clients` script.


### PR DESCRIPTION
## Summary

Implements the **client-management REST CRUD** surface for the **T2** milestone
as sibling routes in the existing `apps/auth-server/src/app/routes/clients`
module (mounted at `/api/clients`), matching the style of the existing
`GET /` list route:

| Method | Path                          | Issue | Behaviour |
| ------ | ----------------------------- | ----- | --------- |
| POST   | `/`                           | #86   | Create: server-generated `clientId` (UUID) + 32-byte hex secret, argon2id-hashed; plaintext returned **once**. |
| GET    | `/:id`                        | #87   | Get one owned client (safe fields only). |
| PATCH  | `/:id`                        | #88   | Update mutable fields (name, description, redirectUris, scopes, grantTypes, responseTypes, tokenEndpointAuthMethod, enabled). |
| DELETE | `/:id`                        | #89   | Delete a client (`204`). |
| POST   | `/:id/regenerate-secret`      | #90   | Rotate the secret, return the new plaintext **once**. |

## Security & correctness

- **Ownership** scoped strictly by `oauth_clients.developer_id` (from the JWT
  `sub`). A client that exists but is owned by **another** developer returns
  **`404`, not `403`**, to avoid existence enumeration (OWASP API1/A01 BOLA) —
  matching how `NotFoundError` is used elsewhere (`consents`, `userinfo`).
- **Secret-once**: the plaintext `client_secret` appears only in the create and
  regenerate responses (`Cache-Control: no-store`); every other response uses
  the safe projection and **never** serializes `clientSecretHash` or internal
  columns. Public clients (`tokenEndpointAuthMethod: none`) get no secret and
  cannot regenerate one.
- **Validation**: `redirect_uris` validated via the shared
  `validateRedirectUri` (OAuth 2.1 §10.3); grant/response-type consistency
  enforced on create **and** update (effective value = request value or
  persisted value for partial updates).
- `developer_id` is always set from the token subject, never the request body
  (no mass-assignment). A non-user (`client_credentials`) token cannot create
  or resolve clients.
- Audit-log entries written for created / updated / deleted / secret_regenerated.

## Scope

Touches only the owned files: `routes/clients/index.ts`,
`schemas/clients.ts`, the route tests, and `docs/api-reference.md` (the
"Planned — gated on the T2 milestone" section replaced with the implemented
contracts). No DB-schema or `routes/oauth/register.ts` changes (a parallel PR
owns those). Reuses the existing `repositories.oauthClients.*` methods.

## Tests / CI

- `pnpm nx run-many -t lint typecheck test build -p auth-server infra-db` — all green (0 errors).
- auth-server: **741 tests pass**; coverage ~79.7% statements / 66.7% branches (above the gate). New route file: 94.7% statements, 100% functions.
- 33 new route tests cover ownership 404s, secret-once + `no-store`, redirect/grant validation, public-client cases, and non-UUID-subject guards.

## Follow-ups

- Surfacing the agent-type field is intentionally **out of scope** (owned by another PR).

Closes #86
Closes #87
Closes #88
Closes #89
Closes #90

https://claude.ai/code/session_01Re2rxPkdcgzJe7LSddhxv6
