### PR TITLE
feat(portal): client-management UI (#91–#96)

### DIFF
--- a/apps/developer-portal/src/components/client-error.ts
+++ b/apps/developer-portal/src/components/client-error.ts
@@ -24,6 +24,8 @@ export function clientErrorMessage(error: ApiError): string {
     case 'NETWORK_ERROR':
       return 'Could not reach the server. Check your connection and try again.';
     default:
-      return error.message || 'Something went wrong. Please try again.';
+      // Do not echo the raw upstream message for unclassified errors (e.g. an
+      // unexpected 5xx body) — show a generic message instead.
+      return 'Something went wrong. Please try again.';
   }
 }

--- a/apps/developer-portal/src/components/client-error.ts
+++ b/apps/developer-portal/src/components/client-error.ts
@@ -1,0 +1,29 @@
+type ApiError = { code: string; message: string; details?: string | string[]; status: number };
+
+/**
+ * Map an API error from a client-management call into a single user-facing
+ * message. `UNAUTHENTICATED` is handled by the route (redirect to login), so
+ * callers typically check `error.code === 'UNAUTHENTICATED'` first and only
+ * pass other errors here.
+ */
+export function clientErrorMessage(error: ApiError): string {
+  switch (error.code) {
+    case 'UNAUTHENTICATED':
+      return 'Your session has expired. Please log in again.';
+    case 'NOT_FOUND':
+      return 'This client was not found, or you do not have access to it.';
+    case 'RATE_LIMITED':
+      return 'Too many requests. Please wait a moment and try again.';
+    case 'VALIDATION_ERROR': {
+      if (Array.isArray(error.details) && error.details.length > 0) {
+        return error.details.join(' ');
+      }
+      if (typeof error.details === 'string') return error.details;
+      return error.message || 'Some fields are invalid. Please review and try again.';
+    }
+    case 'NETWORK_ERROR':
+      return 'Could not reach the server. Check your connection and try again.';
+    default:
+      return error.message || 'Something went wrong. Please try again.';
+  }
+}

--- a/apps/developer-portal/src/components/client-form.test.tsx
+++ b/apps/developer-portal/src/components/client-form.test.tsx
@@ -1,0 +1,56 @@
+import { renderToString } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+
+import { ClientForm, parseRedirectUris, parseScopes } from './client-form';
+
+describe('parseRedirectUris', () => {
+  it('splits on newlines and commas, trimming and dropping blanks', () => {
+    expect(parseRedirectUris('https://a.com/cb\n  https://b.com/cb \n\n,https://c.com/cb')).toEqual(
+      ['https://a.com/cb', 'https://b.com/cb', 'https://c.com/cb']
+    );
+  });
+
+  it('returns an empty array for blank input', () => {
+    expect(parseRedirectUris('   \n  ')).toEqual([]);
+  });
+});
+
+describe('parseScopes', () => {
+  it('splits on whitespace and commas', () => {
+    expect(parseScopes('openid profile, email')).toEqual(['openid', 'profile', 'email']);
+  });
+});
+
+describe('ClientForm component', () => {
+  it('renders a blank create form with the submit label', () => {
+    const html = renderToString(<ClientForm submitLabel="Create client" onSubmit={vi.fn()} />);
+    expect(html).toContain('Create client');
+    expect(html).toContain('Redirect URIs');
+    expect(html).toContain('Token endpoint auth method');
+  });
+
+  it('pre-fills values in edit mode', () => {
+    const html = renderToString(
+      <ClientForm
+        submitLabel="Save changes"
+        onSubmit={vi.fn()}
+        initial={{
+          name: 'My App',
+          redirectUris: ['https://app.example.com/cb'],
+          scopes: ['openid', 'profile'],
+        }}
+      />
+    );
+    expect(html).toContain('My App');
+    expect(html).toContain('https://app.example.com/cb');
+    expect(html).toContain('openid profile');
+    expect(html).toContain('Save changes');
+  });
+
+  it('surfaces a top-level error', () => {
+    const html = renderToString(
+      <ClientForm submitLabel="Create client" onSubmit={vi.fn()} error="Invalid redirect URI" />
+    );
+    expect(html).toContain('Invalid redirect URI');
+  });
+});

