### PR TITLE
feat(db): agent client classification on oauth_clients (#182)

### DIFF
--- a/apps/auth-server/src/app/helpers/cimd.test.ts
+++ b/apps/auth-server/src/app/helpers/cimd.test.ts
@@ -22,7 +22,13 @@ vi.mock('./ssrf-safe-fetch', async () => {
   return { ...actual, ssrfSafeGet };
 });
 
-import { fetchAndValidateCimdDocument, isCimdClientId, resolveCacheTtlSeconds } from './cimd';
+import {
+  cimdDocumentSchema,
+  fetchAndValidateCimdDocument,
+  isCimdClientId,
+  resolveCacheTtlSeconds,
+  toCimdClientInsert,
+} from './cimd';
 
 const CLIENT_ID = 'https://app.example.com/oauth/client-metadata.json';
 
@@ -212,5 +218,30 @@ describe('fetchAndValidateCimdDocument', () => {
 
     const doc = await fetchAndValidateCimdDocument(fastify, CLIENT_ID);
     expect(doc.client_id).toBe(CLIENT_ID);
+  });
+
+  it('recognises the is_agent indicator in the metadata document (ADR-007 §2)', async () => {
+    const fastify = fastifyStub();
+    ssrfSafeGet.mockResolvedValue(ok(validDoc({ is_agent: true })));
+
+    const doc = await fetchAndValidateCimdDocument(fastify, CLIENT_ID);
+    expect(doc.is_agent).toBe(true);
+  });
+});
+
+describe('toCimdClientInsert — agent classification (ADR-007 §2)', () => {
+  const REALM = 'realm-1';
+  const SENTINEL = '$argon2id$v=19$m=65536,t=3,p=4$c2FsdA$ZGlnZXN0';
+
+  it('defaults isAgent to false when the document omits the indicator', () => {
+    const doc = cimdDocumentSchema.parse(validDoc());
+    const insert = toCimdClientInsert(REALM, CLIENT_ID, doc, SENTINEL);
+    expect(insert.isAgent).toBe(false);
+  });
+
+  it('sets isAgent true when the document declares is_agent', () => {
+    const doc = cimdDocumentSchema.parse(validDoc({ is_agent: true }));
+    const insert = toCimdClientInsert(REALM, CLIENT_ID, doc, SENTINEL);
+    expect(insert.isAgent).toBe(true);
   });
 });

--- a/apps/auth-server/src/app/helpers/cimd.ts
+++ b/apps/auth-server/src/app/helpers/cimd.ts
@@ -64,6 +64,14 @@ export const cimdDocumentSchema = z.object({
   logo_uri: z.string().max(2048).optional(),
   tos_uri: z.string().max(2048).optional(),
   policy_uri: z.string().max(2048).optional(),
+  /**
+   * QAuth extension metadata (ADR-007 §2): the document declares itself an
+   * autonomous AI-agent client. Unknown metadata fields are normally stripped
+   * (RFC 7591 §3.2), so we accept this one explicitly to recognise the
+   * indicator. Defaults to a standard (non-agent) client when absent.
+   * Persisted to `oauth_clients.is_agent`; nothing is gated on it yet.
+   */
+  is_agent: z.boolean().optional(),
 });
 
 export type CimdDocument = z.infer<typeof cimdDocumentSchema>;
@@ -94,6 +102,8 @@ export interface CimdClientInsert {
   enabled: true;
   developerId: null;
   scopes: string[];
+  /** ADR-007 §2 agent classification, mirrored from the metadata document. */
+  isAgent: boolean;
   metadata: Record<string, unknown>;
 }
 
@@ -218,6 +228,8 @@ export function toCimdClientInsert(
     enabled: true,
     developerId: null,
     scopes: [],
+    // ADR-007 §2: carry the agent classification from the metadata document.
+    isAgent: doc.is_agent ?? false,
     metadata: {
       registrationType: 'cimd',
       client_id_metadata_url: clientId,

--- a/apps/auth-server/src/app/helpers/cimd.ts
+++ b/apps/auth-server/src/app/helpers/cimd.ts
@@ -70,6 +70,13 @@ export const cimdDocumentSchema = z.object({
    * (RFC 7591 §3.2), so we accept this one explicitly to recognise the
    * indicator. Defaults to a standard (non-agent) client when absent.
    * Persisted to `oauth_clients.is_agent`; nothing is gated on it yet.
+   *
+   * TRUST: this is self-asserted, unverified client input — it comes from the
+   * client's own externally-fetched metadata document, not anything the AS
+   * established. The CIMD url==client_id binding authenticates *which* URL the
+   * document belongs to, NOT the truthfulness of `is_agent`. Later gating must
+   * treat it as untrusted (verify, don't trust) and default-deny, since a
+   * client can also *omit* it to dodge agent-specific controls.
    */
   is_agent: z.boolean().optional(),
 });

--- a/apps/auth-server/src/app/helpers/client-resolution.test.ts
+++ b/apps/auth-server/src/app/helpers/client-resolution.test.ts
@@ -23,7 +23,12 @@ vi.mock('./ssrf-safe-fetch', async () => {
   return { ...actual, ssrfSafeGet };
 });
 
-import { cimdSentinelSecretHash, isCimdClient, resolveClient } from './client-resolution';
+import {
+  cimdSentinelSecretHash,
+  isAgentClient,
+  isCimdClient,
+  resolveClient,
+} from './client-resolution';
 
 const CIMD_ID = 'https://app.example.com/client.json';
 
@@ -173,5 +178,23 @@ describe('resolveClient — pre-registered → CIMD priority (MCP 2025-11-25)', 
     expect(client).toBeNull();
     expect(reason).toBe('invalid_client');
     expect(ssrfSafeGet).not.toHaveBeenCalled();
+  });
+});
+
+describe('isAgentClient — fail-closed agent classification (ADR-007 §2)', () => {
+  it('is true only for a strict isAgent === true', () => {
+    expect(isAgentClient({ isAgent: true })).toBe(true);
+  });
+
+  it('is false for a standard client', () => {
+    expect(isAgentClient({ isAgent: false })).toBe(false);
+  });
+
+  it('fails closed for missing / null / undefined (treats as non-agent, never throws)', () => {
+    // A client omitting the flag is the real escalation direction — it must
+    // read as NOT an agent, not as truthy and not as an error.
+    expect(isAgentClient({})).toBe(false);
+    expect(isAgentClient(null)).toBe(false);
+    expect(isAgentClient(undefined)).toBe(false);
   });
 });

--- a/apps/auth-server/src/app/helpers/client-resolution.ts
+++ b/apps/auth-server/src/app/helpers/client-resolution.ts
@@ -62,9 +62,18 @@ export function isCimdClient(client: { metadata: Record<string, unknown> | null 
  * A thin, intention-revealing accessor for the `is_agent` column so later
  * agent-native gating reads `isAgentClient(client)` rather than poking the
  * raw field. Nothing gates on it yet.
+ *
+ * Fail-closed by design: returns true ONLY for a strict `isAgent === true`,
+ * so a missing / null / undefined field (e.g. an object built via the
+ * `as unknown as ResolvedClient` casts above, or a partially-shaped object)
+ * reads as NOT an agent rather than throwing. This is the safe default for a
+ * classification gate. It does NOT make `is_agent` trustworthy — the value is
+ * self-asserted client input (see the schema column note); downstream gating
+ * must still verify rather than trust, and the escalation risk is a client
+ * *omitting* the flag, which this accessor treats as non-agent.
  */
-export function isAgentClient(client: { isAgent: boolean }): boolean {
-  return client.isAgent === true;
+export function isAgentClient(client: { isAgent?: boolean } | null | undefined): boolean {
+  return client?.isAgent === true;
 }
 
 /**

--- a/apps/auth-server/src/app/helpers/client-resolution.ts
+++ b/apps/auth-server/src/app/helpers/client-resolution.ts
@@ -42,12 +42,29 @@ export interface ResolvedClient {
   tokenEndpointAuthMethod?: string;
   name: string;
   dynamicRegisteredAt: number | null;
+  /**
+   * ADR-007 §2 first-class agent classification. Surfaced here so the
+   * authorize / token / consent handlers that already consume the resolved
+   * client can gate agent-native behaviour (delegation, scope modes,
+   * step-up) in later issues. Nothing is gated on it yet.
+   */
+  isAgent: boolean;
   metadata: Record<string, unknown> | null;
 }
 
 /** True iff the resolved client originated from a CIMD metadata document. */
 export function isCimdClient(client: { metadata: Record<string, unknown> | null }): boolean {
   return client.metadata?.registrationType === 'cimd';
+}
+
+/**
+ * True iff the client is classified as an autonomous AI agent (ADR-007 §2).
+ * A thin, intention-revealing accessor for the `is_agent` column so later
+ * agent-native gating reads `isAgentClient(client)` rather than poking the
+ * raw field. Nothing gates on it yet.
+ */
+export function isAgentClient(client: { isAgent: boolean }): boolean {
+  return client.isAgent === true;
 }
 
 /**

--- a/apps/auth-server/src/app/helpers/dynamic-client-registration.ts
+++ b/apps/auth-server/src/app/helpers/dynamic-client-registration.ts
@@ -105,6 +105,12 @@ export interface NormalizedRegistrationRequest {
   softwareVersion: string | null;
   /** Whether this is a public client (token_endpoint_auth_method = none). */
   isPublic: boolean;
+  /**
+   * Whether the client registered itself as an autonomous AI agent
+   * (ADR-007 §2). Orthogonal to `isPublic`. Persisted to
+   * `oauth_clients.is_agent`; defaults to false when the request omits it.
+   */
+  isAgent: boolean;
 }
 
 /**
@@ -217,5 +223,6 @@ export function validateAndNormalize(
     softwareId: body.software_id ?? null,
     softwareVersion: body.software_version ?? null,
     isPublic,
+    isAgent: body.is_agent ?? false,
   };
 }

--- a/apps/auth-server/src/app/routes/oauth/register.test.ts
+++ b/apps/auth-server/src/app/routes/oauth/register.test.ts
@@ -294,6 +294,60 @@ describe('POST /oauth/register — Dynamic Client Registration (RFC 7591)', () =
     expect('application_type' in result).toBe(false);
   });
 
+  it('registers an agent client and round-trips the is_agent flag (ADR-007 §2)', async () => {
+    const { fastify, ctx, state } = createFastifyStub();
+    await registerRoute(fastify);
+
+    const { reply } = createReply();
+    const result = (await ctx.handler!(
+      {
+        body: {
+          client_name: 'Autonomous Agent',
+          redirect_uris: ['https://agent.example/callback'],
+          grant_types: ['authorization_code', 'refresh_token'],
+          response_types: ['code'],
+          scope: 'openid',
+          is_agent: true,
+        },
+        ip: '127.0.0.1',
+        headers: { 'user-agent': 'vitest' },
+      },
+      reply
+    )) as Record<string, unknown>;
+
+    // Echoed back in the registration response.
+    expect(result.is_agent).toBe(true);
+    // Persisted on the client row.
+    expect(state.createdClients[0].isAgent).toBe(true);
+    // Captured in the audit log for the registration event.
+    expect(state.auditLogs[0].metadata).toMatchObject({ isAgent: true });
+  });
+
+  it('defaults to a standard (non-agent) client when is_agent is omitted', async () => {
+    const { fastify, ctx, state } = createFastifyStub();
+    await registerRoute(fastify);
+
+    const { reply } = createReply();
+    const result = (await ctx.handler!(
+      {
+        body: {
+          client_name: 'Standard Client',
+          redirect_uris: ['https://app.example/cb'],
+          grant_types: ['authorization_code'],
+          response_types: ['code'],
+        },
+        ip: '127.0.0.1',
+        headers: {},
+      },
+      reply
+    )) as Record<string, unknown>;
+
+    // Omitted from the response (matches the optional-field echo convention).
+    expect('is_agent' in result).toBe(false);
+    // Stored as the backward-compatible default.
+    expect(state.createdClients[0].isAgent).toBe(false);
+  });
+
   it('seeds the realm default allowlist on first use when empty', async () => {
     const { fastify, ctx, state } = createFastifyStub({
       dynamicRegistrationAllowedScopes: [],

--- a/apps/auth-server/src/app/routes/oauth/register.ts
+++ b/apps/auth-server/src/app/routes/oauth/register.ts
@@ -127,6 +127,9 @@ export default async function (fastify: FastifyInstance) {
         requirePkce: true,
         enabled: true,
         developerId: null,
+        // ADR-007 §2: first-class agent classification. Defaults to false
+        // (standard client); nothing is gated on it yet.
+        isAgent: normalized.isAgent,
         // Stamp the dyn-reg timestamp so the consent screen (issue #150)
         // can surface the "Newly registered" phishing-defense badge
         // within DYNAMIC_CLIENT_BADGE_DAYS of registration.
@@ -155,6 +158,7 @@ export default async function (fastify: FastifyInstance) {
           registrationType: 'dynamic',
           clientId,
           isPublic: normalized.isPublic,
+          isAgent: normalized.isAgent,
           grantTypes: normalized.grantTypes,
           scopes: normalized.scopes,
         },
@@ -186,6 +190,9 @@ export default async function (fastify: FastifyInstance) {
         ...(normalized.contacts ? { contacts: normalized.contacts } : {}),
         ...(normalized.softwareId ? { software_id: normalized.softwareId } : {}),
         ...(normalized.softwareVersion ? { software_version: normalized.softwareVersion } : {}),
+        // Echo the agent classification back only when set, mirroring the
+        // optional-field convention above (omit for standard clients).
+        ...(normalized.isAgent ? { is_agent: true } : {}),
       };
 
       // RFC 7591 §3.2.1: response MUST NOT be cached (contains secret).

--- a/apps/auth-server/src/app/schemas/oauth.ts
+++ b/apps/auth-server/src/app/schemas/oauth.ts
@@ -208,6 +208,15 @@ export const dynamicClientRegistrationRequestSchema = z.object({
   contacts: z.array(z.email().max(255)).max(10).optional(),
   software_id: z.string().max(255).optional(),
   software_version: z.string().max(64).optional(),
+  /**
+   * QAuth extension metadata (ADR-007 §2): marks the client as an autonomous
+   * AI agent. RFC 7591 §2 permits a server to define additional client
+   * metadata; this QAuth-specific flag is a plain boolean and defaults to a
+   * standard (non-agent) client when omitted. Persisted as
+   * `oauth_clients.is_agent` and echoed back per §3.2.1. Nothing is gated on
+   * it yet — delegation / scope modes / step-up are later ADR-007 §2 issues.
+   */
+  is_agent: z.boolean().optional(),
 });
 
 export type DynamicClientRegistrationRequest = z.infer<