--- a/apps/developer-portal/src/components/client-form.tsx
+++ b/apps/developer-portal/src/components/client-form.tsx
@@ -1,0 +1,203 @@
+import { Button, FormField, Input } from '@qauth-labs/ui';
+import { useState } from 'react';
+
+import type { GrantType, OAuthClient, TokenEndpointAuthMethod } from '../server/auth-server-client';
+
+export interface ClientFormValues {
+  name: string;
+  description: string;
+  redirectUris: string[];
+  scopes: string[];
+  grantTypes: GrantType[];
+  tokenEndpointAuthMethod: TokenEndpointAuthMethod;
+}
+
+interface ClientFormProps {
+  /** Pre-fill values (edit mode). Omit for a blank create form. */
+  initial?: Partial<OAuthClient>;
+  /** Submit button label. */
+  submitLabel: string;
+  /** Disable inputs / show a busy state while a request is in flight. */
+  busy?: boolean;
+  /** Top-level error to display above the form. */
+  error?: string;
+  /** Hide auth-method selection in edit mode if you don't want to surface it. */
+  onSubmit: (values: ClientFormValues) => void;
+  onCancel?: () => void;
+}
+
+const ALL_GRANTS: { value: GrantType; label: string }[] = [
+  { value: 'authorization_code', label: 'Authorization code' },
+  { value: 'refresh_token', label: 'Refresh token' },
+  { value: 'client_credentials', label: 'Client credentials' },
+];
+
+const AUTH_METHODS: { value: TokenEndpointAuthMethod; label: string }[] = [
+  { value: 'none', label: 'None (public client + PKCE)' },
+  { value: 'client_secret_post', label: 'Client secret (POST body)' },
+  { value: 'client_secret_basic', label: 'Client secret (Basic auth)' },
+  { value: 'private_key_jwt', label: 'Private key JWT' },
+];
+
+/** Split a textarea value into trimmed, non-empty lines. */
+export function parseRedirectUris(raw: string): string[] {
+  return raw
+    .split(/[\n,]/)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+/** Split a space/comma-separated scope string into tokens. */
+export function parseScopes(raw: string): string[] {
+  return raw
+    .split(/[\s,]+/)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+/**
+ * Shared create/edit form for OAuth clients (#91 create, #94 edit). Redirect
+ * URIs are entered one per line; scopes space-separated. Client-side checks
+ * are advisory — the auth-server is authoritative and its `400`s are surfaced
+ * via the `error` prop.
+ */
+export function ClientForm({
+  initial,
+  submitLabel,
+  busy = false,
+  error,
+  onSubmit,
+  onCancel,
+}: ClientFormProps) {
+  const [grantTypes, setGrantTypes] = useState<GrantType[]>(
+    initial?.grantTypes ?? ['authorization_code', 'refresh_token']
+  );
+  const [authMethod, setAuthMethod] = useState<TokenEndpointAuthMethod>(
+    initial?.tokenEndpointAuthMethod ?? 'none'
+  );
+  const [localError, setLocalError] = useState<string | null>(null);
+
+  function toggleGrant(g: GrantType) {
+    setGrantTypes((prev) => (prev.includes(g) ? prev.filter((x) => x !== g) : [...prev, g]));
+  }
+
+  function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const fd = new FormData(e.currentTarget);
+    const name = String(fd.get('name') ?? '').trim();
+    const description = String(fd.get('description') ?? '').trim();
+    const redirectUris = parseRedirectUris(String(fd.get('redirectUris') ?? ''));
+    const scopes = parseScopes(String(fd.get('scopes') ?? ''));
+
+    if (name.length === 0) {
+      setLocalError('Name is required.');
+      return;
+    }
+    const userInvolving =
+      grantTypes.includes('authorization_code') || grantTypes.includes('refresh_token');
+    if (userInvolving && redirectUris.length === 0) {
+      setLocalError('At least one redirect URI is required for the authorization code flow.');
+      return;
+    }
+    setLocalError(null);
+    onSubmit({
+      name,
+      description,
+      redirectUris,
+      scopes,
+      grantTypes,
+      tokenEndpointAuthMethod: authMethod,
+    });
+  }
+
+  const shownError = error ?? localError ?? undefined;
+
+  return (
+    <form onSubmit={handleSubmit} noValidate className="space-y-5">
+      {shownError ? (
+        <p role="alert" className="rounded-md bg-red-50 px-3 py-2 text-sm text-red-700">
+          {shownError}
+        </p>
+      ) : null}
+
+      <FormField label="Name" htmlFor="name">
+        <Input id="name" name="name" required defaultValue={initial?.name ?? ''} disabled={busy} />
+      </FormField>
+
+      <FormField label="Description" htmlFor="description" helperText="Optional.">
+        <Input
+          id="description"
+          name="description"
+          defaultValue={initial?.description ?? ''}
+          disabled={busy}
+        />
+      </FormField>
+
+      <FormField
+        label="Redirect URIs"
+        htmlFor="redirectUris"
+        helperText="One per line. Must be https or a loopback address."
+      >
+        <textarea
+          id="redirectUris"
+          name="redirectUris"
+          rows={3}
+          disabled={busy}
+          defaultValue={(initial?.redirectUris ?? []).join('\n')}
+          className="flex w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none disabled:opacity-50"
+        />
+      </FormField>
+
+      <FormField label="Scopes" htmlFor="scopes" helperText="Space-separated, e.g. openid profile.">
+        <Input
+          id="scopes"
+          name="scopes"
+          defaultValue={(initial?.scopes ?? []).join(' ')}
+          disabled={busy}
+        />
+      </FormField>
+
+      <fieldset className="space-y-2" disabled={busy}>
+        <legend className="text-sm font-medium text-gray-700">Grant types</legend>
+        {ALL_GRANTS.map((g) => (
+          <label key={g.value} className="flex items-center gap-2 text-sm text-gray-700">
+            <input
+              type="checkbox"
+              checked={grantTypes.includes(g.value)}
+              onChange={() => toggleGrant(g.value)}
+            />
+            {g.label}
+          </label>
+        ))}
+      </fieldset>
+
+      <FormField label="Token endpoint auth method" htmlFor="tokenEndpointAuthMethod">
+        <select
+          id="tokenEndpointAuthMethod"
+          name="tokenEndpointAuthMethod"
+          value={authMethod}
+          disabled={busy}
+          onChange={(e) => setAuthMethod(e.target.value as TokenEndpointAuthMethod)}
+          className="flex h-9 w-full rounded-md border border-gray-300 bg-white px-3 text-sm shadow-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none disabled:opacity-50"
+        >
+          {AUTH_METHODS.map((m) => (
+            <option key={m.value} value={m.value}>
+              {m.label}
+            </option>
+          ))}
+        </select>
+      </FormField>
+
+      <div className="flex justify-end gap-3">
+        {onCancel ? (
+          <Button type="button" variant="outline" onClick={onCancel} disabled={busy}>
+            Cancel
+          </Button>
+        ) : null}
+        <Button type="submit" disabled={busy}>
+          {busy ? 'Saving…' : submitLabel}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/apps/developer-portal/src/components/copy-field.tsx
+++ b/apps/developer-portal/src/components/copy-field.tsx
@@ -1,0 +1,56 @@
+import { Button } from '@qauth-labs/ui';
+import { useState } from 'react';
+
+interface CopyFieldProps {
+  /** The value to display and copy. */
+  value: string;
+  /** Accessible label / field heading. */
+  label: string;
+  /** Render the value in a monospace, secret-styled box. */
+  mono?: boolean;
+}
+
+/**
+ * Read-only value with a copy-to-clipboard button. Used for `clientId`
+ * (always visible) and one-time `clientSecret` displays. The component holds
+ * no state beyond a transient "copied" flag — the caller owns the value's
+ * lifetime, so a secret is dropped the moment its parent modal unmounts.
+ */
+export function CopyField({ value, label, mono = true }: CopyFieldProps) {
+  const [copied, setCopied] = useState(false);
+
+  async function copy() {
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Clipboard API may be unavailable (insecure context); the value stays
+      // selectable for manual copy.
+    }
+  }
+
+  return (
+    <div className="space-y-1.5">
+      <span className="text-sm font-medium text-gray-700">{label}</span>
+      <div className="flex items-stretch gap-2">
+        <code
+          data-testid="copy-field-value"
+          className={`flex-1 overflow-x-auto rounded-md border border-gray-300 bg-gray-50 px-3 py-2 text-sm text-gray-800 ${
+            mono ? 'font-mono' : ''
+          }`}
+        >
+          {value}
+        </code>
+        <Button
+          type="button"
+          variant="outline"
+          onClick={() => void copy()}
+          aria-label={`Copy ${label}`}
+        >
+          {copied ? 'Copied' : 'Copy'}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/developer-portal/src/components/modal.test.tsx
+++ b/apps/developer-portal/src/components/modal.test.tsx
@@ -1,0 +1,103 @@
+// @vitest-environment jsdom
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { Modal } from './modal';
+
+// Opt into React's act() environment so effects flush synchronously.
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+function renderModal(props: Partial<Parameters<typeof Modal>[0]> = {}) {
+  act(() => {
+    root.render(
+      <Modal
+        title="Test dialog"
+        onClose={props.onClose ?? vi.fn()}
+        dismissible={props.dismissible}
+        footer={props.footer}
+      >
+        {props.children ?? <button type="button">Inside</button>}
+      </Modal>
+    );
+  });
+}
+
+describe('Modal focus management', () => {
+  it('moves focus into the dialog on open', () => {
+    renderModal({ children: <button type="button">First action</button> });
+    const dialog = container.querySelector('[role="dialog"]');
+    expect(dialog).not.toBeNull();
+    // First focusable element inside the dialog receives focus.
+    expect(document.activeElement?.textContent).toBe('First action');
+  });
+
+  it('restores focus to the previously focused element on close', () => {
+    const trigger = document.createElement('button');
+    trigger.textContent = 'Opener';
+    document.body.appendChild(trigger);
+    trigger.focus();
+    expect(document.activeElement).toBe(trigger);
+
+    renderModal({ children: <button type="button">Inside</button> });
+    expect(document.activeElement?.textContent).toBe('Inside');
+
+    act(() => root.unmount());
+    expect(document.activeElement).toBe(trigger);
+    trigger.remove();
+  });
+
+  it('closes on Escape when dismissible', () => {
+    const onClose = vi.fn();
+    renderModal({ onClose, dismissible: true });
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    });
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('does not close on Escape when non-dismissible (one-time secret modal)', () => {
+    const onClose = vi.fn();
+    renderModal({ onClose, dismissible: false });
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    });
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('wraps Tab from the last focusable element back to the first', () => {
+    renderModal({
+      children: (
+        <>
+          <button type="button">First</button>
+          <button type="button">Last</button>
+        </>
+      ),
+    });
+    const buttons = Array.from(container.querySelectorAll('button'));
+    const last = buttons[buttons.length - 1];
+    last.focus();
+    expect(document.activeElement).toBe(last);
+
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', bubbles: true }));
+    });
+    // Focus wrapped back to the first focusable element.
+    expect(document.activeElement?.textContent).toBe('First');
+  });
+});

--- a/apps/developer-portal/src/components/modal.tsx
+++ b/apps/developer-portal/src/components/modal.tsx
@@ -1,4 +1,7 @@
-import { type ReactNode, useEffect } from 'react';
+import { type ReactNode, useEffect, useRef } from 'react';
+
+const FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
 
 interface ModalProps {
   /** Heading shown at the top of the dialog. */
@@ -18,19 +21,68 @@ interface ModalProps {
 }
 
 /**
- * Minimal accessible modal dialog. Centered overlay with a focus-trapping
- * backdrop. Deliberately dependency-free (no portal library) to match the
- * portal's lean component set; the auth-server is the trust boundary, not the
- * UI, so this only needs to be usable and clear.
+ * Minimal accessible modal dialog. Centered overlay that moves focus into the
+ * dialog on open, keeps Tab / Shift+Tab cycling within it, and restores focus
+ * to the previously focused element on close. Deliberately dependency-free (no
+ * portal library) to match the portal's lean component set.
  */
 export function Modal({ title, children, footer, onClose, dismissible = true }: ModalProps) {
+  const dialogRef = useRef<HTMLDivElement>(null);
+
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
-      if (e.key === 'Escape' && dismissible) onClose();
+      if (e.key === 'Escape' && dismissible) {
+        onClose();
+        return;
+      }
+      if (e.key !== 'Tab') return;
+
+      const dialog = dialogRef.current;
+      if (!dialog) return;
+      const focusable = Array.from(dialog.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)).filter(
+        (el) => !el.hasAttribute('hidden') && el.getAttribute('aria-hidden') !== 'true'
+      );
+      if (focusable.length === 0) {
+        // Nothing focusable inside: keep focus on the dialog container.
+        e.preventDefault();
+        dialog.focus();
+        return;
+      }
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const active = document.activeElement;
+
+      // Wrap around the ends, and pull focus back in if it has escaped the
+      // dialog (e.g. focus was on the page behind it).
+      if (e.shiftKey) {
+        if (active === first || !dialog.contains(active)) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else if (active === last || !dialog.contains(active)) {
+        e.preventDefault();
+        first.focus();
+      }
     }
+
     document.addEventListener('keydown', onKey);
     return () => document.removeEventListener('keydown', onKey);
   }, [onClose, dismissible]);
+
+  // Move focus into the dialog on open; restore it to the previously focused
+  // element on close.
+  useEffect(() => {
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+    const dialog = dialogRef.current;
+    if (dialog) {
+      const firstFocusable = dialog.querySelector<HTMLElement>(FOCUSABLE_SELECTOR);
+      (firstFocusable ?? dialog).focus();
+    }
+    return () => {
+      previouslyFocused?.focus?.();
+    };
+  }, []);
 
   return (
     <div
@@ -41,11 +93,13 @@ export function Modal({ title, children, footer, onClose, dismissible = true }: 
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4"
     >
       <div
+        ref={dialogRef}
         role="dialog"
         aria-modal="true"
         aria-label={title}
+        tabIndex={-1}
         onClick={(e) => e.stopPropagation()}
-        className="w-full max-w-lg space-y-4 rounded-lg border border-gray-200 bg-white p-6 shadow-lg"
+        className="w-full max-w-lg space-y-4 rounded-lg border border-gray-200 bg-white p-6 shadow-lg outline-none"
       >
         <h2 className="text-lg font-semibold text-gray-900">{title}</h2>
         <div className="space-y-3 text-sm text-gray-700">{children}</div>

--- a/apps/developer-portal/src/components/modal.tsx
+++ b/apps/developer-portal/src/components/modal.tsx
@@ -1,0 +1,56 @@
+import { type ReactNode, useEffect } from 'react';
+
+interface ModalProps {
+  /** Heading shown at the top of the dialog. */
+  title: string;
+  /** Body content. */
+  children: ReactNode;
+  /** Footer actions (buttons). */
+  footer?: ReactNode;
+  /**
+   * Called when the user dismisses the modal via the backdrop or Escape.
+   * Omit (or no-op) to make the modal non-dismissible while an action is in
+   * flight.
+   */
+  onClose: () => void;
+  /** When true, backdrop click and Escape do not close the modal. */
+  dismissible?: boolean;
+}
+
+/**
+ * Minimal accessible modal dialog. Centered overlay with a focus-trapping
+ * backdrop. Deliberately dependency-free (no portal library) to match the
+ * portal's lean component set; the auth-server is the trust boundary, not the
+ * UI, so this only needs to be usable and clear.
+ */
+export function Modal({ title, children, footer, onClose, dismissible = true }: ModalProps) {
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape' && dismissible) onClose();
+    }
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [onClose, dismissible]);
+
+  return (
+    <div
+      role="presentation"
+      onClick={() => {
+        if (dismissible) onClose();
+      }}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4"
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label={title}
+        onClick={(e) => e.stopPropagation()}
+        className="w-full max-w-lg space-y-4 rounded-lg border border-gray-200 bg-white p-6 shadow-lg"
+      >
+        <h2 className="text-lg font-semibold text-gray-900">{title}</h2>
+        <div className="space-y-3 text-sm text-gray-700">{children}</div>
+        {footer ? <div className="flex justify-end gap-3 pt-2">{footer}</div> : null}
+      </div>
+    </div>
+  );
+}

--- a/apps/developer-portal/src/components/secret-reveal.test.tsx
+++ b/apps/developer-portal/src/components/secret-reveal.test.tsx
@@ -1,0 +1,58 @@
+import { renderToString } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+
+import { clientErrorMessage } from './client-error';
+import { SecretReveal } from './secret-reveal';
+
+describe('SecretReveal component', () => {
+  it('shows the one-time secret with a "won\'t be shown again" warning', () => {
+    const html = renderToString(
+      <SecretReveal
+        title="Client created"
+        clientId="client-uuid"
+        clientSecret={'a'.repeat(64)}
+        onDone={vi.fn()}
+      />
+    );
+    expect(html).toContain('Client created');
+    expect(html).toContain('client-uuid');
+    expect(html).toContain('a'.repeat(64));
+    expect(html).toContain('not');
+    expect(html).toContain('shown again');
+  });
+
+  it('omits the secret block for a public client (no secret)', () => {
+    const html = renderToString(
+      <SecretReveal title="Client created" clientId="client-uuid" onDone={vi.fn()} />
+    );
+    expect(html).toContain('client-uuid');
+    expect(html).toContain('public client');
+    expect(html).toContain('Client ID');
+    expect(html).not.toContain('Client secret');
+  });
+});
+
+describe('clientErrorMessage', () => {
+  it('explains a 404 as not-found / not-owned', () => {
+    expect(clientErrorMessage({ code: 'NOT_FOUND', message: '', status: 404 })).toContain(
+      'not found'
+    );
+  });
+
+  it('joins validation detail arrays', () => {
+    expect(
+      clientErrorMessage({
+        code: 'VALIDATION_ERROR',
+        message: 'bad',
+        details: ['Redirect URI must be https.', 'Name is required.'],
+        status: 400,
+      })
+    ).toBe('Redirect URI must be https. Name is required.');
+  });
+
+  it('maps rate limiting to a wait-and-retry message', () => {
+    expect(clientErrorMessage({ code: 'RATE_LIMITED', message: '', status: 429 })).toContain(
+      'Too many requests'
+    );
+  });
+});

--- a/apps/developer-portal/src/components/secret-reveal.tsx
+++ b/apps/developer-portal/src/components/secret-reveal.tsx
@@ -1,0 +1,56 @@
+import { Button } from '@qauth-labs/ui';
+
+import { CopyField } from './copy-field';
+import { Modal } from './modal';
+
+interface SecretRevealProps {
+  /** The OAuth client identifier (safe to show again later). */
+  clientId: string;
+  /**
+   * The one-time plaintext secret. Public clients have none — in that case
+   * only the `clientId` is shown.
+   */
+  clientSecret?: string;
+  /** Dialog title; differs for create vs. regenerate. */
+  title: string;
+  /** Called when the developer acknowledges they have stored the secret. */
+  onDone: () => void;
+}
+
+/**
+ * One-time secret display (issues #91, #93, #95). Renders inside a
+ * non-dismissible modal so the developer cannot lose the secret by clicking
+ * the backdrop. The secret is passed in as a prop and never written to any
+ * store — when the parent removes this component the value is gone.
+ */
+export function SecretReveal({ clientId, clientSecret, title, onDone }: SecretRevealProps) {
+  return (
+    <Modal
+      title={title}
+      dismissible={false}
+      onClose={onDone}
+      footer={
+        <Button type="button" onClick={onDone}>
+          I&apos;ve stored the secret
+        </Button>
+      }
+    >
+      {clientSecret ? (
+        <div
+          role="alert"
+          className="rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-800"
+        >
+          Copy this secret now. For your security, it will <strong>not</strong> be shown again. If
+          you lose it you will have to regenerate it.
+        </div>
+      ) : (
+        <p className="text-sm text-gray-600">
+          This is a public client, so it has no secret. Use PKCE for the authorization code flow.
+        </p>
+      )}
+
+      <CopyField label="Client ID" value={clientId} />
+      {clientSecret ? <CopyField label="Client secret" value={clientSecret} /> : null}
+    </Modal>
+  );
+}

--- a/apps/developer-portal/src/routeTree.gen.ts
+++ b/apps/developer-portal/src/routeTree.gen.ts
@@ -16,6 +16,9 @@ import { Route as ConsentsRouteImport } from './routes/consents'
 import { Route as AuthedRouteImport } from './routes/_authed'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as AuthedDashboardRouteImport } from './routes/_authed/dashboard'
+import { Route as AuthedClientsIndexRouteImport } from './routes/_authed/clients.index'
+import { Route as AuthedClientsNewRouteImport } from './routes/_authed/clients.new'
+import { Route as AuthedClientsClientIdRouteImport } from './routes/_authed/clients.$clientId'
 
 const VerifyRoute = VerifyRouteImport.update({
   id: '/verify',
@@ -51,6 +54,21 @@ const AuthedDashboardRoute = AuthedDashboardRouteImport.update({
   path: '/dashboard',
   getParentRoute: () => AuthedRoute,
 } as any)
+const AuthedClientsIndexRoute = AuthedClientsIndexRouteImport.update({
+  id: '/clients/',
+  path: '/clients/',
+  getParentRoute: () => AuthedRoute,
+} as any)
+const AuthedClientsNewRoute = AuthedClientsNewRouteImport.update({
+  id: '/clients/new',
+  path: '/clients/new',
+  getParentRoute: () => AuthedRoute,
+} as any)
+const AuthedClientsClientIdRoute = AuthedClientsClientIdRouteImport.update({
+  id: '/clients/$clientId',
+  path: '/clients/$clientId',
+  getParentRoute: () => AuthedRoute,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
@@ -59,6 +77,9 @@ export interface FileRoutesByFullPath {
   '/register': typeof RegisterRoute
   '/verify': typeof VerifyRoute
   '/dashboard': typeof AuthedDashboardRoute
+  '/clients/$clientId': typeof AuthedClientsClientIdRoute
+  '/clients/new': typeof AuthedClientsNewRoute
+  '/clients/': typeof AuthedClientsIndexRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -67,6 +88,9 @@ export interface FileRoutesByTo {
   '/register': typeof RegisterRoute
   '/verify': typeof VerifyRoute
   '/dashboard': typeof AuthedDashboardRoute
+  '/clients/$clientId': typeof AuthedClientsClientIdRoute
+  '/clients/new': typeof AuthedClientsNewRoute
+  '/clients': typeof AuthedClientsIndexRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -77,6 +101,9 @@ export interface FileRoutesById {
   '/register': typeof RegisterRoute
   '/verify': typeof VerifyRoute
   '/_authed/dashboard': typeof AuthedDashboardRoute
+  '/_authed/clients/$clientId': typeof AuthedClientsClientIdRoute
+  '/_authed/clients/new': typeof AuthedClientsNewRoute
+  '/_authed/clients/': typeof AuthedClientsIndexRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -87,8 +114,20 @@ export interface FileRouteTypes {
     | '/register'
     | '/verify'
     | '/dashboard'
+    | '/clients/$clientId'
+    | '/clients/new'
+    | '/clients/'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/consents' | '/login' | '/register' | '/verify' | '/dashboard'
+  to:
+    | '/'
+    | '/consents'
+    | '/login'
+    | '/register'
+    | '/verify'
+    | '/dashboard'
+    | '/clients/$clientId'
+    | '/clients/new'
+    | '/clients'
   id:
     | '__root__'
     | '/'
@@ -98,6 +137,9 @@ export interface FileRouteTypes {
     | '/register'
     | '/verify'
     | '/_authed/dashboard'
+    | '/_authed/clients/$clientId'
+    | '/_authed/clients/new'
+    | '/_authed/clients/'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -160,15 +202,42 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthedDashboardRouteImport
       parentRoute: typeof AuthedRoute
     }
+    '/_authed/clients/': {
+      id: '/_authed/clients/'
+      path: '/clients'
+      fullPath: '/clients/'
+      preLoaderRoute: typeof AuthedClientsIndexRouteImport
+      parentRoute: typeof AuthedRoute
+    }
+    '/_authed/clients/new': {
+      id: '/_authed/clients/new'
+      path: '/clients/new'
+      fullPath: '/clients/new'
+      preLoaderRoute: typeof AuthedClientsNewRouteImport
+      parentRoute: typeof AuthedRoute
+    }
+    '/_authed/clients/$clientId': {
+      id: '/_authed/clients/$clientId'
+      path: '/clients/$clientId'
+      fullPath: '/clients/$clientId'
+      preLoaderRoute: typeof AuthedClientsClientIdRouteImport
+      parentRoute: typeof AuthedRoute
+    }
   }
 }
 
 interface AuthedRouteChildren {
   AuthedDashboardRoute: typeof AuthedDashboardRoute
+  AuthedClientsClientIdRoute: typeof AuthedClientsClientIdRoute
+  AuthedClientsNewRoute: typeof AuthedClientsNewRoute
+  AuthedClientsIndexRoute: typeof AuthedClientsIndexRoute
 }
 
 const AuthedRouteChildren: AuthedRouteChildren = {
   AuthedDashboardRoute: AuthedDashboardRoute,
+  AuthedClientsClientIdRoute: AuthedClientsClientIdRoute,
+  AuthedClientsNewRoute: AuthedClientsNewRoute,
+  AuthedClientsIndexRoute: AuthedClientsIndexRoute,
 }
 
 const AuthedRouteWithChildren =

--- a/apps/developer-portal/src/routes/_authed/clients.$clientId.test.tsx
+++ b/apps/developer-portal/src/routes/_authed/clients.$clientId.test.tsx
@@ -1,0 +1,35 @@
+import { renderToString } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+
+// Never-resolving promise keeps the page in its initial loading state.
+const pending = new Promise(() => undefined);
+vi.mock('../../server/actions/clients', () => ({
+  getClientFn: vi.fn(() => pending),
+  updateClientFn: vi.fn(),
+  deleteClientFn: vi.fn(),
+  regenerateSecretFn: vi.fn(),
+}));
+
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tanstack/react-router')>();
+  return {
+    ...actual,
+    useRouter: vi.fn(() => ({ navigate: vi.fn() })),
+    Link: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+  };
+});
+
+import { Route } from './clients.$clientId';
+
+// Route.useParams() reads the route id; stub it to return our test param.
+vi.spyOn(Route, 'useParams').mockReturnValue({ clientId: 'row-1' } as never);
+
+const PageComponent = Route.options.component as NonNullable<typeof Route.options.component>;
+
+describe('ClientDetailsPage', () => {
+  it('renders a loading state and a back link before data resolves', () => {
+    const html = renderToString(<PageComponent />);
+    expect(html).toContain('Back to clients');
+    expect(html).toContain('Loading');
+  });
+});

--- a/apps/developer-portal/src/routes/_authed/clients.$clientId.tsx
+++ b/apps/developer-portal/src/routes/_authed/clients.$clientId.tsx
@@ -1,0 +1,326 @@
+import { Button, Card, CardContent, CardHeader, CardTitle } from '@qauth-labs/ui';
+import { createFileRoute, Link, useRouter } from '@tanstack/react-router';
+import { useEffect, useState } from 'react';
+
+import { clientErrorMessage } from '../../components/client-error';
+import { ClientForm, type ClientFormValues } from '../../components/client-form';
+import { CopyField } from '../../components/copy-field';
+import { Modal } from '../../components/modal';
+import { SecretReveal } from '../../components/secret-reveal';
+import {
+  deleteClientFn,
+  getClientFn,
+  regenerateSecretFn,
+  updateClientFn,
+} from '../../server/actions/clients';
+import type { ClientWithSecret, OAuthClient } from '../../server/auth-server-client';
+
+export const Route = createFileRoute('/_authed/clients/$clientId')({
+  component: ClientDetailsPage,
+});
+
+type LoadState =
+  | { status: 'loading' }
+  | { status: 'ready'; client: OAuthClient }
+  | { status: 'error'; message: string };
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="py-2">
+      <dt className="text-xs font-medium tracking-wide text-gray-500 uppercase">{label}</dt>
+      <dd className="mt-0.5 text-sm text-gray-800">{children}</dd>
+    </div>
+  );
+}
+
+function ClientDetailsPage() {
+  const router = useRouter();
+  const { clientId } = Route.useParams();
+
+  const [load, setLoad] = useState<LoadState>({ status: 'loading' });
+  const [editing, setEditing] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [formError, setFormError] = useState<string | undefined>(undefined);
+
+  // Modal state.
+  const [confirmDelete, setConfirmDelete] = useState(false);
+  const [confirmRegenerate, setConfirmRegenerate] = useState(false);
+  const [actionError, setActionError] = useState<string | undefined>(undefined);
+  // One-time secret from a regenerate; never persisted beyond this modal.
+  const [regenerated, setRegenerated] = useState<ClientWithSecret | null>(null);
+
+  async function refresh() {
+    const result = await getClientFn({ data: { id: clientId } });
+    if (result.ok) {
+      setLoad({ status: 'ready', client: result.data });
+      return;
+    }
+    if (result.error.code === 'UNAUTHENTICATED') {
+      await router.navigate({ to: '/login' });
+      return;
+    }
+    setLoad({ status: 'error', message: clientErrorMessage(result.error) });
+  }
+
+  // Reload whenever the route param changes. `refresh` closes over `clientId`,
+  // so keying the effect on it is sufficient.
+  useEffect(() => {
+    void refresh();
+  }, [clientId]);
+
+  async function handleSave(values: ClientFormValues) {
+    setBusy(true);
+    setFormError(undefined);
+    const result = await updateClientFn({
+      data: {
+        id: clientId,
+        name: values.name,
+        description: values.description || null,
+        redirectUris: values.redirectUris,
+        scopes: values.scopes,
+        grantTypes: values.grantTypes,
+        tokenEndpointAuthMethod: values.tokenEndpointAuthMethod,
+      },
+    });
+    setBusy(false);
+    if (result.ok) {
+      setLoad({ status: 'ready', client: result.data });
+      setEditing(false);
+      return;
+    }
+    if (result.error.code === 'UNAUTHENTICATED') {
+      await router.navigate({ to: '/login' });
+      return;
+    }
+    setFormError(clientErrorMessage(result.error));
+  }
+
+  async function handleDelete() {
+    setBusy(true);
+    setActionError(undefined);
+    const result = await deleteClientFn({ data: { id: clientId } });
+    setBusy(false);
+    if (result.ok) {
+      setConfirmDelete(false);
+      await router.navigate({ to: '/clients' });
+      return;
+    }
+    if (result.error.code === 'UNAUTHENTICATED') {
+      await router.navigate({ to: '/login' });
+      return;
+    }
+    setActionError(clientErrorMessage(result.error));
+  }
+
+  async function handleRegenerate() {
+    setBusy(true);
+    setActionError(undefined);
+    const result = await regenerateSecretFn({ data: { id: clientId } });
+    setBusy(false);
+    if (result.ok) {
+      setConfirmRegenerate(false);
+      setRegenerated(result.data);
+      return;
+    }
+    if (result.error.code === 'UNAUTHENTICATED') {
+      await router.navigate({ to: '/login' });
+      return;
+    }
+    setActionError(clientErrorMessage(result.error));
+  }
+
+  return (
+    <main className="mx-auto max-w-2xl px-6 py-10">
+      <div className="mb-6">
+        <Link to="/clients" className="text-sm text-blue-600 hover:underline">
+          ← Back to clients
+        </Link>
+      </div>
+
+      {load.status === 'loading' ? <p className="text-sm text-gray-500">Loading…</p> : null}
+
+      {load.status === 'error' ? (
+        <p role="alert" className="rounded-md bg-red-50 px-3 py-2 text-sm text-red-700">
+          {load.message}
+        </p>
+      ) : null}
+
+      {load.status === 'ready' && !editing ? (
+        <Card>
+          <CardHeader className="flex-row items-start justify-between space-y-0">
+            <CardTitle>{load.client.name}</CardTitle>
+            <div className="flex gap-2">
+              <Button type="button" variant="outline" onClick={() => setEditing(true)}>
+                Edit
+              </Button>
+              <Button
+                type="button"
+                className="bg-red-600 hover:bg-red-700"
+                onClick={() => {
+                  setActionError(undefined);
+                  setConfirmDelete(true);
+                }}
+              >
+                Delete
+              </Button>
+            </div>
+          </CardHeader>
+          <CardContent>
+            <dl className="divide-y divide-gray-100">
+              <Field label="Client ID">
+                <CopyField label="Client ID" value={load.client.clientId} />
+              </Field>
+              <Field label="Description">{load.client.description ?? '—'}</Field>
+              <Field label="Redirect URIs">
+                {load.client.redirectUris.length > 0 ? (
+                  <ul className="list-disc space-y-0.5 pl-5">
+                    {load.client.redirectUris.map((u) => (
+                      <li key={u} className="font-mono text-xs break-all">
+                        {u}
+                      </li>
+                    ))}
+                  </ul>
+                ) : (
+                  '—'
+                )}
+              </Field>
+              <Field label="Scopes">
+                {load.client.scopes.length > 0 ? load.client.scopes.join(', ') : '—'}
+              </Field>
+              <Field label="Grant types">{load.client.grantTypes.join(', ')}</Field>
+              <Field label="Token endpoint auth method">
+                {load.client.tokenEndpointAuthMethod}
+              </Field>
+              <Field label="Status">{load.client.enabled ? 'Enabled' : 'Disabled'}</Field>
+              <Field label="Client secret">
+                <div className="flex items-center justify-between gap-4">
+                  <span className="text-sm text-gray-500">
+                    {load.client.tokenEndpointAuthMethod === 'none'
+                      ? 'Public client — no secret.'
+                      : 'Hidden. Secrets are shown only once, at creation or regeneration.'}
+                  </span>
+                  {load.client.tokenEndpointAuthMethod !== 'none' ? (
+                    <Button
+                      type="button"
+                      variant="outline"
+                      onClick={() => {
+                        setActionError(undefined);
+                        setConfirmRegenerate(true);
+                      }}
+                    >
+                      Regenerate
+                    </Button>
+                  ) : null}
+                </div>
+              </Field>
+            </dl>
+          </CardContent>
+        </Card>
+      ) : null}
+
+      {load.status === 'ready' && editing ? (
+        <Card>
+          <CardHeader>
+            <CardTitle>Edit client</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <ClientForm
+              initial={load.client}
+              submitLabel="Save changes"
+              busy={busy}
+              error={formError}
+              onSubmit={(v) => void handleSave(v)}
+              onCancel={() => {
+                setFormError(undefined);
+                setEditing(false);
+              }}
+            />
+          </CardContent>
+        </Card>
+      ) : null}
+
+      {confirmDelete ? (
+        <Modal
+          title="Delete this client?"
+          dismissible={!busy}
+          onClose={() => setConfirmDelete(false)}
+          footer={
+            <>
+              <Button
+                type="button"
+                variant="outline"
+                disabled={busy}
+                onClick={() => setConfirmDelete(false)}
+              >
+                Cancel
+              </Button>
+              <Button
+                type="button"
+                className="bg-red-600 hover:bg-red-700"
+                disabled={busy}
+                onClick={() => void handleDelete()}
+              >
+                {busy ? 'Deleting…' : 'Delete client'}
+              </Button>
+            </>
+          }
+        >
+          <p>
+            This permanently deletes the client. It can no longer authenticate or start new
+            authorization flows, and any dependent data is removed. This cannot be undone.
+          </p>
+          {actionError ? (
+            <p role="alert" className="text-sm text-red-700">
+              {actionError}
+            </p>
+          ) : null}
+        </Modal>
+      ) : null}
+
+      {confirmRegenerate ? (
+        <Modal
+          title="Regenerate client secret?"
+          dismissible={!busy}
+          onClose={() => setConfirmRegenerate(false)}
+          footer={
+            <>
+              <Button
+                type="button"
+                variant="outline"
+                disabled={busy}
+                onClick={() => setConfirmRegenerate(false)}
+              >
+                Cancel
+              </Button>
+              <Button type="button" disabled={busy} onClick={() => void handleRegenerate()}>
+                {busy ? 'Regenerating…' : 'Regenerate secret'}
+              </Button>
+            </>
+          }
+        >
+          <p>
+            The current secret is invalidated immediately. Existing integrations using the old
+            secret will stop working until you update them with the new one.
+          </p>
+          {actionError ? (
+            <p role="alert" className="text-sm text-red-700">
+              {actionError}
+            </p>
+          ) : null}
+        </Modal>
+      ) : null}
+
+      {regenerated ? (
+        <SecretReveal
+          title="New client secret"
+          clientId={regenerated.clientId}
+          clientSecret={regenerated.clientSecret}
+          onDone={() => {
+            setRegenerated(null);
+            void refresh();
+          }}
+        />
+      ) : null}
+    </main>
+  );
+}

--- a/apps/developer-portal/src/routes/_authed/clients.index.test.tsx
+++ b/apps/developer-portal/src/routes/_authed/clients.index.test.tsx
@@ -1,0 +1,35 @@
+import { renderToString } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+
+// A never-resolving promise keeps the component in its initial "loading"
+// state for SSR rendering (effects do not run under renderToString anyway).
+const pending = new Promise(() => undefined);
+vi.mock('../../server/actions/clients', () => ({
+  listClientsFn: vi.fn(() => pending),
+}));
+
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tanstack/react-router')>();
+  return {
+    ...actual,
+    useRouter: vi.fn(() => ({ navigate: vi.fn() })),
+    Link: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+  };
+});
+
+import { Route } from './clients.index';
+
+const PageComponent = Route.options.component as NonNullable<typeof Route.options.component>;
+
+describe('ClientListPage', () => {
+  it('renders the heading and a New client action', () => {
+    const html = renderToString(<PageComponent />);
+    expect(html).toContain('OAuth Clients');
+    expect(html).toContain('New client');
+  });
+
+  it('shows a loading state on first render (before the effect resolves)', () => {
+    const html = renderToString(<PageComponent />);
+    expect(html).toContain('Loading');
+  });
+});