@@ -239,6 +248,8 @@ export const dynamicClientRegistrationResponseSchema = z.object({
   contacts: z.array(z.string()).optional(),
   software_id: z.string().optional(),
   software_version: z.string().optional(),
+  /** QAuth extension: echoed back when the client was registered as an agent. */
+  is_agent: z.boolean().optional(),
 });
 
 export type DynamicClientRegistrationResponse = z.infer<

--- a/apps/auth-server/src/app/schemas/oauth.ts
+++ b/apps/auth-server/src/app/schemas/oauth.ts
@@ -215,6 +215,11 @@ export const dynamicClientRegistrationRequestSchema = z.object({
    * standard (non-agent) client when omitted. Persisted as
    * `oauth_clients.is_agent` and echoed back per §3.2.1. Nothing is gated on
    * it yet — delegation / scope modes / step-up are later ADR-007 §2 issues.
+   *
+   * TRUST: this is self-asserted, unverified client input — the client sets
+   * it in its own registration request. Later gating must treat it as
+   * untrusted (verify, don't trust) and default-deny, since a client can
+   * also *omit* it to dodge agent-specific controls.
    */
   is_agent: z.boolean().optional(),
 });

--- a/libs/infra/db/drizzle/0004_agent_client_type.sql
+++ b/libs/infra/db/drizzle/0004_agent_client_type.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "oauth_clients" ADD COLUMN "is_agent" boolean DEFAULT false NOT NULL;

--- a/libs/infra/db/drizzle/meta/0004_snapshot.json
+++ b/libs/infra/db/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,2128 @@
+{
+  "id": "7abce4e6-6b69-4780-815a-4d9d392c9021",
+  "prevId": "2d8e303d-29d8-40a5-99a3-7c7ab66840f8",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_client_id": {
+          "name": "oauth_client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event": {
+          "name": "event",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "audit_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(EXTRACT(EPOCH FROM NOW())::bigint * 1000)"
+        }
+      },
+      "indexes": {
+        "idx_audit_logs_user_id": {
+          "name": "idx_audit_logs_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_logs_oauth_client_id": {
+          "name": "idx_audit_logs_oauth_client_id",
+          "columns": [
+            {
+              "expression": "oauth_client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_logs_event_type": {
+          "name": "idx_audit_logs_event_type",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_logs_event": {
+          "name": "idx_audit_logs_event",
+          "columns": [
+            {
+              "expression": "event",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_logs_created_at": {
+          "name": "idx_audit_logs_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_logs_user_event": {
+          "name": "idx_audit_logs_user_event",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_logs_failed": {
+          "name": "idx_audit_logs_failed",
+          "columns": [
+            {
+              "expression": "event",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"audit_logs\".\"success\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_logs_ip_address": {
+          "name": "idx_audit_logs_ip_address",
+          "columns": [
+            {
+              "expression": "ip_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_logs_user_id_users_id_fk": {
+          "name": "audit_logs_user_id_users_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "audit_logs_oauth_client_id_oauth_clients_id_fk": {
+          "name": "audit_logs_oauth_client_id_oauth_clients_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "oauth_clients",
+          "columnsFrom": ["oauth_client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_consents": {
+      "name": "oauth_consents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oauth_client_id": {
+          "name": "oauth_client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "realm_id": {
+          "name": "realm_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(EXTRACT(EPOCH FROM NOW())::bigint * 1000)"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_oauth_consents_user_client_active": {
+          "name": "idx_oauth_consents_user_client_active",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "oauth_client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"oauth_consents\".\"revoked_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_oauth_consents_user_id": {
+          "name": "idx_oauth_consents_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_oauth_consents_client_id": {
+          "name": "idx_oauth_consents_client_id",
+          "columns": [
+            {
+              "expression": "oauth_client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_oauth_consents_realm_id": {
+          "name": "idx_oauth_consents_realm_id",
+          "columns": [
+            {
+              "expression": "realm_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_consents_user_id_users_id_fk": {
+          "name": "oauth_consents_user_id_users_id_fk",
+          "tableFrom": "oauth_consents",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_consents_oauth_client_id_oauth_clients_id_fk": {
+          "name": "oauth_consents_oauth_client_id_oauth_clients_id_fk",
+          "tableFrom": "oauth_consents",
+          "tableTo": "oauth_clients",
+          "columnsFrom": ["oauth_client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_consents_realm_id_realms_id_fk": {
+          "name": "oauth_consents_realm_id_realms_id_fk",
+          "tableFrom": "oauth_consents",
+          "tableTo": "realms",
+          "columnsFrom": ["realm_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_clients": {
+      "name": "oauth_clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "realm_id": {
+          "name": "realm_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret_hash": {
+          "name": "client_secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "audience": {
+          "name": "audience",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "require_pkce": {
+          "name": "require_pkce",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "token_endpoint_auth_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'client_secret_post'"
+        },
+        "grant_types": {
+          "name": "grant_types",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[\"authorization_code\",\"refresh_token\"]'::jsonb"
+        },
+        "response_types": {
+          "name": "response_types",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[\"code\"]'::jsonb"
+        },
+        "developer_id": {
+          "name": "developer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_agent": {
+          "name": "is_agent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "dynamic_registered_at": {
+          "name": "dynamic_registered_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(EXTRACT(EPOCH FROM NOW())::bigint * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(EXTRACT(EPOCH FROM NOW())::bigint * 1000)"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_oauth_clients_realm_client_id_unique": {
+          "name": "idx_oauth_clients_realm_client_id_unique",
+          "columns": [
+            {
+              "expression": "realm_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_oauth_clients_client_id": {
+          "name": "idx_oauth_clients_client_id",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_oauth_clients_realm_id": {
+          "name": "idx_oauth_clients_realm_id",
+          "columns": [
+            {
+              "expression": "realm_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_oauth_clients_developer_id": {
+          "name": "idx_oauth_clients_developer_id",
+          "columns": [
+            {
+              "expression": "developer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_oauth_clients_enabled": {
+          "name": "idx_oauth_clients_enabled",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"oauth_clients\".\"enabled\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_oauth_clients_realm_client_id_enabled": {
+          "name": "idx_oauth_clients_realm_client_id_enabled",
+          "columns": [
+            {
+              "expression": "realm_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_clients_realm_id_realms_id_fk": {
+          "name": "oauth_clients_realm_id_realms_id_fk",
+          "tableFrom": "oauth_clients",
+          "tableTo": "realms",
+          "columnsFrom": ["realm_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_clients_developer_id_users_id_fk": {
+          "name": "oauth_clients_developer_id_users_id_fk",
+          "tableFrom": "oauth_clients",
+          "tableTo": "users",
+          "columnsFrom": ["developer_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "oauth_clients_audience_is_array": {
+          "name": "oauth_clients_audience_is_array",
+          "value": "\"oauth_clients\".\"audience\" IS NULL OR jsonb_typeof(\"oauth_clients\".\"audience\") = 'array'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.realms": {
+      "name": "realms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "access_token_lifespan": {
+          "name": "access_token_lifespan",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 900
+        },
+        "refresh_token_lifespan": {
+          "name": "refresh_token_lifespan",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 604800
+        },
+        "ssl_required": {
+          "name": "ssl_required",
+          "type": "ssl_required",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'external'"
+        },
+        "verify_email": {
+          "name": "verify_email",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "registration_allowed": {
+          "name": "registration_allowed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "login_with_email_allowed": {
+          "name": "login_with_email_allowed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "duplicate_emails_allowed": {
+          "name": "duplicate_emails_allowed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "password_policy": {
+          "name": "password_policy",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sso_idle_timeout": {
+          "name": "sso_idle_timeout",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sso_max_lifespan": {
+          "name": "sso_max_lifespan",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoke_refresh_token": {
+          "name": "revoke_refresh_token",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "refresh_token_max_reuse": {
+          "name": "refresh_token_max_reuse",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "default_locale": {
+          "name": "default_locale",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supported_locales": {
+          "name": "supported_locales",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "dynamic_registration_allowed_scopes": {
+          "name": "dynamic_registration_allowed_scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(EXTRACT(EPOCH FROM NOW())::bigint * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(EXTRACT(EPOCH FROM NOW())::bigint * 1000)"
+        }
+      },
+      "indexes": {
+        "idx_realms_enabled": {
+          "name": "idx_realms_enabled",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"realms\".\"enabled\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "realms_name_unique": {
+          "name": "realms_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "realm_id": {
+          "name": "realm_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_normalized": {
+          "name": "email_normalized",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(EXTRACT(EPOCH FROM NOW())::bigint * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(EXTRACT(EPOCH FROM NOW())::bigint * 1000)"
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_users_realm_email_normalized_unique": {
+          "name": "idx_users_realm_email_normalized_unique",
+          "columns": [
+            {
+              "expression": "realm_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email_normalized",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_email": {
+          "name": "idx_users_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_realm_id": {
+          "name": "idx_users_realm_id",
+          "columns": [
+            {
+              "expression": "realm_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_enabled": {
+          "name": "idx_users_enabled",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"users\".\"enabled\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_realm_email_enabled": {
+          "name": "idx_users_realm_email_enabled",
+          "columns": [
+            {
+              "expression": "realm_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email_normalized",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_realm_id_realms_id_fk": {
+          "name": "users_realm_id_realms_id_fk",
+          "tableFrom": "users",
+          "tableTo": "realms",
+          "columnsFrom": ["realm_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roles": {
+      "name": "roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "realm_id": {
+          "name": "realm_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_client_id": {
+          "name": "oauth_client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(EXTRACT(EPOCH FROM NOW())::bigint * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(EXTRACT(EPOCH FROM NOW())::bigint * 1000)"
+        }
+      },
+      "indexes": {
+        "idx_roles_realm_name_unique": {
+          "name": "idx_roles_realm_name_unique",
+          "columns": [
+            {
+              "expression": "realm_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "oauth_client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_roles_name": {
+          "name": "idx_roles_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_roles_realm_id": {
+          "name": "idx_roles_realm_id",
+          "columns": [
+            {
+              "expression": "realm_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_roles_oauth_client_id": {
+          "name": "idx_roles_oauth_client_id",
+          "columns": [
+            {
+              "expression": "oauth_client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "roles_realm_id_realms_id_fk": {
+          "name": "roles_realm_id_realms_id_fk",
+          "tableFrom": "roles",
+          "tableTo": "realms",
+          "columnsFrom": ["realm_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "roles_oauth_client_id_oauth_clients_id_fk": {
+          "name": "roles_oauth_client_id_oauth_clients_id_fk",
+          "tableFrom": "roles",
+          "tableTo": "oauth_clients",
+          "columnsFrom": ["oauth_client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_roles": {
+      "name": "user_roles",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigned_at": {
+          "name": "assigned_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(EXTRACT(EPOCH FROM NOW())::bigint * 1000)"
+        },
+        "assigned_by": {
+          "name": "assigned_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_user_roles_user_id": {
+          "name": "idx_user_roles_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_roles_role_id": {
+          "name": "idx_user_roles_role_id",
+          "columns": [
+            {
+              "expression": "role_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_roles_user_id_users_id_fk": {
+          "name": "user_roles_user_id_users_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_roles_role_id_roles_id_fk": {
+          "name": "user_roles_role_id_roles_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "roles",
+          "columnsFrom": ["role_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_roles_assigned_by_users_id_fk": {
+          "name": "user_roles_assigned_by_users_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "users",
+          "columnsFrom": ["assigned_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_roles_pk": {
+          "name": "user_roles_pk",
+          "columns": ["user_id", "role_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oauth_client_id": {
+          "name": "oauth_client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_hash": {
+          "name": "access_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_hash": {
+          "name": "refresh_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(EXTRACT(EPOCH FROM NOW())::bigint * 1000)"
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(EXTRACT(EPOCH FROM NOW())::bigint * 1000)"
+        }
+      },
+      "indexes": {
+        "idx_sessions_user_id": {
+          "name": "idx_sessions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sessions_active": {
+          "name": "idx_sessions_active",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"sessions\".\"revoked\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sessions_expires_at": {
+          "name": "idx_sessions_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sessions_access_token_hash": {
+          "name": "idx_sessions_access_token_hash",
+          "columns": [
+            {
+              "expression": "access_token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sessions_oauth_client_id": {
+          "name": "idx_sessions_oauth_client_id",
+          "columns": [
+            {
+              "expression": "oauth_client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sessions_oauth_client_id_oauth_clients_id_fk": {
+          "name": "sessions_oauth_client_id_oauth_clients_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "oauth_clients",
+          "columnsFrom": ["oauth_client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.authorization_codes": {
+      "name": "authorization_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oauth_client_id": {
+          "name": "oauth_client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge": {
+          "name": "code_challenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge_method": {
+          "name": "code_challenge_method",
+          "type": "code_challenge_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'S256'"
+        },
+        "nonce": {
+          "name": "nonce",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "resource": {
+          "name": "resource",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used": {
+          "name": "used",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(EXTRACT(EPOCH FROM NOW())::bigint * 1000)"
+        }
+      },
+      "indexes": {
+        "idx_authorization_codes_active": {
+          "name": "idx_authorization_codes_active",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"authorization_codes\".\"used\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_authorization_codes_expires_at": {
+          "name": "idx_authorization_codes_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_authorization_codes_user_id": {
+          "name": "idx_authorization_codes_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_authorization_codes_oauth_client_id": {
+          "name": "idx_authorization_codes_oauth_client_id",
+          "columns": [
+            {
+              "expression": "oauth_client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "authorization_codes_oauth_client_id_oauth_clients_id_fk": {
+          "name": "authorization_codes_oauth_client_id_oauth_clients_id_fk",
+          "tableFrom": "authorization_codes",
+          "tableTo": "oauth_clients",
+          "columnsFrom": ["oauth_client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "authorization_codes_user_id_users_id_fk": {
+          "name": "authorization_codes_user_id_users_id_fk",
+          "tableFrom": "authorization_codes",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "authorization_codes_code_unique": {
+          "name": "authorization_codes_code_unique",
+          "nullsNotDistinct": false,
+          "columns": ["code"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_verification_tokens": {
+      "name": "email_verification_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used": {
+          "name": "used",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(EXTRACT(EPOCH FROM NOW())::bigint * 1000)"
+        }
+      },
+      "indexes": {
+        "idx_email_verification_tokens_user_id": {
+          "name": "idx_email_verification_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_email_verification_tokens_active": {
+          "name": "idx_email_verification_tokens_active",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"email_verification_tokens\".\"used\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_email_verification_tokens_expires_at": {
+          "name": "idx_email_verification_tokens_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_verification_tokens_user_id_users_id_fk": {
+          "name": "email_verification_tokens_user_id_users_id_fk",
+          "tableFrom": "email_verification_tokens",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "email_verification_tokens_token_hash_unique": {
+          "name": "email_verification_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.refresh_tokens": {
+      "name": "refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oauth_client_id": {
+          "name": "oauth_client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "family_id": {
+          "name": "family_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "resource": {
+          "name": "resource",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_reason": {
+          "name": "revoked_reason",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_token_hash": {
+          "name": "previous_token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(EXTRACT(EPOCH FROM NOW())::bigint * 1000)"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_refresh_tokens_active": {
+          "name": "idx_refresh_tokens_active",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"refresh_tokens\".\"revoked\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_refresh_tokens_expires_at": {
+          "name": "idx_refresh_tokens_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_refresh_tokens_user_id": {
+          "name": "idx_refresh_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_refresh_tokens_oauth_client_id": {
+          "name": "idx_refresh_tokens_oauth_client_id",
+          "columns": [
+            {
+              "expression": "oauth_client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_refresh_tokens_user_active": {
+          "name": "idx_refresh_tokens_user_active",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"refresh_tokens\".\"revoked\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_refresh_tokens_family_id": {
+          "name": "idx_refresh_tokens_family_id",
+          "columns": [
+            {
+              "expression": "family_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "refresh_tokens_user_id_users_id_fk": {
+          "name": "refresh_tokens_user_id_users_id_fk",
+          "tableFrom": "refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "refresh_tokens_oauth_client_id_oauth_clients_id_fk": {
+          "name": "refresh_tokens_oauth_client_id_oauth_clients_id_fk",
+          "tableFrom": "refresh_tokens",
+          "tableTo": "oauth_clients",
+          "columnsFrom": ["oauth_client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "refresh_tokens_token_hash_unique": {
+          "name": "refresh_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.audit_event_type": {
+      "name": "audit_event_type",
+      "schema": "public",
+      "values": ["auth", "token", "client", "security", "user", "realm"]
+    },
+    "public.code_challenge_method": {
+      "name": "code_challenge_method",
+      "schema": "public",
+      "values": ["S256"]
+    },
+    "public.grant_type": {
+      "name": "grant_type",
+      "schema": "public",
+      "values": ["authorization_code", "refresh_token", "client_credentials"]
+    },
+    "public.response_type": {
+      "name": "response_type",
+      "schema": "public",
+      "values": ["code"]
+    },
+    "public.ssl_required": {
+      "name": "ssl_required",
+      "schema": "public",
+      "values": ["none", "external", "all"]
+    },
+    "public.token_endpoint_auth_method": {
+      "name": "token_endpoint_auth_method",
+      "schema": "public",
+      "values": ["client_secret_post", "client_secret_basic", "private_key_jwt", "none"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/libs/infra/db/drizzle/meta/_journal.json
+++ b/libs/infra/db/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1777054812718,
       "tag": "0003_rfc8707_resource_indicators",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1782369732705,
+      "tag": "0004_agent_client_type",
+      "breakpoints": true
     }
   ]
 }

--- a/libs/infra/db/src/lib/repositories/oauth-clients.repository.ts
+++ b/libs/infra/db/src/lib/repositories/oauth-clients.repository.ts
@@ -146,6 +146,10 @@ export function createOAuthClientsRepository(defaultDb: DbClient): OAuthClientsR
             grantTypes: data.grantTypes,
             responseTypes: data.responseTypes,
             tokenEndpointAuthMethod: data.tokenEndpointAuthMethod,
+            // Keep the agent classification in sync with the metadata document
+            // (ADR-007 §2) so a CIMD doc that flips `is_agent` is reflected on
+            // re-resolution, matching the other document-derived fields above.
+            isAgent: data.isAgent,
             metadata: data.metadata,
             enabled: data.enabled,
             updatedAt: Date.now(),

--- a/libs/infra/db/src/lib/repositories/repositories.integration.test.ts
+++ b/libs/infra/db/src/lib/repositories/repositories.integration.test.ts
@@ -410,4 +410,36 @@ describe('repository integration (real Postgres)', () => {
       await expect(seedRealm('unique-realm')).rejects.toThrow(UniqueConstraintError);
     });
   });
+
+  // --- oauth_clients agent classification (ADR-007 §2) ----------------------
+
+  describe('oauth_clients — is_agent classification', () => {
+    it('defaults is_agent to false (backward-compatible migration)', async () => {
+      const realm = await seedRealm('agent-default-realm');
+      // seedClient does not set isAgent, so the column default applies.
+      const client = await seedClient(realm.id, 'standard-client');
+      expect(client.isAgent).toBe(false);
+    });
+
+    it('persists and round-trips an agent client', async () => {
+      const realm = await seedRealm('agent-realm');
+      const clients = createOAuthClientsRepository(db().database.db);
+
+      const created = await clients.create({
+        realmId: realm.id,
+        clientId: 'agent-client',
+        clientSecretHash: 'secret-hash',
+        name: 'Autonomous Agent',
+        redirectUris: ['https://agent.example.com/cb'],
+        scopes: ['read:foo'],
+        grantTypes: ['authorization_code', 'refresh_token'],
+        isAgent: true,
+      });
+      expect(created.isAgent).toBe(true);
+
+      // Reloads carry the flag through findByClientId (the path auth handlers use).
+      const reloaded = await clients.findByClientId(realm.id, 'agent-client');
+      expect(reloaded?.isAgent).toBe(true);
+    });
+  });
 });

--- a/libs/infra/db/src/lib/schema/core.ts
+++ b/libs/infra/db/src/lib/schema/core.ts
@@ -148,6 +148,16 @@ export const oauthClients = pgTable(
      * Orthogonal to confidential/public: an agent client can be either.
      * Defaults to false so every existing row stays a standard client and
      * the migration is backward-compatible.
+     *
+     * TRUST BOUNDARY — this value is SELF-ASSERTED, UNVERIFIED client input.
+     * It is set by the client itself: in its own DCR request body, or in its
+     * own externally-fetched CIMD metadata document. It is NOT an
+     * authenticated property the AS established. Downstream agent gating
+     * (token exchange #183, scope modes #184, step-up #185) MUST treat it as
+     * untrusted (verify, don't trust). Note the real escalation direction is
+     * a client *omitting* the flag to dodge agent-specific controls, so any
+     * such gating must default-deny / fail-closed and must not assume the
+     * flag is truthful or present.
      */
     isAgent: boolean('is_agent').notNull().default(false),
     /**

--- a/libs/infra/db/src/lib/schema/core.ts
+++ b/libs/infra/db/src/lib/schema/core.ts
@@ -138,6 +138,19 @@ export const oauthClients = pgTable(
       .$type<ResponseType[]>(),
     developerId: uuid('developer_id').references(() => users.id, { onDelete: 'set null' }),
     /**
+     * First-class classification flag for autonomous AI-agent clients
+     * (ADR-007 §2 agent-native authorization). When true, the auth server
+     * may later treat the client differently for delegation eligibility,
+     * scope modes, step-up policy, and per-agent audit — all gated by
+     * separate, later issues. This issue only persists + plumbs the flag;
+     * nothing is gated on it yet.
+     *
+     * Orthogonal to confidential/public: an agent client can be either.
+     * Defaults to false so every existing row stays a standard client and
+     * the migration is backward-compatible.
+     */
+    isAgent: boolean('is_agent').notNull().default(false),
+    /**
      * Set when the client was created via dynamic client registration (RFC 7591).
      * Null for hand-provisioned / first-party clients. Consumed by the consent
      * screen to show a "newly registered" phishing-defense badge — callers

--- a/libs/infra/db/src/scripts/seed-oauth-clients.ts
+++ b/libs/infra/db/src/scripts/seed-oauth-clients.ts
@@ -68,6 +68,10 @@ const clientSpecSchema = z
     redirect_uris: z.array(z.url()).optional(),
     require_pkce: z.boolean().optional(),
     token_endpoint_auth_method: tokenEndpointAuthMethodZ.optional(),
+    // ADR-007 §2: classify a seeded client as an autonomous AI agent.
+    // Defaults to false (standard client) when omitted, mirroring the schema
+    // column default so existing manifests are unaffected.
+    is_agent: z.boolean().optional(),
   })
   .strict();
 
@@ -221,6 +225,7 @@ function buildInsert(realmId: string, spec: ClientSpec, clientSecretHash: string
     tokenEndpointAuthMethod: spec.token_endpoint_auth_method ?? 'client_secret_basic',
     grantTypes: spec.grant_types,
     responseTypes: spec.response_types ?? ['code'],
+    isAgent: spec.is_agent ?? false,
     enabled: true,
   } as const;
 }
@@ -242,6 +247,7 @@ function buildUpdate(spec: ClientSpec, clientSecretHash: string) {
     tokenEndpointAuthMethod: spec.token_endpoint_auth_method ?? 'client_secret_basic',
     grantTypes: spec.grant_types,
     responseTypes: spec.response_types ?? ['code'],
+    isAgent: spec.is_agent ?? false,
     updatedAt: sql`(EXTRACT(EPOCH FROM now()) * 1000)::bigint`,
   } as const;
 }


### PR DESCRIPTION
## Summary

Introduces a first-class **agent** client classification on `oauth_clients` (ADR-007 §2 agent-native epic, #181). This is the foundation issue: it **only persists + plumbs** the classification so the auth server can later treat autonomous AI-agent clients differently. It deliberately does **not** build delegation, scope modes, or step-up — those are separate, later issues in the epic.

### What changed
- **Schema + migration** (`libs/infra/db/src/lib/schema/core.ts`, `drizzle/0004_agent_client_type.sql`): adds `is_agent boolean NOT NULL DEFAULT false`. Backward-compatible — every existing row stays a standard client. `NewOAuthClient` / `UpdateOAuthClient` / `OAuthClient` are `Infer*Model` types, so they pick up the column automatically.
- **DCR** (`POST /oauth/register`): the request schema accepts an optional `is_agent` extension field (RFC 7591 §2 permits server-defined metadata); it is persisted, recorded in the `oauth.client.registered` audit event, and echoed back per §3.2.1 (omitted for standard clients, matching the existing optional-field convention).
- **CIMD** (`helpers/cimd.ts`): recognises an `is_agent` indicator in the client metadata document and carries it onto the materialised row. `upsertCimdClient` refreshes it on re-resolution so a document that flips the flag stays in sync.
- **Seed tooling** (`scripts/seed-oauth-clients.ts`): the manifest allows `is_agent` per client (defaults to false).
- **Downstream exposure**: `ResolvedClient` now carries `isAgent`, plus a tiny `isAgentClient(client)` accessor. **Nothing is gated on it yet.**

### Decision: boolean `is_agent` vs enum `client_type`
Chose the boolean. Agent is **orthogonal** to confidential/public (an agent client can be either), so an enum that mixed those axes would be wrong, and a `'standard' | 'agent'` enum buys nothing over a defaulted boolean while making the backward-compatible default less obvious. A defaulted boolean keeps the migration clean and existing rows untouched.

### Follow-up (intentionally NOT in this PR)
Surfacing the agent field (read-only) on the `/api/clients` management API (`routes/clients/index.ts` + `schemas/clients.ts`) is owned by a parallel PR and deliberately left out here. The downstream agent-only gating (token exchange / scope modes / step-up) lands in the later #181 sub-issues.

### Tests / CI
- `infra-db:test-integration` (Docker, real migrations): **16 passed** — migration applies cleanly + `is_agent` defaults false and round-trips through `create` / `findByClientId`.
- `auth-server` register + cimd: **28 passed** — agent client registers via DCR and round-trips the flag (response + persisted row + audit log); CIMD recognises the document indicator; standard clients default to false.
- `lint typecheck test build` green for `auth-server` + `infra-db` (lint: 0 errors; pre-existing test-file `any` warnings only).

Closes #182

https://claude.ai/code/session_01Re2rxPkdcgzJe7LSddhxv6