--- a/apps/developer-portal/src/routes/_authed/clients.index.tsx
+++ b/apps/developer-portal/src/routes/_authed/clients.index.tsx
@@ -1,0 +1,100 @@
+import { Button, Card, CardContent, CardHeader, CardTitle } from '@qauth-labs/ui';
+import { createFileRoute, Link, useRouter } from '@tanstack/react-router';
+import { useEffect, useState } from 'react';
+
+import { clientErrorMessage } from '../../components/client-error';
+import { listClientsFn } from '../../server/actions/clients';
+import type { OAuthClient } from '../../server/auth-server-client';
+
+export const Route = createFileRoute('/_authed/clients/')({
+  component: ClientListPage,
+});
+
+type State =
+  | { status: 'loading' }
+  | { status: 'ready'; clients: OAuthClient[] }
+  | { status: 'error'; message: string };
+
+function ClientListPage() {
+  const router = useRouter();
+  const [state, setState] = useState<State>({ status: 'loading' });
+
+  async function load() {
+    setState({ status: 'loading' });
+    const result = await listClientsFn();
+    if (result.ok) {
+      setState({ status: 'ready', clients: result.data.clients });
+      return;
+    }
+    if (result.error.code === 'UNAUTHENTICATED') {
+      await router.navigate({ to: '/login' });
+      return;
+    }
+    setState({ status: 'error', message: clientErrorMessage(result.error) });
+  }
+
+  useEffect(() => {
+    void load();
+  }, []);
+
+  return (
+    <main className="mx-auto max-w-5xl px-6 py-10">
+      <div className="mb-8 flex items-center justify-between">
+        <h1 className="text-2xl font-semibold text-gray-900">OAuth Clients</h1>
+        <Link to="/clients/new">
+          <Button type="button">New client</Button>
+        </Link>
+      </div>
+
+      {state.status === 'loading' ? <p className="text-sm text-gray-500">Loading…</p> : null}
+
+      {state.status === 'error' ? (
+        <p role="alert" className="rounded-md bg-red-50 px-3 py-2 text-sm text-red-700">
+          {state.message}
+        </p>
+      ) : null}
+
+      {state.status === 'ready' && state.clients.length === 0 ? (
+        <Card>
+          <CardContent className="py-12 text-center">
+            <p className="text-sm text-gray-600">You don&apos;t have any OAuth clients yet.</p>
+            <Link to="/clients/new" className="mt-4 inline-block">
+              <Button type="button">Create your first client</Button>
+            </Link>
+          </CardContent>
+        </Card>
+      ) : null}
+
+      {state.status === 'ready' && state.clients.length > 0 ? (
+        <ul className="space-y-3">
+          {state.clients.map((c) => (
+            <li key={c.id}>
+              <Link to="/clients/$clientId" params={{ clientId: c.id }} className="block">
+                <Card className="transition-colors hover:border-blue-400">
+                  <CardHeader className="flex-row items-center justify-between space-y-0">
+                    <div>
+                      <CardTitle>{c.name}</CardTitle>
+                      <code className="text-xs text-gray-500">{c.clientId}</code>
+                    </div>
+                    <div className="text-right text-xs text-gray-500">
+                      <span
+                        className={
+                          c.enabled
+                            ? 'rounded-full bg-green-100 px-2 py-0.5 text-green-700'
+                            : 'rounded-full bg-gray-100 px-2 py-0.5 text-gray-600'
+                        }
+                      >
+                        {c.enabled ? 'Enabled' : 'Disabled'}
+                      </span>
+                      <div className="mt-1">{c.redirectUris.length} redirect URI(s)</div>
+                    </div>
+                  </CardHeader>
+                </Card>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+    </main>
+  );
+}

--- a/apps/developer-portal/src/routes/_authed/clients.new.test.tsx
+++ b/apps/developer-portal/src/routes/_authed/clients.new.test.tsx
@@ -1,0 +1,28 @@
+import { renderToString } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../server/actions/clients', () => ({
+  createClientFn: vi.fn(),
+}));
+
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tanstack/react-router')>();
+  return {
+    ...actual,
+    useRouter: vi.fn(() => ({ navigate: vi.fn() })),
+    Link: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+  };
+});
+
+import { Route } from './clients.new';
+
+const PageComponent = Route.options.component as NonNullable<typeof Route.options.component>;
+
+describe('NewClientPage', () => {
+  it('renders the create form inside the page', () => {
+    const html = renderToString(<PageComponent />);
+    expect(html).toContain('New OAuth client');
+    expect(html).toContain('Create client');
+    expect(html).toContain('Back to clients');
+  });
+});

--- a/apps/developer-portal/src/routes/_authed/clients.new.tsx
+++ b/apps/developer-portal/src/routes/_authed/clients.new.tsx
@@ -1,0 +1,92 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@qauth-labs/ui';
+import { createFileRoute, Link, useRouter } from '@tanstack/react-router';
+import { useState } from 'react';
+
+import { clientErrorMessage } from '../../components/client-error';
+import { ClientForm, type ClientFormValues } from '../../components/client-form';
+import { SecretReveal } from '../../components/secret-reveal';
+import { createClientFn } from '../../server/actions/clients';
+import type { ClientWithSecret } from '../../server/auth-server-client';
+
+export const Route = createFileRoute('/_authed/clients/new')({
+  component: NewClientPage,
+});
+
+function NewClientPage() {
+  const router = useRouter();
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | undefined>(undefined);
+  // Holds the one-time secret response. Cleared (and never persisted) once the
+  // developer acknowledges the secret display.
+  const [created, setCreated] = useState<ClientWithSecret | null>(null);
+
+  async function handleSubmit(values: ClientFormValues) {
+    setBusy(true);
+    setError(undefined);
+    const result = await createClientFn({
+      data: {
+        name: values.name,
+        description: values.description || null,
+        redirectUris: values.redirectUris,
+        scopes: values.scopes,
+        grantTypes: values.grantTypes,
+        tokenEndpointAuthMethod: values.tokenEndpointAuthMethod,
+      },
+    });
+    setBusy(false);
+
+    if (result.ok) {
+      setCreated(result.data);
+      return;
+    }
+    if (result.error.code === 'UNAUTHENTICATED') {
+      await router.navigate({ to: '/login' });
+      return;
+    }
+    setError(clientErrorMessage(result.error));
+  }
+
+  async function finishReveal() {
+    const id = created?.id;
+    setCreated(null);
+    if (id) {
+      await router.navigate({ to: '/clients/$clientId', params: { clientId: id } });
+    } else {
+      await router.navigate({ to: '/clients' });
+    }
+  }
+
+  return (
+    <main className="mx-auto max-w-2xl px-6 py-10">
+      <div className="mb-6">
+        <Link to="/clients" className="text-sm text-blue-600 hover:underline">
+          ← Back to clients
+        </Link>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>New OAuth client</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <ClientForm
+            submitLabel="Create client"
+            busy={busy}
+            error={error}
+            onSubmit={(v) => void handleSubmit(v)}
+            onCancel={() => void router.navigate({ to: '/clients' })}
+          />
+        </CardContent>
+      </Card>
+
+      {created ? (
+        <SecretReveal
+          title="Client created"
+          clientId={created.clientId}
+          clientSecret={created.clientSecret}
+          onDone={() => void finishReveal()}
+        />
+      ) : null}
+    </main>
+  );
+}

--- a/apps/developer-portal/src/routes/_authed/dashboard.test.tsx
+++ b/apps/developer-portal/src/routes/_authed/dashboard.test.tsx
@@ -1,6 +1,14 @@
 import { RouterContextProvider } from '@tanstack/react-router';
 import { renderToString } from 'react-dom/server';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tanstack/react-router')>();
+  return {
+    ...actual,
+    Link: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+  };
+});
 
 import { Route } from './dashboard';
 
@@ -42,14 +50,14 @@ describe('DashboardPage component', () => {
     expect(html).toContain('Welcome');
   });
 
-  it('renders the OAuth Clients placeholder card', () => {
+  it('renders the OAuth Clients card with a link to manage clients', () => {
     const html = renderToString(
       <RouterContextProvider router={fakeRouter}>
         <PageComponent />
       </RouterContextProvider>
     );
     expect(html).toContain('OAuth Clients');
-    expect(html).toContain('Coming soon');
+    expect(html).toContain('Manage clients');
   });
 
   it('renders the API Keys placeholder card', () => {

--- a/apps/developer-portal/src/routes/_authed/dashboard.tsx
+++ b/apps/developer-portal/src/routes/_authed/dashboard.tsx
@@ -1,5 +1,5 @@
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@qauth-labs/ui';
-import { createFileRoute } from '@tanstack/react-router';
+import { Button, Card, CardContent, CardDescription, CardHeader, CardTitle } from '@qauth-labs/ui';
+import { createFileRoute, Link } from '@tanstack/react-router';
 
 import type { UserInfoData } from '../../server/auth-server-client';
 
@@ -25,7 +25,11 @@ function DashboardPage() {
             </CardDescription>
           </CardHeader>
           <CardContent>
-            <p className="text-sm text-gray-400">Coming soon in Phase 2.2.</p>
+            <Link to="/clients">
+              <Button type="button" variant="outline">
+                Manage clients
+              </Button>
+            </Link>
           </CardContent>
         </Card>
 

--- a/apps/developer-portal/src/server/actions/clients.test.ts
+++ b/apps/developer-portal/src/server/actions/clients.test.ts
@@ -41,6 +41,8 @@ import {
   deleteClientHandler,
   getClientHandler,
   listClientsHandler,
+  normalizeCreateInput,
+  normalizeUpdateInput,
   regenerateSecretHandler,
   updateClientHandler,
 } from './clients';
@@ -170,5 +172,108 @@ describe('regenerateSecretHandler', () => {
     const result = await regenerateSecretHandler({ data: { id: 'row-1' } });
     expect(result.ok).toBe(true);
     expect(mockSetResponseHeader).toHaveBeenCalledWith('Cache-Control', 'no-store');
+  });
+});
+
+describe('GET handlers set no-store', () => {
+  it('listClientsHandler marks the list non-cacheable', async () => {
+    vi.mocked(readSessionCookie).mockReturnValue(validSession);
+    vi.mocked(authServerClient.listClients).mockResolvedValue({ ok: true, data: { clients: [] } });
+    await listClientsHandler();
+    expect(mockSetResponseHeader).toHaveBeenCalledWith('Cache-Control', 'no-store');
+  });
+
+  it('getClientHandler marks the response non-cacheable', async () => {
+    vi.mocked(readSessionCookie).mockReturnValue(validSession);
+    vi.mocked(authServerClient.getClient).mockResolvedValue({ ok: true, data: {} as never });
+    await getClientHandler({ data: { id: 'row-1' } });
+    expect(mockSetResponseHeader).toHaveBeenCalledWith('Cache-Control', 'no-store');
+  });
+});
+
+describe('expired-session short-circuit applies to mutations too', () => {
+  it('updateClientHandler returns UNAUTHENTICATED without a network call', async () => {
+    vi.mocked(readSessionCookie).mockReturnValue(expiredSession);
+    const result = await updateClientHandler({ data: { id: 'row-1', patch: { name: 'x' } } });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe('UNAUTHENTICATED');
+    expect(authServerClient.updateClient).not.toHaveBeenCalled();
+  });
+
+  it('regenerateSecretHandler returns UNAUTHENTICATED without a network call', async () => {
+    vi.mocked(readSessionCookie).mockReturnValue(expiredSession);
+    const result = await regenerateSecretHandler({ data: { id: 'row-1' } });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe('UNAUTHENTICATED');
+    expect(authServerClient.regenerateClientSecret).not.toHaveBeenCalled();
+  });
+});
+
+describe('normalizeCreateInput — input caps & enum validation', () => {
+  it('accepts a minimal valid payload', () => {
+    expect(normalizeCreateInput({ name: '  My App  ' })).toEqual({ name: 'My App' });
+  });
+
+  it('rejects a missing/blank name', () => {
+    expect(() => normalizeCreateInput({ name: '   ' })).toThrow(/name is required/i);
+  });
+
+  it('rejects an over-length name', () => {
+    expect(() => normalizeCreateInput({ name: 'a'.repeat(256) })).toThrow(/at most 255/i);
+  });
+
+  it('rejects an over-length description', () => {
+    expect(() => normalizeCreateInput({ name: 'ok', description: 'd'.repeat(2001) })).toThrow(
+      /at most 2000/i
+    );
+  });
+
+  it('rejects too many redirect URIs', () => {
+    const redirectUris = Array.from({ length: 51 }, (_, i) => `https://app.example.com/cb${i}`);
+    expect(() => normalizeCreateInput({ name: 'ok', redirectUris })).toThrow(/at most 50 entries/i);
+  });
+
+  it('rejects an over-length redirect URI', () => {
+    expect(() =>
+      normalizeCreateInput({ name: 'ok', redirectUris: [`https://x/${'a'.repeat(2001)}`] })
+    ).toThrow(/at most 2000 characters/i);
+  });
+
+  it('rejects too many scopes', () => {
+    const scopes = Array.from({ length: 101 }, (_, i) => `scope${i}`);
+    expect(() => normalizeCreateInput({ name: 'ok', scopes })).toThrow(/at most 100 entries/i);
+  });
+
+  it('surfaces an unknown grant type instead of silently dropping it', () => {
+    expect(() =>
+      normalizeCreateInput({ name: 'ok', grantTypes: ['authorization_code', 'password'] })
+    ).toThrow(/unknown grant type/i);
+  });
+
+  it('surfaces an unknown token endpoint auth method', () => {
+    expect(() => normalizeCreateInput({ name: 'ok', tokenEndpointAuthMethod: 'magic' })).toThrow(
+      /unknown token endpoint auth method/i
+    );
+  });
+});
+
+describe('normalizeUpdateInput — input caps & enum validation', () => {
+  it('rejects an over-length name', () => {
+    expect(() => normalizeUpdateInput({ id: 'row-1', name: 'a'.repeat(256) })).toThrow(
+      /at most 255/i
+    );
+  });
+
+  it('clears the description when an empty string is given', () => {
+    expect(normalizeUpdateInput({ id: 'row-1', description: '' })).toEqual({
+      id: 'row-1',
+      patch: { description: null },
+    });
+  });
+
+  it('surfaces an unknown grant type', () => {
+    expect(() => normalizeUpdateInput({ id: 'row-1', grantTypes: ['nope'] })).toThrow(
+      /unknown grant type/i
+    );
   });
 });

--- a/apps/developer-portal/src/server/actions/clients.test.ts
+++ b/apps/developer-portal/src/server/actions/clients.test.ts
@@ -1,0 +1,174 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../config', () => ({
+  env: {
+    AUTH_SERVER_URL: 'http://localhost:3001',
+    PORTAL_SESSION_SECRET: 'test-secret-minimum-32-chars-long!!',
+    PORTAL_SESSION_TTL: 900,
+  },
+}));
+
+vi.mock('../auth-server-client', () => ({
+  authServerClient: {
+    listClients: vi.fn(),
+    getClient: vi.fn(),
+    createClient: vi.fn(),
+    updateClient: vi.fn(),
+    deleteClient: vi.fn(),
+    regenerateClientSecret: vi.fn(),
+  },
+}));
+
+vi.mock('../session-cookie', () => ({
+  SESSION_COOKIE_NAME: '__Host-qauth_portal_session',
+  readSessionCookie: vi.fn(),
+}));
+
+const { mockGetRequestHeader, mockSetResponseHeader } = vi.hoisted(() => ({
+  mockGetRequestHeader: vi.fn(),
+  mockSetResponseHeader: vi.fn(),
+}));
+
+vi.mock('@tanstack/react-start/server', () => ({
+  getRequestHeader: mockGetRequestHeader,
+  setResponseHeader: mockSetResponseHeader,
+}));
+
+import { authServerClient } from '../auth-server-client';
+import { readSessionCookie } from '../session-cookie';
+import {
+  createClientHandler,
+  deleteClientHandler,
+  getClientHandler,
+  listClientsHandler,
+  regenerateSecretHandler,
+  updateClientHandler,
+} from './clients';
+
+const validSession = {
+  accessToken: 'dev-token',
+  refreshToken: 'rt',
+  expiresAt: Date.now() + 60_000,
+};
+const expiredSession = { accessToken: 'old', refreshToken: 'rt', expiresAt: Date.now() - 1000 };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetRequestHeader.mockReturnValue('cookie-header');
+});
+
+describe('listClientsHandler', () => {
+  it('forwards the bearer token from the session cookie', async () => {
+    vi.mocked(readSessionCookie).mockReturnValue(validSession);
+    vi.mocked(authServerClient.listClients).mockResolvedValue({ ok: true, data: { clients: [] } });
+
+    const result = await listClientsHandler();
+    expect(result.ok).toBe(true);
+    expect(authServerClient.listClients).toHaveBeenCalledWith('dev-token');
+  });
+
+  it('returns UNAUTHENTICATED without a network call when no session exists', async () => {
+    vi.mocked(readSessionCookie).mockReturnValue(null);
+
+    const result = await listClientsHandler();
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe('UNAUTHENTICATED');
+    expect(authServerClient.listClients).not.toHaveBeenCalled();
+  });
+
+  it('returns UNAUTHENTICATED when the session is past its expiry', async () => {
+    vi.mocked(readSessionCookie).mockReturnValue(expiredSession);
+
+    const result = await listClientsHandler();
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe('UNAUTHENTICATED');
+    expect(authServerClient.listClients).not.toHaveBeenCalled();
+  });
+});
+
+describe('getClientHandler', () => {
+  it('passes the id through to the client', async () => {
+    vi.mocked(readSessionCookie).mockReturnValue(validSession);
+    vi.mocked(authServerClient.getClient).mockResolvedValue({
+      ok: false,
+      error: { code: 'NOT_FOUND', message: 'x', status: 404 },
+    });
+
+    const result = await getClientHandler({ data: { id: 'row-1' } });
+    expect(authServerClient.getClient).toHaveBeenCalledWith('dev-token', 'row-1');
+    expect(result.ok).toBe(false);
+  });
+});
+
+describe('createClientHandler', () => {
+  it('sets Cache-Control: no-store on a successful (secret-bearing) response', async () => {
+    vi.mocked(readSessionCookie).mockReturnValue(validSession);
+    vi.mocked(authServerClient.createClient).mockResolvedValue({
+      ok: true,
+      data: { clientId: 'c', clientSecret: 's' } as never,
+    });
+
+    const result = await createClientHandler({ data: { name: 'My App' } });
+    expect(result.ok).toBe(true);
+    expect(mockSetResponseHeader).toHaveBeenCalledWith('Cache-Control', 'no-store');
+  });
+
+  it('does not set no-store on a failed create', async () => {
+    vi.mocked(readSessionCookie).mockReturnValue(validSession);
+    vi.mocked(authServerClient.createClient).mockResolvedValue({
+      ok: false,
+      error: { code: 'VALIDATION_ERROR', message: 'bad', status: 400 },
+    });
+
+    await createClientHandler({ data: { name: 'x' } });
+    expect(mockSetResponseHeader).not.toHaveBeenCalled();
+  });
+});
+
+describe('updateClientHandler', () => {
+  it('forwards id and patch', async () => {
+    vi.mocked(readSessionCookie).mockReturnValue(validSession);
+    vi.mocked(authServerClient.updateClient).mockResolvedValue({
+      ok: true,
+      data: { name: 'New' } as never,
+    });
+
+    await updateClientHandler({ data: { id: 'row-1', patch: { name: 'New' } } });
+    expect(authServerClient.updateClient).toHaveBeenCalledWith('dev-token', 'row-1', {
+      name: 'New',
+    });
+  });
+});
+
+describe('deleteClientHandler', () => {
+  it('returns ok on a successful delete', async () => {
+    vi.mocked(readSessionCookie).mockReturnValue(validSession);
+    vi.mocked(authServerClient.deleteClient).mockResolvedValue({ ok: true, data: null });
+
+    const result = await deleteClientHandler({ data: { id: 'row-1' } });
+    expect(result.ok).toBe(true);
+    expect(authServerClient.deleteClient).toHaveBeenCalledWith('dev-token', 'row-1');
+  });
+
+  it('returns UNAUTHENTICATED when not logged in', async () => {
+    vi.mocked(readSessionCookie).mockReturnValue(null);
+    const result = await deleteClientHandler({ data: { id: 'row-1' } });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe('UNAUTHENTICATED');
+    expect(authServerClient.deleteClient).not.toHaveBeenCalled();
+  });
+});
+
+describe('regenerateSecretHandler', () => {
+  it('sets no-store on the new-secret response', async () => {
+    vi.mocked(readSessionCookie).mockReturnValue(validSession);
+    vi.mocked(authServerClient.regenerateClientSecret).mockResolvedValue({
+      ok: true,
+      data: { clientId: 'c', clientSecret: 'new' } as never,
+    });
+
+    const result = await regenerateSecretHandler({ data: { id: 'row-1' } });
+    expect(result.ok).toBe(true);
+    expect(mockSetResponseHeader).toHaveBeenCalledWith('Cache-Control', 'no-store');
+  });
+});

--- a/apps/developer-portal/src/server/actions/clients.ts
+++ b/apps/developer-portal/src/server/actions/clients.ts
@@ -55,6 +55,61 @@ function asStringArray(value: unknown): string[] {
   return value.filter((v): v is string => typeof v === 'string');
 }
 
+/**
+ * Defense-in-depth input caps. The auth-server is authoritative, but these
+ * keep the portal from proxying an unbounded payload (e.g. a megabyte of
+ * redirect URIs) before the upstream rejects it. Values are generous — they
+ * only fence off abuse, not legitimate use.
+ */
+const LIMITS = {
+  NAME_MAX: 255,
+  DESCRIPTION_MAX: 2000,
+  REDIRECT_URIS_MAX: 50,
+  REDIRECT_URI_MAX: 2000,
+  SCOPES_MAX: 100,
+  SCOPE_MAX: 255,
+} as const;
+
+class InputError extends Error {}
+
+function checkLength(field: string, value: string, max: number): void {
+  if (value.length > max) {
+    throw new InputError(`${field} must be at most ${max} characters.`);
+  }
+}
+
+function checkArray(field: string, arr: string[], maxItems: number, itemMax: number): void {
+  if (arr.length > maxItems) {
+    throw new InputError(`${field} must have at most ${maxItems} entries.`);
+  }
+  for (const item of arr) {
+    if (item.length > itemMax) {
+      throw new InputError(`Each ${field} entry must be at most ${itemMax} characters.`);
+    }
+  }
+}
+
+/**
+ * Validate `grantTypes` strictly: unknown values are reported rather than
+ * silently dropped, so a malformed selection surfaces as an error instead of
+ * vanishing.
+ */
+function validateGrantTypes(value: unknown): GrantType[] {
+  const arr = asStringArray(value);
+  const invalid = arr.filter((g) => !VALID_GRANT_TYPES.includes(g as GrantType));
+  if (invalid.length > 0) {
+    throw new InputError(`Unknown grant type(s): ${invalid.join(', ')}.`);
+  }
+  return arr as GrantType[];
+}
+
+function validateAuthMethod(value: unknown): TokenEndpointAuthMethod {
+  if (typeof value !== 'string' || !VALID_AUTH_METHODS.includes(value as TokenEndpointAuthMethod)) {
+    throw new InputError(`Unknown token endpoint auth method: ${String(value)}.`);
+  }
+  return value as TokenEndpointAuthMethod;
+}
+
 // ---------------------------------------------------------------------------
 // List
 // ---------------------------------------------------------------------------
@@ -62,6 +117,9 @@ function asStringArray(value: unknown): string[] {
 export async function listClientsHandler(): Promise<Result<{ clients: OAuthClient[] }>> {
   const token = readAccessToken();
   if (!token) return UNAUTHENTICATED;
+  // Client config is not secret, but it is per-developer; keep it out of any
+  // shared/proxy cache for consistency with the secret-bearing responses.
+  setResponseHeader('Cache-Control', 'no-store');
   return authServerClient.listClients(token);
 }
 
@@ -78,6 +136,7 @@ export async function getClientHandler({
 }): Promise<Result<OAuthClient>> {
   const token = readAccessToken();
   if (!token) return UNAUTHENTICATED;
+  setResponseHeader('Cache-Control', 'no-store');
   return authServerClient.getClient(token, data.id);
 }
 
@@ -98,28 +157,35 @@ export const getClientFn = createServerFn({ method: 'GET' })
 // Create
 // ---------------------------------------------------------------------------
 
-function normalizeCreateInput(data: unknown): CreateClientInput {
+export function normalizeCreateInput(data: unknown): CreateClientInput {
   if (typeof data !== 'object' || data === null) {
     throw new Error('Invalid input: expected an object');
   }
   const d = data as Record<string, unknown>;
   if (typeof d['name'] !== 'string' || d['name'].trim().length === 0) {
-    throw new Error('Invalid input: name is required');
+    throw new InputError('Name is required.');
   }
-  const input: CreateClientInput = { name: d['name'].trim() };
+  const name = d['name'].trim();
+  checkLength('Name', name, LIMITS.NAME_MAX);
+  const input: CreateClientInput = { name };
   if (typeof d['description'] === 'string' && d['description'].trim().length > 0) {
-    input.description = d['description'].trim();
+    const description = d['description'].trim();
+    checkLength('Description', description, LIMITS.DESCRIPTION_MAX);
+    input.description = description;
   }
-  if (d['redirectUris'] !== undefined) input.redirectUris = asStringArray(d['redirectUris']);
-  if (d['scopes'] !== undefined) input.scopes = asStringArray(d['scopes']);
-  if (d['grantTypes'] !== undefined) {
-    input.grantTypes = asStringArray(d['grantTypes']).filter((g): g is GrantType =>
-      VALID_GRANT_TYPES.includes(g as GrantType)
-    );
+  if (d['redirectUris'] !== undefined) {
+    const uris = asStringArray(d['redirectUris']);
+    checkArray('Redirect URI', uris, LIMITS.REDIRECT_URIS_MAX, LIMITS.REDIRECT_URI_MAX);
+    input.redirectUris = uris;
   }
-  if (typeof d['tokenEndpointAuthMethod'] === 'string') {
-    const m = d['tokenEndpointAuthMethod'] as TokenEndpointAuthMethod;
-    if (VALID_AUTH_METHODS.includes(m)) input.tokenEndpointAuthMethod = m;
+  if (d['scopes'] !== undefined) {
+    const scopes = asStringArray(d['scopes']);
+    checkArray('Scope', scopes, LIMITS.SCOPES_MAX, LIMITS.SCOPE_MAX);
+    input.scopes = scopes;
+  }
+  if (d['grantTypes'] !== undefined) input.grantTypes = validateGrantTypes(d['grantTypes']);
+  if (d['tokenEndpointAuthMethod'] !== undefined) {
+    input.tokenEndpointAuthMethod = validateAuthMethod(d['tokenEndpointAuthMethod']);
   }
   return input;
 }
@@ -145,7 +211,7 @@ export const createClientFn = createServerFn({ method: 'POST' })
 // Update (PATCH)
 // ---------------------------------------------------------------------------
 
-function normalizeUpdateInput(data: unknown): { id: string; patch: UpdateClientInput } {
+export function normalizeUpdateInput(data: unknown): { id: string; patch: UpdateClientInput } {
   if (
     typeof data !== 'object' ||
     data === null ||
@@ -155,23 +221,33 @@ function normalizeUpdateInput(data: unknown): { id: string; patch: UpdateClientI
   }
   const d = data as Record<string, unknown>;
   const patch: UpdateClientInput = {};
-  if (typeof d['name'] === 'string') patch.name = d['name'].trim();
+  if (typeof d['name'] === 'string') {
+    const name = d['name'].trim();
+    checkLength('Name', name, LIMITS.NAME_MAX);
+    patch.name = name;
+  }
   if (d['description'] !== undefined) {
-    patch.description =
-      typeof d['description'] === 'string' && d['description'].trim().length > 0
-        ? d['description'].trim()
-        : null;
+    if (typeof d['description'] === 'string' && d['description'].trim().length > 0) {
+      const description = d['description'].trim();
+      checkLength('Description', description, LIMITS.DESCRIPTION_MAX);
+      patch.description = description;
+    } else {
+      patch.description = null;
+    }
   }
-  if (d['redirectUris'] !== undefined) patch.redirectUris = asStringArray(d['redirectUris']);
-  if (d['scopes'] !== undefined) patch.scopes = asStringArray(d['scopes']);
-  if (d['grantTypes'] !== undefined) {
-    patch.grantTypes = asStringArray(d['grantTypes']).filter((g): g is GrantType =>
-      VALID_GRANT_TYPES.includes(g as GrantType)
-    );
+  if (d['redirectUris'] !== undefined) {
+    const uris = asStringArray(d['redirectUris']);
+    checkArray('Redirect URI', uris, LIMITS.REDIRECT_URIS_MAX, LIMITS.REDIRECT_URI_MAX);
+    patch.redirectUris = uris;
   }
-  if (typeof d['tokenEndpointAuthMethod'] === 'string') {
-    const m = d['tokenEndpointAuthMethod'] as TokenEndpointAuthMethod;
-    if (VALID_AUTH_METHODS.includes(m)) patch.tokenEndpointAuthMethod = m;
+  if (d['scopes'] !== undefined) {
+    const scopes = asStringArray(d['scopes']);
+    checkArray('Scope', scopes, LIMITS.SCOPES_MAX, LIMITS.SCOPE_MAX);
+    patch.scopes = scopes;
+  }
+  if (d['grantTypes'] !== undefined) patch.grantTypes = validateGrantTypes(d['grantTypes']);
+  if (d['tokenEndpointAuthMethod'] !== undefined) {
+    patch.tokenEndpointAuthMethod = validateAuthMethod(d['tokenEndpointAuthMethod']);
   }
   if (typeof d['enabled'] === 'boolean') patch.enabled = d['enabled'];
   return { id: d['id'] as string, patch };

--- a/apps/developer-portal/src/server/actions/clients.ts
+++ b/apps/developer-portal/src/server/actions/clients.ts
@@ -1,0 +1,248 @@
+import { createServerFn } from '@tanstack/react-start';
+import { getRequestHeader, setResponseHeader } from '@tanstack/react-start/server';
+
+import {
+  authServerClient,
+  type ClientWithSecret,
+  type CreateClientInput,
+  type GrantType,
+  type OAuthClient,
+  type Result,
+  type TokenEndpointAuthMethod,
+  type UpdateClientInput,
+} from '../auth-server-client';
+import { readSessionCookie } from '../session-cookie';
+
+/**
+ * Result returned to the browser when the portal session is missing or
+ * expired. The route components map this onto a re-authentication prompt.
+ * Mirrors the auth-server's `401` semantics without making a network call.
+ */
+export const UNAUTHENTICATED: Result<never> = {
+  ok: false,
+  error: {
+    code: 'UNAUTHENTICATED',
+    message: 'Your session has expired. Please log in again.',
+    status: 401,
+  },
+};
+
+/**
+ * Read the developer's access token from the signed, HttpOnly session cookie.
+ * The token never leaves the server — every `/api/clients` call is proxied
+ * through these server functions with `Authorization: Bearer <token>`.
+ */
+function readAccessToken(): string | null {
+  const session = readSessionCookie(getRequestHeader('cookie'));
+  if (!session || Date.now() >= session.expiresAt) return null;
+  return session.accessToken;
+}
+
+const VALID_GRANT_TYPES: GrantType[] = [
+  'authorization_code',
+  'refresh_token',
+  'client_credentials',
+];
+const VALID_AUTH_METHODS: TokenEndpointAuthMethod[] = [
+  'none',
+  'client_secret_post',
+  'client_secret_basic',
+  'private_key_jwt',
+];
+
+function asStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((v): v is string => typeof v === 'string');
+}
+
+// ---------------------------------------------------------------------------
+// List
+// ---------------------------------------------------------------------------
+
+export async function listClientsHandler(): Promise<Result<{ clients: OAuthClient[] }>> {
+  const token = readAccessToken();
+  if (!token) return UNAUTHENTICATED;
+  return authServerClient.listClients(token);
+}
+
+export const listClientsFn = createServerFn({ method: 'GET' }).handler(listClientsHandler);
+
+// ---------------------------------------------------------------------------
+// Get one
+// ---------------------------------------------------------------------------
+
+export async function getClientHandler({
+  data,
+}: {
+  data: { id: string };
+}): Promise<Result<OAuthClient>> {
+  const token = readAccessToken();
+  if (!token) return UNAUTHENTICATED;
+  return authServerClient.getClient(token, data.id);
+}
+
+export const getClientFn = createServerFn({ method: 'GET' })
+  .inputValidator((data: unknown): { id: string } => {
+    if (
+      typeof data !== 'object' ||
+      data === null ||
+      typeof (data as { id?: unknown }).id !== 'string'
+    ) {
+      throw new Error('Invalid input: expected { id: string }');
+    }
+    return { id: (data as { id: string }).id };
+  })
+  .handler(getClientHandler);
+
+// ---------------------------------------------------------------------------
+// Create
+// ---------------------------------------------------------------------------
+
+function normalizeCreateInput(data: unknown): CreateClientInput {
+  if (typeof data !== 'object' || data === null) {
+    throw new Error('Invalid input: expected an object');
+  }
+  const d = data as Record<string, unknown>;
+  if (typeof d['name'] !== 'string' || d['name'].trim().length === 0) {
+    throw new Error('Invalid input: name is required');
+  }
+  const input: CreateClientInput = { name: d['name'].trim() };
+  if (typeof d['description'] === 'string' && d['description'].trim().length > 0) {
+    input.description = d['description'].trim();
+  }
+  if (d['redirectUris'] !== undefined) input.redirectUris = asStringArray(d['redirectUris']);
+  if (d['scopes'] !== undefined) input.scopes = asStringArray(d['scopes']);
+  if (d['grantTypes'] !== undefined) {
+    input.grantTypes = asStringArray(d['grantTypes']).filter((g): g is GrantType =>
+      VALID_GRANT_TYPES.includes(g as GrantType)
+    );
+  }
+  if (typeof d['tokenEndpointAuthMethod'] === 'string') {
+    const m = d['tokenEndpointAuthMethod'] as TokenEndpointAuthMethod;
+    if (VALID_AUTH_METHODS.includes(m)) input.tokenEndpointAuthMethod = m;
+  }
+  return input;
+}
+
+export async function createClientHandler({
+  data,
+}: {
+  data: CreateClientInput;
+}): Promise<Result<ClientWithSecret>> {
+  const token = readAccessToken();
+  if (!token) return UNAUTHENTICATED;
+  const result = await authServerClient.createClient(token, data);
+  // Secret-bearing responses are no-store; the browser must never cache them.
+  if (result.ok) setResponseHeader('Cache-Control', 'no-store');
+  return result;
+}
+
+export const createClientFn = createServerFn({ method: 'POST' })
+  .inputValidator(normalizeCreateInput)
+  .handler(createClientHandler);
+
+// ---------------------------------------------------------------------------
+// Update (PATCH)
+// ---------------------------------------------------------------------------
+
+function normalizeUpdateInput(data: unknown): { id: string; patch: UpdateClientInput } {
+  if (
+    typeof data !== 'object' ||
+    data === null ||
+    typeof (data as { id?: unknown }).id !== 'string'
+  ) {
+    throw new Error('Invalid input: expected { id: string, ... }');
+  }
+  const d = data as Record<string, unknown>;
+  const patch: UpdateClientInput = {};
+  if (typeof d['name'] === 'string') patch.name = d['name'].trim();
+  if (d['description'] !== undefined) {
+    patch.description =
+      typeof d['description'] === 'string' && d['description'].trim().length > 0
+        ? d['description'].trim()
+        : null;
+  }
+  if (d['redirectUris'] !== undefined) patch.redirectUris = asStringArray(d['redirectUris']);
+  if (d['scopes'] !== undefined) patch.scopes = asStringArray(d['scopes']);
+  if (d['grantTypes'] !== undefined) {
+    patch.grantTypes = asStringArray(d['grantTypes']).filter((g): g is GrantType =>
+      VALID_GRANT_TYPES.includes(g as GrantType)
+    );
+  }
+  if (typeof d['tokenEndpointAuthMethod'] === 'string') {
+    const m = d['tokenEndpointAuthMethod'] as TokenEndpointAuthMethod;
+    if (VALID_AUTH_METHODS.includes(m)) patch.tokenEndpointAuthMethod = m;
+  }
+  if (typeof d['enabled'] === 'boolean') patch.enabled = d['enabled'];
+  return { id: d['id'] as string, patch };
+}
+
+export async function updateClientHandler({
+  data,
+}: {
+  data: { id: string; patch: UpdateClientInput };
+}): Promise<Result<OAuthClient>> {
+  const token = readAccessToken();
+  if (!token) return UNAUTHENTICATED;
+  return authServerClient.updateClient(token, data.id, data.patch);
+}
+
+export const updateClientFn = createServerFn({ method: 'POST' })
+  .inputValidator(normalizeUpdateInput)
+  .handler(updateClientHandler);
+
+// ---------------------------------------------------------------------------
+// Delete
+// ---------------------------------------------------------------------------
+
+export async function deleteClientHandler({
+  data,
+}: {
+  data: { id: string };
+}): Promise<Result<null>> {
+  const token = readAccessToken();
+  if (!token) return UNAUTHENTICATED;
+  return authServerClient.deleteClient(token, data.id);
+}
+
+export const deleteClientFn = createServerFn({ method: 'POST' })
+  .inputValidator((data: unknown): { id: string } => {
+    if (
+      typeof data !== 'object' ||
+      data === null ||
+      typeof (data as { id?: unknown }).id !== 'string'
+    ) {
+      throw new Error('Invalid input: expected { id: string }');
+    }
+    return { id: (data as { id: string }).id };
+  })
+  .handler(deleteClientHandler);
+
+// ---------------------------------------------------------------------------
+// Regenerate secret
+// ---------------------------------------------------------------------------
+
+export async function regenerateSecretHandler({
+  data,
+}: {
+  data: { id: string };
+}): Promise<Result<ClientWithSecret>> {
+  const token = readAccessToken();
+  if (!token) return UNAUTHENTICATED;
+  const result = await authServerClient.regenerateClientSecret(token, data.id);
+  if (result.ok) setResponseHeader('Cache-Control', 'no-store');
+  return result;
+}
+
+export const regenerateSecretFn = createServerFn({ method: 'POST' })
+  .inputValidator((data: unknown): { id: string } => {
+    if (
+      typeof data !== 'object' ||
+      data === null ||
+      typeof (data as { id?: unknown }).id !== 'string'
+    ) {
+      throw new Error('Invalid input: expected { id: string }');
+    }
+    return { id: (data as { id: string }).id };
+  })
+  .handler(regenerateSecretHandler);

--- a/apps/developer-portal/src/server/auth-server-client.test.ts
+++ b/apps/developer-portal/src/server/auth-server-client.test.ts
@@ -205,3 +205,123 @@ describe('authServerClient.userinfo', () => {
     if (!result.ok) expect(result.error.status).toBe(401);
   });
 });
+
+const sampleClient = {
+  id: 'row-1',
+  clientId: 'client-uuid',
+  name: 'My App',
+  description: null,
+  redirectUris: ['https://app.example.com/cb'],
+  scopes: ['openid'],
+  grantTypes: ['authorization_code', 'refresh_token'],
+  responseTypes: ['code'],
+  tokenEndpointAuthMethod: 'client_secret_post',
+  enabled: true,
+  requirePkce: true,
+  createdAt: 1_750_000_000_000,
+  updatedAt: 1_750_000_000_000,
+  lastUsedAt: null,
+};
+
+describe('authServerClient.listClients', () => {
+  it('returns the clients array on 200', async () => {
+    mockFetch(200, { clients: [sampleClient] });
+    const result = await authServerClient.listClients('at');
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.data.clients).toHaveLength(1);
+  });
+
+  it('maps 401 to UNAUTHENTICATED', async () => {
+    mockFetch(401, { error: 'Unauthorized', statusCode: 401 }, false);
+    const result = await authServerClient.listClients('bad');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe('UNAUTHENTICATED');
+  });
+});
+
+describe('authServerClient.getClient', () => {
+  it('returns the client on 200', async () => {
+    mockFetch(200, sampleClient);
+    const result = await authServerClient.getClient('at', 'row-1');
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.data.clientId).toBe('client-uuid');
+  });
+
+  it('maps 404 to NOT_FOUND (not owned / missing)', async () => {
+    mockFetch(404, { error: 'Not found', statusCode: 404 }, false);
+    const result = await authServerClient.getClient('at', 'missing');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe('NOT_FOUND');
+  });
+});
+
+describe('authServerClient.createClient', () => {
+  it('returns the client with a one-time secret on 201', async () => {
+    mockFetch(201, { ...sampleClient, clientSecret: 'a'.repeat(64) });
+    const result = await authServerClient.createClient('at', { name: 'My App' });
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.data.clientSecret).toHaveLength(64);
+  });
+
+  it('maps a 400 without a code to VALIDATION_ERROR', async () => {
+    mockFetch(400, { error: 'Invalid redirect URI', statusCode: 400 }, false);
+    const result = await authServerClient.createClient('at', { name: 'x' });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('maps 429 to RATE_LIMITED', async () => {
+    mockFetch(429, { error: 'Too many requests', statusCode: 429 }, false);
+    const result = await authServerClient.createClient('at', { name: 'x' });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe('RATE_LIMITED');
+  });
+});
+
+describe('authServerClient.updateClient', () => {
+  it('returns the updated client on 200 (no secret)', async () => {
+    mockFetch(200, { ...sampleClient, name: 'Renamed' });
+    const result = await authServerClient.updateClient('at', 'row-1', { name: 'Renamed' });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.name).toBe('Renamed');
+      expect((result.data as { clientSecret?: string }).clientSecret).toBeUndefined();
+    }
+  });
+});
+
+describe('authServerClient.deleteClient', () => {
+  it('returns ok with null data on 204 without parsing a body', async () => {
+    const jsonSpy = vi.fn(() => Promise.reject(new Error('no body')));
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue({ ok: true, status: 204, json: jsonSpy } as unknown as Response);
+    const result = await authServerClient.deleteClient('at', 'row-1');
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.data).toBeNull();
+    expect(jsonSpy).not.toHaveBeenCalled();
+  });
+
+  it('maps 404 to NOT_FOUND', async () => {
+    mockFetch(404, { error: 'Not found', statusCode: 404 }, false);
+    const result = await authServerClient.deleteClient('at', 'missing');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe('NOT_FOUND');
+  });
+});
+
+describe('authServerClient.regenerateClientSecret', () => {
+  it('returns the new one-time secret on 200', async () => {
+    mockFetch(200, { ...sampleClient, clientSecret: 'b'.repeat(64) });
+    const result = await authServerClient.regenerateClientSecret('at', 'row-1');
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.data.clientSecret).toBe('b'.repeat(64));
+  });
+
+  it('maps a public-client 400 to VALIDATION_ERROR', async () => {
+    mockFetch(400, { error: 'Public client has no secret', statusCode: 400 }, false);
+    const result = await authServerClient.regenerateClientSecret('at', 'row-1');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe('VALIDATION_ERROR');
+  });
+});

--- a/apps/developer-portal/src/server/auth-server-client.ts
+++ b/apps/developer-portal/src/server/auth-server-client.ts
@@ -51,8 +51,74 @@ export interface UserInfoData {
   email_verified?: boolean;
 }
 
+export type TokenEndpointAuthMethod =
+  | 'none'
+  | 'client_secret_post'
+  | 'client_secret_basic'
+  | 'private_key_jwt';
+
+export type GrantType = 'authorization_code' | 'refresh_token' | 'client_credentials';
+
+/**
+ * Safe representation of an OAuth client as returned by every `/api/clients`
+ * route except the secret-bearing responses. The plaintext `clientSecret` is
+ * deliberately absent here — it only exists on {@link ClientWithSecret}.
+ */
+export interface OAuthClient {
+  id: string;
+  clientId: string;
+  name: string;
+  description: string | null;
+  redirectUris: string[];
+  scopes: string[];
+  grantTypes: GrantType[];
+  responseTypes: string[];
+  tokenEndpointAuthMethod: TokenEndpointAuthMethod;
+  enabled: boolean;
+  requirePkce: boolean;
+  createdAt: number;
+  updatedAt: number | null;
+  lastUsedAt: number | null;
+}
+
+/**
+ * Returned only by `POST /api/clients` (create) and
+ * `POST /api/clients/:id/regenerate-secret`. The `clientSecret` is shown once
+ * and is unrecoverable afterwards — never persist it beyond the one-time
+ * display modal.
+ */
+export interface ClientWithSecret extends OAuthClient {
+  clientSecret?: string;
+}
+
+export interface ClientListData {
+  clients: OAuthClient[];
+}
+
+export interface CreateClientInput {
+  name: string;
+  description?: string | null;
+  redirectUris?: string[];
+  scopes?: string[];
+  grantTypes?: GrantType[];
+  responseTypes?: string[];
+  tokenEndpointAuthMethod?: TokenEndpointAuthMethod;
+}
+
+export interface UpdateClientInput {
+  name?: string;
+  description?: string | null;
+  redirectUris?: string[];
+  scopes?: string[];
+  grantTypes?: GrantType[];
+  responseTypes?: string[];
+  tokenEndpointAuthMethod?: TokenEndpointAuthMethod;
+  enabled?: boolean;
+}
+
 function mapErrorCode(body: AuthServerErrorBody, httpStatus: number): string {
   if (httpStatus === 429) return 'RATE_LIMITED';
+  if (httpStatus === 404) return 'NOT_FOUND';
   switch (body.code) {
     case 'INVALID_CREDENTIALS':
       return 'INVALID_CREDENTIALS';
@@ -64,8 +130,71 @@ function mapErrorCode(body: AuthServerErrorBody, httpStatus: number): string {
       return 'INVALID_TOKEN';
     case 'EMAIL_ALREADY_VERIFIED':
       return 'EMAIL_ALREADY_VERIFIED';
+    case 'VALIDATION_ERROR':
+      return 'VALIDATION_ERROR';
     default:
+      // No domain code: classify by status. The `/api/clients` routes return
+      // bare `401`/`400`s; login etc. carry a `code` handled above.
+      if (httpStatus === 401) return 'UNAUTHENTICATED';
+      if (httpStatus === 400) return 'VALIDATION_ERROR';
       return 'UNKNOWN';
+  }
+}
+
+/**
+ * Variant of {@link apiRequest} for endpoints that return `204 No Content`
+ * (notably `DELETE /api/clients/:id`). Calling `res.json()` on an empty body
+ * would throw, so success is reported without parsing.
+ */
+async function apiRequestNoContent(
+  path: string,
+  init: RequestInit & { skipContentType?: boolean }
+): Promise<Result<null>> {
+  // `skipContentType` is irrelevant here (no request body); drop it so it is
+  // not forwarded to `fetch`.
+  const { skipContentType, ...fetchInit } = init;
+  void skipContentType;
+  try {
+    const res = await fetch(`${env.AUTH_SERVER_URL}${path}`, {
+      ...fetchInit,
+      headers: { ...(fetchInit.headers as Record<string, string> | undefined) },
+    });
+
+    if (res.ok) return { ok: true, data: null };
+
+    let parsed: unknown;
+    try {
+      parsed = await res.json();
+    } catch {
+      return {
+        ok: false,
+        error: {
+          code: mapErrorCode({ error: '', statusCode: res.status }, res.status),
+          message: `HTTP ${res.status}`,
+          status: res.status,
+        },
+      };
+    }
+    const body = (
+      typeof parsed === 'object' && parsed !== null ? parsed : {}
+    ) as AuthServerErrorBody;
+    return {
+      ok: false,
+      error: {
+        code: mapErrorCode(body, res.status),
+        message: body.error || `HTTP ${res.status}`,
+        status: res.status,
+      },
+    };
+  } catch (err) {
+    return {
+      ok: false,
+      error: {
+        code: 'NETWORK_ERROR',
+        message: err instanceof Error ? err.message : 'Network error',
+        status: 0,
+      },
+    };
   }
 }
 
@@ -175,5 +304,60 @@ export const authServerClient = {
       headers: { Authorization: `Bearer ${accessToken}` },
       skipContentType: true,
     });
+  },
+
+  listClients(accessToken: string): Promise<Result<ClientListData>> {
+    return apiRequest<ClientListData>('/api/clients', {
+      method: 'GET',
+      headers: { Authorization: `Bearer ${accessToken}` },
+      skipContentType: true,
+    });
+  },
+
+  getClient(accessToken: string, id: string): Promise<Result<OAuthClient>> {
+    return apiRequest<OAuthClient>(`/api/clients/${encodeURIComponent(id)}`, {
+      method: 'GET',
+      headers: { Authorization: `Bearer ${accessToken}` },
+      skipContentType: true,
+    });
+  },
+
+  createClient(accessToken: string, input: CreateClientInput): Promise<Result<ClientWithSecret>> {
+    return apiRequest<ClientWithSecret>('/api/clients', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${accessToken}` },
+      body: JSON.stringify(input),
+    });
+  },
+
+  updateClient(
+    accessToken: string,
+    id: string,
+    input: UpdateClientInput
+  ): Promise<Result<OAuthClient>> {
+    return apiRequest<OAuthClient>(`/api/clients/${encodeURIComponent(id)}`, {
+      method: 'PATCH',
+      headers: { Authorization: `Bearer ${accessToken}` },
+      body: JSON.stringify(input),
+    });
+  },
+
+  deleteClient(accessToken: string, id: string): Promise<Result<null>> {
+    return apiRequestNoContent(`/api/clients/${encodeURIComponent(id)}`, {
+      method: 'DELETE',
+      headers: { Authorization: `Bearer ${accessToken}` },
+      skipContentType: true,
+    });
+  },
+
+  regenerateClientSecret(accessToken: string, id: string): Promise<Result<ClientWithSecret>> {
+    return apiRequest<ClientWithSecret>(
+      `/api/clients/${encodeURIComponent(id)}/regenerate-secret`,
+      {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${accessToken}` },
+        skipContentType: true,
+      }
+    );
   },
 };


### PR DESCRIPTION
## Summary

Developer-portal UI for managing a developer's own OAuth clients, built against the live `/api/clients` REST API. One cohesive feature covering issues #91–#96, scoped entirely to `apps/developer-portal`.

| Issue | Screen | Endpoint |
| --- | --- | --- |
| #92 | Client list (cards + empty state) | `GET /api/clients` |
| #91 | New client form, one-time secret display | `POST /api/clients` |
| #93 | Client details (client_id copyable, secret hidden) | `GET /api/clients/:id` |
| #94 | Edit client (shared create/edit form) | `PATCH /api/clients/:id` |
| #95 | Regenerate secret (confirm + one-time new secret) | `POST /api/clients/:id/regenerate-secret` |
| #96 | Delete confirmation modal | `DELETE /api/clients/:id` |

## Architecture — follows the existing portal pattern

The portal already authenticates by storing the developer's access/refresh tokens in a **signed, HttpOnly session cookie**; the browser never sees the token. API calls go through TanStack Start **server functions** (`createServerFn`) that read the cookie server-side and proxy to the auth-server with `Authorization: Bearer <token>` via the existing `authServerClient`.

This PR extends exactly that pattern rather than introducing anything new:
- Added `/api/clients` methods + types to `auth-server-client.ts` (incl. a 204-safe path for DELETE so an empty body is not `JSON.parse`d), and mapped bare `401 → UNAUTHENTICATED` / `404 → NOT_FOUND` / `400 → VALIDATION_ERROR` without disturbing the coded auth errors (e.g. login's `INVALID_CREDENTIALS`).
- Six server functions in `server/actions/clients.ts`, each with input validation, returning the project's `Result<T>` discriminated union. Secret-bearing responses set `Cache-Control: no-store`.
- New file-based routes under the existing `_authed` guarded layout: `clients.index`, `clients.new`, `clients.$clientId`.
- Shared components (`CopyField`, `Modal`, `SecretReveal`, `ClientForm`) under `src/components/` — the portal had no component dir beyond the `@qauth-labs/ui` primitives, so these are minimal and local.

## Security / one-time secret handling

- The one-time `client_secret` (create + regenerate) is passed **only as a prop** into a non-dismissible `SecretReveal` modal with a clear "copy now, won't be shown again" warning. It is never written to component/app state and is gone the moment the modal unmounts.
- `401` redirects to `/login` (re-auth); `404` shows a "not found or not owned" message (matching the API's ownership semantics).
- Public clients (`tokenEndpointAuthMethod: none`) get no secret and the Regenerate action is hidden.

## Foundation: found vs. built

**Found (reused as-is):** HttpOnly signed-session auth, `authServerClient` + `Result<T>`, server-function action pattern, `_authed` route guard, `@qauth-labs/ui` primitives, vitest SSR (`renderToString`) test setup.
**Built (minimum needed):** the `/api/clients` client methods + server functions, the three routes, and four local presentational components. No new libraries, no auth/session changes.

## Routes added

- `/clients` — list
- `/clients/new` — create
- `/clients/$clientId` — details + inline edit + regenerate + delete

(`routeTree.gen.ts` regenerated by the TanStack Start vite plugin.) The dashboard "OAuth Clients" card now links to `/clients`.

## Tests / CI

`pnpm nx run-many -t lint typecheck test build -p developer-portal` is green. Test suite: **109 passing** (19 files) — covers the api-client methods (incl. 204 DELETE and error mapping), all six server-fn handlers (token forwarding, unauthenticated short-circuit, `no-store`), the form parsing helpers, error-message mapping, and route/component rendering.

> Note for reviewers: did **not** touch `apps/auth-server` or `libs/` (parallel backend PRs in flight).

Closes #91
Closes #92
Closes #93
Closes #94
Closes #95
Closes #96

https://claude.ai/code/session_01Re2rxPkdcgzJe7LSddhxv6
