### PR TITLE
feat(oauth): RFC 8693 token exchange for agent on-behalf-of delegation

### DIFF
--- a/apps/auth-server/src/app/helpers/client-auth.ts
+++ b/apps/auth-server/src/app/helpers/client-auth.ts
@@ -32,6 +32,17 @@ export type OAuthClientLike = {
    * When absent we conservatively treat the client as confidential.
    */
   tokenEndpointAuthMethod?: string;
+  /**
+   * ADR-007 §2 agent classification (`oauth_clients.is_agent`). Surfaced so
+   * the token-exchange grant can gate on it via `isAgentClient`. Optional /
+   * fail-closed: a missing value reads as a NON-agent client.
+   *
+   * TRUST: self-asserted, unverified client input — never sufficient on its
+   * own. The token-exchange handler treats it as one of several gates and
+   * still performs server-side checks (subject-token signature/iss/exp,
+   * client enabled, aud/scope subset). See epic #181's default-deny note.
+   */
+  isAgent?: boolean;
 };
 
 /**

--- a/apps/auth-server/src/app/helpers/discovery.test.ts
+++ b/apps/auth-server/src/app/helpers/discovery.test.ts
@@ -29,6 +29,7 @@ describe('buildAuthorizationServerMetadata', () => {
       'authorization_code',
       'client_credentials',
       'refresh_token',
+      'urn:ietf:params:oauth:grant-type:token-exchange',
     ]);
     expect(meta['code_challenge_methods_supported']).toEqual(['S256']);
     expect(meta['token_endpoint_auth_methods_supported']).toEqual([

--- a/apps/auth-server/src/app/helpers/discovery.ts
+++ b/apps/auth-server/src/app/helpers/discovery.ts
@@ -69,7 +69,14 @@ export function buildAuthorizationServerMetadata(
     response_types_supported: ['code'],
     // refresh_token is advertised eagerly: a sibling branch is implementing
     // the grant handler. Token endpoint still rejects unsupported grants.
-    grant_types_supported: ['authorization_code', 'client_credentials', 'refresh_token'],
+    // The token-exchange grant (RFC 8693, ADR-007 §2) powers agent
+    // on-behalf-of delegation; only agent clients may use it (handler-gated).
+    grant_types_supported: [
+      'authorization_code',
+      'client_credentials',
+      'refresh_token',
+      'urn:ietf:params:oauth:grant-type:token-exchange',
+    ],
     code_challenge_methods_supported: ['S256'],
     token_endpoint_auth_methods_supported: ['client_secret_basic', 'client_secret_post', 'none'],
     introspection_endpoint_auth_methods_supported: ['client_secret_basic', 'client_secret_post'],

--- a/apps/auth-server/src/app/plugins/error-handler.ts
+++ b/apps/auth-server/src/app/plugins/error-handler.ts
@@ -5,6 +5,7 @@ import {
   InvalidClientError,
   InvalidCredentialsError,
   InvalidGrantError,
+  InvalidRequestError,
   InvalidScopeError,
   InvalidTargetError,
   InvalidTokenError,
@@ -69,6 +70,7 @@ export default fp(async function (fastify: FastifyInstance) {
       if (
         error instanceof InvalidScopeError ||
         error instanceof InvalidGrantError ||
+        error instanceof InvalidRequestError ||
         error instanceof InvalidTargetError
       ) {
         const response: ErrorResponse = {

--- a/apps/auth-server/src/app/routes/oauth/token.test.ts
+++ b/apps/auth-server/src/app/routes/oauth/token.test.ts
@@ -1,4 +1,5 @@
 import {
+  BadRequestError,
   InvalidClientError,
   InvalidGrantError,
   InvalidScopeError,
@@ -94,6 +95,7 @@ function createFastifyStub() {
     },
     jwtUtils: {
       signAccessToken: vi.fn(),
+      verifyAccessToken: vi.fn(),
       generateRefreshToken: vi.fn(),
       hashRefreshToken: vi.fn().mockImplementation((t: string) => `hash:${t}`),
       getAccessTokenLifespan: vi.fn().mockReturnValue(900),
@@ -1407,5 +1409,261 @@ describe('POST /oauth/token route — refresh_token grant', () => {
     expect(
       fastify.repositories.refreshTokens.findByTokenHashIncludingRevoked
     ).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /oauth/token route — token-exchange grant (RFC 8693, ADR-007 §2)', () => {
+  const GRANT = 'urn:ietf:params:oauth:grant-type:token-exchange';
+  const ACCESS_TOKEN_TYPE = 'urn:ietf:params:oauth:token-type:access_token';
+
+  /**
+   * Set up a confidential AGENT client (is_agent: true) authorised for the
+   * token-exchange grant, plus a verifiable subject token and an enabled user.
+   */
+  function setupExchangeStub(
+    opts: {
+      isAgent?: boolean;
+      grantTypes?: string[];
+      subjectScope?: string;
+      subjectAud?: string | string[] | undefined;
+      subjectAct?: unknown;
+      userEnabled?: boolean;
+      userFound?: boolean;
+    } = {}
+  ) {
+    const { fastify, ctx } = createFastifyStub();
+
+    const client = {
+      id: 'client-uuid-agent-1',
+      clientId: 'agent-client',
+      clientSecretHash: 'hash',
+      enabled: true,
+      grantTypes: opts.grantTypes ?? [GRANT],
+      scopes: [] as string[],
+      audience: null,
+      isAgent: opts.isAgent ?? true,
+    };
+
+    const user = {
+      id: 'user-uuid-subject',
+      email: 'subject@example.com',
+      emailVerified: true,
+      enabled: opts.userEnabled ?? true,
+    };
+
+    const subjectPayload = {
+      sub: user.id,
+      clientId: 'original-app-client',
+      scope: opts.subjectScope ?? 'read:docs write:docs',
+      aud: opts.subjectAud === undefined ? 'https://api.example.com' : opts.subjectAud,
+      ...(opts.subjectAct ? { act: opts.subjectAct } : {}),
+    };
+
+    (fastify.repositories.oauthClients.findByClientId as unknown as Mock).mockResolvedValue(client);
+    (fastify.passwordHasher.verifyPassword as unknown as Mock).mockResolvedValue(true);
+    (fastify.jwtUtils.verifyAccessToken as unknown as Mock).mockResolvedValue(subjectPayload);
+    (fastify.repositories.users.findById as unknown as Mock).mockResolvedValue(
+      opts.userFound === false ? null : user
+    );
+    (fastify.jwtUtils.signAccessToken as unknown as Mock).mockResolvedValue('delegated.jwt');
+
+    return { fastify, ctx, client, user, subjectPayload };
+  }
+
+  function exchangeRequest(overrides: Record<string, unknown> = {}) {
+    return {
+      body: {
+        grant_type: GRANT,
+        client_id: 'agent-client',
+        client_secret: 'secret',
+        subject_token: 'subject.jwt.token',
+        subject_token_type: ACCESS_TOKEN_TYPE,
+        ...overrides,
+      },
+      ip: '127.0.0.1',
+      headers: { 'user-agent': 'vitest' },
+    };
+  }
+
+  async function invoke(fastify: FastifyInstance, ctx: TestContext, req: unknown) {
+    await tokenRoute(fastify);
+    const handler = ctx.handler;
+    if (!handler) throw new Error('Handler missing');
+    return handler(req, createReply());
+  }
+
+  it('mints a delegated token: sub=user, act.sub=agent, preserved scope+aud', async () => {
+    const { fastify, ctx, client, user } = setupExchangeStub();
+    const result = await invoke(fastify, ctx, exchangeRequest());
+
+    // sub is the end-user; act identifies the acting agent (RFC 8693 §4.1).
+    expect(fastify.jwtUtils.signAccessToken).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sub: user.id,
+        clientId: client.clientId,
+        scope: 'read:docs write:docs',
+        aud: 'https://api.example.com',
+        act: { sub: 'agent-client' },
+      })
+    );
+    expect(result).toMatchObject({
+      access_token: 'delegated.jwt',
+      issued_token_type: ACCESS_TOKEN_TYPE,
+      token_type: 'Bearer',
+      scope: 'read:docs write:docs',
+    });
+    // RFC 8693: no refresh token issued on delegation.
+    expect(result).not.toHaveProperty('refresh_token');
+  });
+
+  it('nests the prior act chain for chained delegation', async () => {
+    // Subject token already carries an act (a previous agent delegation).
+    const { fastify, ctx } = setupExchangeStub({ subjectAct: { sub: 'prior-agent' } });
+    await invoke(fastify, ctx, exchangeRequest());
+
+    expect(fastify.jwtUtils.signAccessToken).toHaveBeenCalledWith(
+      expect.objectContaining({
+        act: { sub: 'agent-client', act: { sub: 'prior-agent' } },
+      })
+    );
+  });
+
+  it('rejects an over-deep delegation chain (invalid_request)', async () => {
+    // Subject token already carries 4 nested actors; this exchange would make 5,
+    // exceeding MAX_DELEGATION_DEPTH (4) → invalid_request, no token minted.
+    const deepAct = { sub: 'a3', act: { sub: 'a2', act: { sub: 'a1', act: { sub: 'a0' } } } };
+    const { fastify, ctx } = setupExchangeStub({ subjectAct: deepAct });
+    await expect(invoke(fastify, ctx, exchangeRequest())).rejects.toThrow(BadRequestError);
+    expect(fastify.jwtUtils.signAccessToken).not.toHaveBeenCalled();
+  });
+
+  it('narrows scope to a subset of the subject token scope', async () => {
+    const { fastify, ctx } = setupExchangeStub({ subjectScope: 'read:docs write:docs' });
+    await invoke(fastify, ctx, exchangeRequest({ scope: 'read:docs' }));
+
+    expect(fastify.jwtUtils.signAccessToken).toHaveBeenCalledWith(
+      expect.objectContaining({ scope: 'read:docs' })
+    );
+  });
+
+  it('rejects scope widening beyond the subject token (invalid_scope)', async () => {
+    const { fastify, ctx } = setupExchangeStub({ subjectScope: 'read:docs' });
+    await expect(
+      invoke(fastify, ctx, exchangeRequest({ scope: 'read:docs admin:all' }))
+    ).rejects.toThrow(InvalidScopeError);
+    expect(fastify.jwtUtils.signAccessToken).not.toHaveBeenCalled();
+  });
+
+  it('narrows aud to a requested resource within the subject token audience', async () => {
+    const { fastify, ctx } = setupExchangeStub({
+      subjectAud: ['https://api.example.com/v1', 'https://api2.example.com/v1'],
+    });
+    await invoke(fastify, ctx, exchangeRequest({ resource: ['https://api.example.com/v1'] }));
+    expect(fastify.jwtUtils.signAccessToken).toHaveBeenCalledWith(
+      expect.objectContaining({ aud: 'https://api.example.com/v1' })
+    );
+  });
+
+  it('rejects a resource/audience outside the subject token audience (invalid_target)', async () => {
+    const { fastify, ctx } = setupExchangeStub({ subjectAud: 'https://api.example.com/v1' });
+    await expect(
+      invoke(fastify, ctx, exchangeRequest({ resource: ['https://evil.example.com/v1'] }))
+    ).rejects.toThrow(InvalidTargetError);
+    expect(fastify.jwtUtils.signAccessToken).not.toHaveBeenCalled();
+  });
+
+  it('rejects a non-agent client (unauthorized_client, default-deny)', async () => {
+    // Self-asserted is_agent omitted/false → fail-closed rejection (epic #181).
+    const { fastify, ctx } = setupExchangeStub({ isAgent: false });
+    await expect(invoke(fastify, ctx, exchangeRequest())).rejects.toThrow(UnauthorizedClientError);
+    expect(fastify.jwtUtils.verifyAccessToken).not.toHaveBeenCalled();
+    expect(fastify.jwtUtils.signAccessToken).not.toHaveBeenCalled();
+  });
+
+  it('rejects an agent client not allowed the token-exchange grant', async () => {
+    const { fastify, ctx } = setupExchangeStub({ grantTypes: ['authorization_code'] });
+    await expect(invoke(fastify, ctx, exchangeRequest())).rejects.toThrow(UnauthorizedClientError);
+    expect(fastify.jwtUtils.signAccessToken).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unsupported subject_token_type (invalid_request)', async () => {
+    const { fastify, ctx } = setupExchangeStub();
+    await expect(
+      invoke(
+        fastify,
+        ctx,
+        exchangeRequest({ subject_token_type: 'urn:ietf:params:oauth:token-type:saml2' })
+      )
+    ).rejects.toThrow(BadRequestError);
+    expect(fastify.jwtUtils.verifyAccessToken).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unsupported requested_token_type (invalid_request)', async () => {
+    const { fastify, ctx } = setupExchangeStub();
+    await expect(
+      invoke(
+        fastify,
+        ctx,
+        exchangeRequest({ requested_token_type: 'urn:ietf:params:oauth:token-type:refresh_token' })
+      )
+    ).rejects.toThrow(BadRequestError);
+  });
+
+  it('rejects an unverifiable subject_token (invalid_request)', async () => {
+    const { fastify, ctx } = setupExchangeStub();
+    (fastify.jwtUtils.verifyAccessToken as unknown as Mock).mockRejectedValue(
+      new Error('bad signature')
+    );
+    await expect(invoke(fastify, ctx, exchangeRequest())).rejects.toThrow(BadRequestError);
+    expect(fastify.jwtUtils.signAccessToken).not.toHaveBeenCalled();
+  });
+
+  it('rejects when actor_token is present without actor_token_type (invalid_request)', async () => {
+    const { fastify, ctx } = setupExchangeStub();
+    await expect(
+      invoke(fastify, ctx, exchangeRequest({ actor_token: 'actor.jwt' }))
+    ).rejects.toThrow(BadRequestError);
+  });
+
+  it('rejects when the subject user is disabled (invalid_request)', async () => {
+    const { fastify, ctx } = setupExchangeStub({ userEnabled: false });
+    await expect(invoke(fastify, ctx, exchangeRequest())).rejects.toThrow(BadRequestError);
+    expect(fastify.jwtUtils.signAccessToken).not.toHaveBeenCalled();
+  });
+
+  it('accepts and verifies an actor_token, recording the actor subject in audit', async () => {
+    const { fastify, ctx } = setupExchangeStub();
+    // Subject + actor tokens both verify; actor identity in `act` is still the
+    // authenticated agent's client_id, not the actor token's self-declaration.
+    (fastify.jwtUtils.verifyAccessToken as unknown as Mock)
+      .mockResolvedValueOnce({
+        sub: 'user-uuid-subject',
+        clientId: 'original-app-client',
+        scope: 'read:docs',
+        aud: 'https://api.example.com',
+      })
+      .mockResolvedValueOnce({ sub: 'actor-service', clientId: 'actor-service', aud: 'x' });
+
+    await invoke(
+      fastify,
+      ctx,
+      exchangeRequest({ actor_token: 'actor.jwt', actor_token_type: ACCESS_TOKEN_TYPE })
+    );
+
+    expect(fastify.jwtUtils.signAccessToken).toHaveBeenCalledWith(
+      expect.objectContaining({ act: { sub: 'agent-client' } })
+    );
+    expect(fastify.repositories.auditLogs.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'oauth.token.exchange.success',
+        success: true,
+        metadata: expect.objectContaining({
+          grantType: 'token-exchange',
+          actor: 'agent-client',
+          hasActorToken: true,
+          actorTokenSubject: 'actor-service',
+        }),
+      })
+    );
   });
 });

--- a/apps/auth-server/src/app/routes/oauth/token.test.ts
+++ b/apps/auth-server/src/app/routes/oauth/token.test.ts
@@ -1,7 +1,7 @@
 import {
-  BadRequestError,
   InvalidClientError,
   InvalidGrantError,
+  InvalidRequestError,
   InvalidScopeError,
   InvalidTargetError,
   NotFoundError,
@@ -100,6 +100,7 @@ function createFastifyStub() {
       hashRefreshToken: vi.fn().mockImplementation((t: string) => `hash:${t}`),
       getAccessTokenLifespan: vi.fn().mockReturnValue(900),
       getRefreshTokenLifespan: vi.fn().mockReturnValue(604800),
+      getIssuer: vi.fn().mockReturnValue('https://auth.example.com'),
     },
     pkceUtils: {
       verifyCodeChallenge: vi.fn(),
@@ -1416,17 +1417,30 @@ describe('POST /oauth/token route — token-exchange grant (RFC 8693, ADR-007 §
   const GRANT = 'urn:ietf:params:oauth:grant-type:token-exchange';
   const ACCESS_TOKEN_TYPE = 'urn:ietf:params:oauth:token-type:access_token';
 
+  const ISSUER = 'https://auth.example.com';
+  const AGENT_CLIENT_ID = 'agent-client';
+
   /**
    * Set up a confidential AGENT client (is_agent: true) authorised for the
    * token-exchange grant, plus a verifiable subject token and an enabled user.
+   *
+   * The subject token defaults to a QAuth-issued access token whose `aud`
+   * includes the requesting agent's `client_id` (so the agent-binding GATE 3c
+   * passes by default). `confidential: false` simulates a PUBLIC agent
+   * (token_endpoint_auth_method=none, no secret on the request).
    */
   function setupExchangeStub(
     opts: {
       isAgent?: boolean;
+      confidential?: boolean;
       grantTypes?: string[];
       subjectScope?: string;
       subjectAud?: string | string[] | undefined;
       subjectAct?: unknown;
+      subjectIss?: string | undefined;
+      subjectTokenUse?: string | undefined;
+      subjectExp?: number;
+      bindAgentInAud?: boolean;
       userEnabled?: boolean;
       userFound?: boolean;
     } = {}
@@ -1435,13 +1449,14 @@ describe('POST /oauth/token route — token-exchange grant (RFC 8693, ADR-007 §
 
     const client = {
       id: 'client-uuid-agent-1',
-      clientId: 'agent-client',
+      clientId: AGENT_CLIENT_ID,
       clientSecretHash: 'hash',
       enabled: true,
       grantTypes: opts.grantTypes ?? [GRANT],
       scopes: [] as string[],
       audience: null,
       isAgent: opts.isAgent ?? true,
+      tokenEndpointAuthMethod: opts.confidential === false ? 'none' : 'client_secret_post',
     };
 
     const user = {
@@ -1451,11 +1466,26 @@ describe('POST /oauth/token route — token-exchange grant (RFC 8693, ADR-007 §
       enabled: opts.userEnabled ?? true,
     };
 
+    // Resolve the subject audience, ensuring the agent's client_id is present
+    // unless the test explicitly opts out (to exercise the binding failure).
+    const baseAud = opts.subjectAud === undefined ? 'https://api.example.com' : opts.subjectAud;
+    const bindAgent = opts.bindAgentInAud ?? true;
+    let aud: string | string[] | undefined;
+    if (!bindAgent) {
+      aud = baseAud;
+    } else {
+      const arr = baseAud === undefined ? [] : Array.isArray(baseAud) ? baseAud : [baseAud];
+      aud = arr.includes(AGENT_CLIENT_ID) ? baseAud : [...arr, AGENT_CLIENT_ID];
+    }
+
     const subjectPayload = {
       sub: user.id,
       clientId: 'original-app-client',
       scope: opts.subjectScope ?? 'read:docs write:docs',
-      aud: opts.subjectAud === undefined ? 'https://api.example.com' : opts.subjectAud,
+      aud,
+      iss: opts.subjectIss === undefined ? ISSUER : opts.subjectIss,
+      token_use: 'subjectTokenUse' in opts ? opts.subjectTokenUse : 'access',
+      exp: opts.subjectExp ?? Math.floor(Date.now() / 1000) + 600,
       ...(opts.subjectAct ? { act: opts.subjectAct } : {}),
     };
 
@@ -1474,7 +1504,7 @@ describe('POST /oauth/token route — token-exchange grant (RFC 8693, ADR-007 §
     return {
       body: {
         grant_type: GRANT,
-        client_id: 'agent-client',
+        client_id: AGENT_CLIENT_ID,
         client_secret: 'secret',
         subject_token: 'subject.jwt.token',
         subject_token_type: ACCESS_TOKEN_TYPE,
@@ -1493,7 +1523,11 @@ describe('POST /oauth/token route — token-exchange grant (RFC 8693, ADR-007 §
   }
 
   it('mints a delegated token: sub=user, act.sub=agent, preserved scope+aud', async () => {
-    const { fastify, ctx, client, user } = setupExchangeStub();
+    // Subject token minted for both a resource and the agent (so GATE 3c binds);
+    // with no narrowing requested the delegated aud is preserved verbatim.
+    const { fastify, ctx, client, user } = setupExchangeStub({
+      subjectAud: ['https://api.example.com', AGENT_CLIENT_ID],
+    });
     const result = await invoke(fastify, ctx, exchangeRequest());
 
     // sub is the end-user; act identifies the acting agent (RFC 8693 §4.1).
@@ -1502,8 +1536,8 @@ describe('POST /oauth/token route — token-exchange grant (RFC 8693, ADR-007 §
         sub: user.id,
         clientId: client.clientId,
         scope: 'read:docs write:docs',
-        aud: 'https://api.example.com',
-        act: { sub: 'agent-client' },
+        aud: ['https://api.example.com', AGENT_CLIENT_ID],
+        act: { sub: AGENT_CLIENT_ID },
       })
     );
     expect(result).toMatchObject({
@@ -1533,7 +1567,7 @@ describe('POST /oauth/token route — token-exchange grant (RFC 8693, ADR-007 §
     // exceeding MAX_DELEGATION_DEPTH (4) → invalid_request, no token minted.
     const deepAct = { sub: 'a3', act: { sub: 'a2', act: { sub: 'a1', act: { sub: 'a0' } } } };
     const { fastify, ctx } = setupExchangeStub({ subjectAct: deepAct });
-    await expect(invoke(fastify, ctx, exchangeRequest())).rejects.toThrow(BadRequestError);
+    await expect(invoke(fastify, ctx, exchangeRequest())).rejects.toThrow(InvalidRequestError);
     expect(fastify.jwtUtils.signAccessToken).not.toHaveBeenCalled();
   });
 
@@ -1594,7 +1628,7 @@ describe('POST /oauth/token route — token-exchange grant (RFC 8693, ADR-007 §
         ctx,
         exchangeRequest({ subject_token_type: 'urn:ietf:params:oauth:token-type:saml2' })
       )
-    ).rejects.toThrow(BadRequestError);
+    ).rejects.toThrow(InvalidRequestError);
     expect(fastify.jwtUtils.verifyAccessToken).not.toHaveBeenCalled();
   });
 
@@ -1606,7 +1640,7 @@ describe('POST /oauth/token route — token-exchange grant (RFC 8693, ADR-007 §
         ctx,
         exchangeRequest({ requested_token_type: 'urn:ietf:params:oauth:token-type:refresh_token' })
       )
-    ).rejects.toThrow(BadRequestError);
+    ).rejects.toThrow(InvalidRequestError);
   });
 
   it('rejects an unverifiable subject_token (invalid_request)', async () => {
@@ -1614,7 +1648,7 @@ describe('POST /oauth/token route — token-exchange grant (RFC 8693, ADR-007 §
     (fastify.jwtUtils.verifyAccessToken as unknown as Mock).mockRejectedValue(
       new Error('bad signature')
     );
-    await expect(invoke(fastify, ctx, exchangeRequest())).rejects.toThrow(BadRequestError);
+    await expect(invoke(fastify, ctx, exchangeRequest())).rejects.toThrow(InvalidRequestError);
     expect(fastify.jwtUtils.signAccessToken).not.toHaveBeenCalled();
   });
 
@@ -1622,12 +1656,12 @@ describe('POST /oauth/token route — token-exchange grant (RFC 8693, ADR-007 §
     const { fastify, ctx } = setupExchangeStub();
     await expect(
       invoke(fastify, ctx, exchangeRequest({ actor_token: 'actor.jwt' }))
-    ).rejects.toThrow(BadRequestError);
+    ).rejects.toThrow(InvalidRequestError);
   });
 
   it('rejects when the subject user is disabled (invalid_request)', async () => {
     const { fastify, ctx } = setupExchangeStub({ userEnabled: false });
-    await expect(invoke(fastify, ctx, exchangeRequest())).rejects.toThrow(BadRequestError);
+    await expect(invoke(fastify, ctx, exchangeRequest())).rejects.toThrow(InvalidRequestError);
     expect(fastify.jwtUtils.signAccessToken).not.toHaveBeenCalled();
   });
 
@@ -1640,9 +1674,19 @@ describe('POST /oauth/token route — token-exchange grant (RFC 8693, ADR-007 §
         sub: 'user-uuid-subject',
         clientId: 'original-app-client',
         scope: 'read:docs',
-        aud: 'https://api.example.com',
+        aud: ['https://api.example.com', AGENT_CLIENT_ID],
+        iss: ISSUER,
+        token_use: 'access',
+        exp: Math.floor(Date.now() / 1000) + 600,
       })
-      .mockResolvedValueOnce({ sub: 'actor-service', clientId: 'actor-service', aud: 'x' });
+      .mockResolvedValueOnce({
+        sub: 'actor-service',
+        clientId: 'actor-service',
+        aud: 'x',
+        iss: ISSUER,
+        token_use: 'access',
+        exp: Math.floor(Date.now() / 1000) + 600,
+      });
 
     await invoke(
       fastify,
@@ -1665,5 +1709,87 @@ describe('POST /oauth/token route — token-exchange grant (RFC 8693, ADR-007 §
         }),
       })
     );
+  });
+
+  it('rejects when the subject_token was not minted for this agent (binding, invalid_request)', async () => {
+    // Subject token aud does NOT contain the requesting agent's client_id.
+    // Closes "any user's token + any agent client_id mints delegation".
+    const { fastify, ctx } = setupExchangeStub({
+      subjectAud: 'https://api.example.com',
+      bindAgentInAud: false,
+    });
+    await expect(invoke(fastify, ctx, exchangeRequest())).rejects.toThrow(InvalidRequestError);
+    expect(fastify.jwtUtils.signAccessToken).not.toHaveBeenCalled();
+  });
+
+  it('rejects a PUBLIC agent client — token-exchange requires confidential auth (invalid_client)', async () => {
+    // Public client (token_endpoint_auth_method=none) presents no secret; the
+    // confidential auth path rejects it before any exchange logic runs.
+    const { fastify, ctx } = setupExchangeStub({ confidential: false });
+    const req = exchangeRequest();
+    delete (req.body as Record<string, unknown>).client_secret; // public: no secret
+    await expect(invoke(fastify, ctx, req)).rejects.toThrow(InvalidClientError);
+    expect(fastify.jwtUtils.verifyAccessToken).not.toHaveBeenCalled();
+    expect(fastify.jwtUtils.signAccessToken).not.toHaveBeenCalled();
+  });
+
+  it('rejects a QAuth-signed JWT that is not an access token (token confusion, invalid_request)', async () => {
+    // An ID-token-shaped JWT (no token_use marker, no client_id) verifies by
+    // signature but must NOT be accepted as a subject token.
+    const { fastify, ctx } = setupExchangeStub();
+    (fastify.jwtUtils.verifyAccessToken as unknown as Mock).mockResolvedValue({
+      sub: 'user-uuid-subject',
+      aud: ['https://api.example.com', AGENT_CLIENT_ID],
+      iss: ISSUER,
+      token_use: 'id', // positively NOT an access token
+      exp: Math.floor(Date.now() / 1000) + 600,
+    });
+    await expect(invoke(fastify, ctx, exchangeRequest())).rejects.toThrow(InvalidRequestError);
+    expect(fastify.jwtUtils.signAccessToken).not.toHaveBeenCalled();
+  });
+
+  it('rejects a subject_token from a foreign issuer (invalid_request)', async () => {
+    const { fastify, ctx } = setupExchangeStub({ subjectIss: 'https://evil.example.com' });
+    await expect(invoke(fastify, ctx, exchangeRequest())).rejects.toThrow(InvalidRequestError);
+    expect(fastify.jwtUtils.signAccessToken).not.toHaveBeenCalled();
+  });
+
+  it('clamps the delegated token lifespan to the subject token remaining lifetime', async () => {
+    // Subject token expires in 120s; configured lifespan is 900s → clamp to 120.
+    const exp = Math.floor(Date.now() / 1000) + 120;
+    const { fastify, ctx } = setupExchangeStub({ subjectExp: exp });
+    const result = await invoke(fastify, ctx, exchangeRequest());
+
+    const signArg = (fastify.jwtUtils.signAccessToken as unknown as Mock).mock.calls[0][0];
+    expect(signArg.expiresInOverride).toBeGreaterThan(110);
+    expect(signArg.expiresInOverride).toBeLessThanOrEqual(120);
+    expect((result as { expires_in: number }).expires_in).toBe(signArg.expiresInOverride);
+  });
+
+  it('does NOT extend lifespan beyond the configured default when the subject lives longer', async () => {
+    // Subject token expires in 10000s; configured lifespan is 900s → cap at 900.
+    const exp = Math.floor(Date.now() / 1000) + 10000;
+    const { fastify, ctx } = setupExchangeStub({ subjectExp: exp });
+    await invoke(fastify, ctx, exchangeRequest());
+    const signArg = (fastify.jwtUtils.signAccessToken as unknown as Mock).mock.calls[0][0];
+    expect(signArg.expiresInOverride).toBe(900);
+  });
+
+  it('emits the bare `invalid_request` error code via InvalidRequestError (RFC 6749 §5.2)', async () => {
+    // The wire `error` field must be the bare token; detail goes in
+    // error_description. InvalidRequestError.message is exactly "invalid_request".
+    const { fastify, ctx } = setupExchangeStub();
+    try {
+      await invoke(
+        fastify,
+        ctx,
+        exchangeRequest({ subject_token_type: 'urn:ietf:params:oauth:token-type:saml2' })
+      );
+      throw new Error('expected rejection');
+    } catch (err) {
+      expect(err).toBeInstanceOf(InvalidRequestError);
+      expect((err as InvalidRequestError).message).toBe('invalid_request');
+      expect((err as InvalidRequestError).errorDescription).toBeTruthy();
+    }
   });
 });

--- a/apps/auth-server/src/app/routes/oauth/token.ts
+++ b/apps/auth-server/src/app/routes/oauth/token.ts
@@ -1,11 +1,14 @@
 import { randomUUID } from 'node:crypto';
 
+import type { ActClaim } from '@qauth-labs/fastify-plugin-jwt';
 import {
   BadRequestError,
   InvalidClientError,
   InvalidGrantError,
   InvalidScopeError,
   InvalidTargetError,
+  JWTExpiredError,
+  JWTInvalidError,
   NotFoundError,
   UnauthorizedClientError,
 } from '@qauth-labs/shared-errors';
@@ -22,15 +25,19 @@ import {
   resolveAudience,
   validateScopes,
 } from '../../helpers/client-auth';
+import { isAgentClient } from '../../helpers/client-resolution';
 import { getOrCreateDefaultRealm } from '../../helpers/realm';
 import { ensureMinimumResponseTime } from '../../helpers/timing';
 import {
+  TOKEN_EXCHANGE_GRANT_TYPE,
+  TOKEN_TYPE_ACCESS_TOKEN,
   type TokenExchangeAuthCodeBody,
   tokenExchangeBodySchema,
   type TokenExchangeClientCredsBody,
   type TokenExchangeRefreshBody,
   type TokenExchangeResponse,
   tokenExchangeResponseSchema,
+  type TokenExchangeTokenExchangeBody,
 } from '../../schemas/oauth';
 
 /**
@@ -77,7 +84,8 @@ export default async function (fastify: FastifyInstance) {
       const body = request.body as
         | TokenExchangeAuthCodeBody
         | TokenExchangeClientCredsBody
-        | TokenExchangeRefreshBody;
+        | TokenExchangeRefreshBody
+        | TokenExchangeTokenExchangeBody;
 
       try {
         const realm = await getOrCreateDefaultRealm(fastify);
@@ -90,7 +98,15 @@ export default async function (fastify: FastifyInstance) {
         // 'none'`. client_credentials is confidential-only by definition.
         let client: OAuthClientLike;
         try {
-          if (body.grant_type === 'authorization_code' || body.grant_type === 'refresh_token') {
+          if (
+            body.grant_type === 'authorization_code' ||
+            body.grant_type === 'refresh_token' ||
+            body.grant_type === TOKEN_EXCHANGE_GRANT_TYPE
+          ) {
+            // token-exchange agents may be public (PKCE-registered, no secret)
+            // or confidential; this resolver accepts both. The agent
+            // classification + subject-token validation gate the grant in the
+            // handler — client auth alone never authorises an exchange.
             client = await authenticateClientPublicOrConfidential(
               fastify,
               realm.id,
@@ -154,6 +170,16 @@ export default async function (fastify: FastifyInstance) {
           return reply.send(responseBody);
         }
 
+        if (body.grant_type === TOKEN_EXCHANGE_GRANT_TYPE) {
+          const responseBody = await handleTokenExchange({
+            fastify,
+            request: request as FastifyRequest,
+            client,
+            body,
+          });
+          return reply.send(responseBody);
+        }
+
         // Schema validation should have rejected this already, but guard anyway.
         throw new BadRequestError('unsupported_grant_type');
       } catch (error) {
@@ -164,6 +190,8 @@ export default async function (fastify: FastifyInstance) {
           error instanceof InvalidScopeError ||
           error instanceof NotFoundError ||
           error instanceof BadRequestError ||
+          error instanceof JWTExpiredError ||
+          error instanceof JWTInvalidError ||
           error instanceof UnauthorizedClientError
         ) {
           await ensureMinimumResponseTime(startTime, MIN_RESPONSE_TIME_MS.TOKEN);
@@ -798,6 +826,286 @@ async function handleRefreshToken(
   return {
     access_token: accessToken,
     refresh_token: newRefreshToken,
+    expires_in: accessTokenExpiresIn,
+    token_type: 'Bearer' as const,
+    ...(scopeString ? { scope: scopeString } : {}),
+  };
+}
+
+/**
+ * Normalise a JWT `aud` claim (string | string[] | undefined) to a string[].
+ */
+function audToArray(aud: string | string[] | undefined): string[] {
+  if (aud === undefined) return [];
+  return Array.isArray(aud) ? aud : [aud];
+}
+
+/**
+ * Collapse a string[] back to the JWT `aud` shape (single → string).
+ */
+function arrayToAud(values: string[]): string | string[] {
+  return values.length === 1 ? values[0] : values;
+}
+
+/** Count the delegation depth of an `act` chain (1 = single actor). */
+function actDepth(act: ActClaim | undefined): number {
+  let depth = 0;
+  let cursor: ActClaim | undefined = act;
+  while (cursor) {
+    depth += 1;
+    cursor = cursor.act;
+  }
+  return depth;
+}
+
+/**
+ * Maximum delegation depth (number of nested `act` actors) we will mint. Each
+ * additional hop appends a nested `act`, growing the JWT unboundedly; an
+ * attacker chaining re-exchanges could otherwise inflate token size (DoS) and
+ * obscure provenance. A small cap bounds both. Re-exchanging an already-deep
+ * delegated token past the limit → `invalid_request`.
+ */
+const MAX_DELEGATION_DEPTH = 4;
+
+/**
+ * Handle the OAuth 2.0 Token Exchange grant (RFC 8693) — QAuth's agent
+ * on-behalf-of delegation (ADR-007 §2). An **agent** client presents a user's
+ * `subject_token` and receives a delegated access token whose `sub` is the
+ * user and whose `act` (actor) claim identifies the agent (nested for chained
+ * delegation). This is an MCP auth *extension* (ext-auth), not core MCP.
+ *
+ * Security invariants (epic #181 default-deny: `is_agent` is self-asserted and
+ * NEVER sufficient on its own):
+ *  - GATE 1 — agent classification: `isAgentClient(client)` must hold AND the
+ *    client must be allowed the token-exchange grant. Non-agent clients are
+ *    rejected with `unauthorized_client` (RFC 6749 §5.2). The client is
+ *    already authenticated + enabled at this point (client-auth path).
+ *  - GATE 2 — token-type support: only `urn:...:token-type:access_token` is
+ *    accepted for `subject_token_type` / `actor_token_type` /
+ *    `requested_token_type`. Anything else → `invalid_request` (RFC 8693
+ *    §2.2.2).
+ *  - GATE 3 — subject-token validity: the subject token is cryptographically
+ *    verified (EdDSA signature + `exp`) via `jwtUtils.verifyAccessToken`. Since
+ *    QAuth's own signing key is the only key that verifies, a valid signature
+ *    establishes provenance (the `iss` claim itself is not separately asserted
+ *    by `verifyAccessToken`). An unverifiable / expired token →
+ *    `invalid_request` (the presented token is unacceptable, RFC 8693 §2.2.2).
+ *    The subject user must still exist and be enabled (RFC 9700 §4.14).
+ *  - GATE 4 — no privilege escalation: scope and audience are PRESERVED or
+ *    NARROWED relative to the subject token, never widened (RFC 8707 §2.2 /
+ *    RFC 8693). Up-scoping → `invalid_scope`; out-of-set audience →
+ *    `invalid_target`. Delegation depth is bounded by `MAX_DELEGATION_DEPTH`.
+ *
+ * No refresh token is issued — a delegated token is intentionally short-lived
+ * and the agent re-exchanges as needed.
+ *
+ * TODO(#184): scope modes (ReadOnly / Admin / Exec) are owned by the parallel
+ * scope-mode PR. This handler does generic scope preservation/narrowing only;
+ * once #184 lands, the narrowed scope set should additionally be clamped to
+ * the agent's `max_agent_mode`. The two integrate at that point.
+ */
+async function handleTokenExchange(
+  ctx: HandlerContext<TokenExchangeTokenExchangeBody>
+): Promise<TokenExchangeResponse> {
+  const { fastify, request, client, body } = ctx;
+
+  const auditFailure = async (error: string, extra?: Record<string, unknown>): Promise<void> => {
+    await fastify.repositories.auditLogs.create({
+      userId: null,
+      oauthClientId: client.id,
+      event: 'oauth.token.exchange.failure',
+      eventType: 'token',
+      success: false,
+      ipAddress: request.ip,
+      userAgent: request.headers['user-agent'] || null,
+      metadata: { error, grantType: 'token-exchange', ...extra },
+    });
+  };
+
+  // GATE 1 — agent classification + grant authorisation (default-deny).
+  // `isAgentClient` is fail-closed; a client that omitted `is_agent` reads as
+  // a non-agent and is rejected here.
+  if (!isAgentClient(client)) {
+    await auditFailure('unauthorized_client: token-exchange is restricted to agent clients');
+    throw new UnauthorizedClientError();
+  }
+  if (!client.grantTypes.includes(TOKEN_EXCHANGE_GRANT_TYPE)) {
+    await auditFailure('unauthorized_client: client not allowed the token-exchange grant');
+    throw new UnauthorizedClientError();
+  }
+
+  // GATE 2 — token-type support. We only mint/consume OAuth access tokens.
+  if (body.subject_token_type !== TOKEN_TYPE_ACCESS_TOKEN) {
+    await auditFailure('invalid_request: unsupported subject_token_type', {
+      subjectTokenType: body.subject_token_type,
+    });
+    throw new BadRequestError('invalid_request: unsupported subject_token_type');
+  }
+  if (
+    body.requested_token_type !== undefined &&
+    body.requested_token_type !== TOKEN_TYPE_ACCESS_TOKEN
+  ) {
+    await auditFailure('invalid_request: unsupported requested_token_type', {
+      requestedTokenType: body.requested_token_type,
+    });
+    throw new BadRequestError('invalid_request: unsupported requested_token_type');
+  }
+  // RFC 8693 §2.1: actor_token_type is REQUIRED when actor_token is present.
+  if (body.actor_token !== undefined && body.actor_token_type === undefined) {
+    await auditFailure('invalid_request: actor_token_type required when actor_token present');
+    throw new BadRequestError('invalid_request: actor_token_type is required with actor_token');
+  }
+  if (body.actor_token !== undefined && body.actor_token_type !== TOKEN_TYPE_ACCESS_TOKEN) {
+    await auditFailure('invalid_request: unsupported actor_token_type', {
+      actorTokenType: body.actor_token_type,
+    });
+    throw new BadRequestError('invalid_request: unsupported actor_token_type');
+  }
+
+  // GATE 3 — verify the subject token (EdDSA signature + exp). Only QAuth's
+  // signing key verifies, so a valid signature establishes provenance; an
+  // unverifiable or expired token is "unacceptable" → invalid_request.
+  let subjectPayload: Awaited<ReturnType<typeof fastify.jwtUtils.verifyAccessToken>>;
+  try {
+    subjectPayload = await fastify.jwtUtils.verifyAccessToken(body.subject_token);
+  } catch {
+    await auditFailure('invalid_request: subject_token failed verification');
+    throw new BadRequestError('invalid_request: subject_token is not a valid access token');
+  }
+  if (!subjectPayload.sub) {
+    await auditFailure('invalid_request: subject_token missing sub');
+    throw new BadRequestError('invalid_request: subject_token has no subject');
+  }
+
+  // If an actor_token is supplied, verify it too. We do not trust the agent's
+  // self-declared identity from an unverified token — the actor identity used
+  // in the `act` claim is the authenticated agent's own client_id (below).
+  let actorPayload: Awaited<ReturnType<typeof fastify.jwtUtils.verifyAccessToken>> | undefined;
+  if (body.actor_token !== undefined) {
+    try {
+      actorPayload = await fastify.jwtUtils.verifyAccessToken(body.actor_token);
+    } catch {
+      await auditFailure('invalid_request: actor_token failed verification');
+      throw new BadRequestError('invalid_request: actor_token is not a valid access token');
+    }
+  }
+
+  // The subject user must still exist and be enabled (RFC 9700 §4.14). We bind
+  // the delegated token's `sub` to the *current* user record, not blindly to
+  // the token's `sub` string.
+  const user = await fastify.repositories.users.findById(subjectPayload.sub);
+  if (!user) {
+    await auditFailure('invalid_request: subject user not found');
+    throw new BadRequestError('invalid_request: subject_token subject is unknown');
+  }
+  if (!user.enabled) {
+    await auditFailure('invalid_request: subject user disabled', { userId: user.id });
+    throw new BadRequestError('invalid_request: subject_token subject is not active');
+  }
+
+  // GATE 4a — scope narrowing. The delegated token's scope is the subject
+  // token's scope, optionally narrowed by the request. Up-scoping is rejected.
+  const subjectScopes = subjectPayload.scope
+    ? subjectPayload.scope.split(/\s+/).filter((s) => s.length > 0)
+    : [];
+  let grantedScopes: string[];
+  if (body.scope !== undefined && body.scope.trim().length > 0) {
+    const requested = body.scope.split(/\s+/).filter((s) => s.length > 0);
+    const extraneous = requested.filter((s) => !subjectScopes.includes(s));
+    if (extraneous.length > 0) {
+      await auditFailure('invalid_scope: requested scope exceeds subject token', {
+        extraneous,
+        subjectScopes,
+      });
+      throw new InvalidScopeError(`${extraneous.join(' ')} not in subject_token scope`);
+    }
+    grantedScopes = requested;
+  } else {
+    grantedScopes = subjectScopes;
+  }
+
+  // GATE 4b — audience narrowing (RFC 8707 §2.2 + RFC 8693 `audience`). The
+  // delegated token's `aud` is the subject token's `aud`, optionally narrowed
+  // by `resource` and/or `audience`. Any value outside the subject token's
+  // audience set is rejected (`invalid_target`) — never widen.
+  const subjectAudience = audToArray(subjectPayload.aud);
+  const requestedTargets = [...(body.resource ?? []), ...(body.audience ?? [])];
+  let effectiveAudience: string[];
+  if (requestedTargets.length > 0) {
+    const extra = requestedTargets.filter((t) => !subjectAudience.includes(t));
+    if (extra.length > 0) {
+      await auditFailure('invalid_target: requested audience outside subject token audience', {
+        extra,
+        subjectAudience,
+      });
+      throw new InvalidTargetError('requested resource/audience is outside the subject token');
+    }
+    effectiveAudience = requestedTargets;
+  } else {
+    effectiveAudience = subjectAudience;
+  }
+
+  // Build the RFC 8693 §4.1 `act` claim. The current actor (the authenticated
+  // agent) is the outermost `act`; any pre-existing delegation chain on the
+  // subject token is nested beneath it. This reflects the *real* actor — the
+  // agent's own client_id — not an unverified self-declaration.
+  const act: ActClaim = {
+    sub: client.clientId,
+    ...(subjectPayload.act ? { act: subjectPayload.act } : {}),
+  };
+
+  // Bound delegation depth: each re-exchange nests another `act`, growing the
+  // JWT unboundedly. Reject once the chain would exceed MAX_DELEGATION_DEPTH.
+  const depth = actDepth(act);
+  if (depth > MAX_DELEGATION_DEPTH) {
+    await auditFailure('invalid_request: delegation chain too deep', {
+      depth,
+      max: MAX_DELEGATION_DEPTH,
+    });
+    throw new BadRequestError('invalid_request: delegation chain exceeds the maximum depth');
+  }
+
+  const scopeString = grantedScopes.length > 0 ? grantedScopes.join(' ') : undefined;
+  // Preserve the subject token's aud when no narrowing was requested; fall back
+  // to resolveAudience's client default only if the subject had no aud at all.
+  const aud =
+    effectiveAudience.length > 0 ? arrayToAud(effectiveAudience) : resolveAudience(client);
+
+  const accessToken = await fastify.jwtUtils.signAccessToken({
+    sub: user.id,
+    email: user.email,
+    email_verified: user.emailVerified,
+    clientId: client.clientId,
+    scope: scopeString,
+    aud,
+    act,
+  });
+
+  const accessTokenExpiresIn = fastify.jwtUtils.getAccessTokenLifespan();
+
+  await fastify.repositories.auditLogs.create({
+    userId: user.id,
+    oauthClientId: client.id,
+    event: 'oauth.token.exchange.success',
+    eventType: 'token',
+    success: true,
+    ipAddress: request.ip,
+    userAgent: request.headers['user-agent'] || null,
+    metadata: {
+      grantType: 'token-exchange',
+      actor: client.clientId,
+      delegationDepth: actDepth(act),
+      hasActorToken: body.actor_token !== undefined,
+      actorTokenSubject: actorPayload?.sub,
+      scope: scopeString,
+      audience: effectiveAudience,
+    },
+  });
+
+  // RFC 8693 §2.2.1: token-exchange responses MUST include `issued_token_type`.
+  return {
+    access_token: accessToken,
+    issued_token_type: TOKEN_TYPE_ACCESS_TOKEN,
     expires_in: accessTokenExpiresIn,
     token_type: 'Bearer' as const,
     ...(scopeString ? { scope: scopeString } : {}),

--- a/apps/auth-server/src/app/routes/oauth/token.ts
+++ b/apps/auth-server/src/app/routes/oauth/token.ts
@@ -5,10 +5,9 @@ import {
   BadRequestError,
   InvalidClientError,
   InvalidGrantError,
+  InvalidRequestError,
   InvalidScopeError,
   InvalidTargetError,
-  JWTExpiredError,
-  JWTInvalidError,
   NotFoundError,
   UnauthorizedClientError,
 } from '@qauth-labs/shared-errors';
@@ -98,15 +97,7 @@ export default async function (fastify: FastifyInstance) {
         // 'none'`. client_credentials is confidential-only by definition.
         let client: OAuthClientLike;
         try {
-          if (
-            body.grant_type === 'authorization_code' ||
-            body.grant_type === 'refresh_token' ||
-            body.grant_type === TOKEN_EXCHANGE_GRANT_TYPE
-          ) {
-            // token-exchange agents may be public (PKCE-registered, no secret)
-            // or confidential; this resolver accepts both. The agent
-            // classification + subject-token validation gate the grant in the
-            // handler — client auth alone never authorises an exchange.
+          if (body.grant_type === 'authorization_code' || body.grant_type === 'refresh_token') {
             client = await authenticateClientPublicOrConfidential(
               fastify,
               realm.id,
@@ -115,6 +106,12 @@ export default async function (fastify: FastifyInstance) {
               body.client_secret
             );
           } else {
+            // client_credentials AND token-exchange are CONFIDENTIAL-ONLY. For
+            // token-exchange this is a deliberate security floor (RFC 9700,
+            // epic #181): on-behalf-of delegation must not be mintable by a
+            // public client that proves nothing but knowledge of a `client_id`.
+            // A public agent (token_endpoint_auth_method=none) presents no
+            // secret, so `extractClientCredentials` → `invalid_client`.
             const creds = extractClientCredentials(
               request as FastifyRequest,
               body.client_id,
@@ -188,10 +185,9 @@ export default async function (fastify: FastifyInstance) {
           error instanceof InvalidTargetError ||
           error instanceof InvalidClientError ||
           error instanceof InvalidScopeError ||
+          error instanceof InvalidRequestError ||
           error instanceof NotFoundError ||
           error instanceof BadRequestError ||
-          error instanceof JWTExpiredError ||
-          error instanceof JWTInvalidError ||
           error instanceof UnauthorizedClientError
         ) {
           await ensureMinimumResponseTime(startTime, MIN_RESPONSE_TIME_MS.TOKEN);
@@ -935,11 +931,13 @@ async function handleTokenExchange(
   }
 
   // GATE 2 — token-type support. We only mint/consume OAuth access tokens.
+  // OAuth error codes are the BARE token (RFC 6749 §5.2 / RFC 8693 §2.2.2);
+  // human detail goes in `error_description` via InvalidRequestError.
   if (body.subject_token_type !== TOKEN_TYPE_ACCESS_TOKEN) {
     await auditFailure('invalid_request: unsupported subject_token_type', {
       subjectTokenType: body.subject_token_type,
     });
-    throw new BadRequestError('invalid_request: unsupported subject_token_type');
+    throw new InvalidRequestError('unsupported subject_token_type');
   }
   if (
     body.requested_token_type !== undefined &&
@@ -948,18 +946,18 @@ async function handleTokenExchange(
     await auditFailure('invalid_request: unsupported requested_token_type', {
       requestedTokenType: body.requested_token_type,
     });
-    throw new BadRequestError('invalid_request: unsupported requested_token_type');
+    throw new InvalidRequestError('unsupported requested_token_type');
   }
   // RFC 8693 §2.1: actor_token_type is REQUIRED when actor_token is present.
   if (body.actor_token !== undefined && body.actor_token_type === undefined) {
     await auditFailure('invalid_request: actor_token_type required when actor_token present');
-    throw new BadRequestError('invalid_request: actor_token_type is required with actor_token');
+    throw new InvalidRequestError('actor_token_type is required when actor_token is present');
   }
   if (body.actor_token !== undefined && body.actor_token_type !== TOKEN_TYPE_ACCESS_TOKEN) {
     await auditFailure('invalid_request: unsupported actor_token_type', {
       actorTokenType: body.actor_token_type,
     });
-    throw new BadRequestError('invalid_request: unsupported actor_token_type');
+    throw new InvalidRequestError('unsupported actor_token_type');
   }
 
   // GATE 3 — verify the subject token (EdDSA signature + exp). Only QAuth's
@@ -970,11 +968,36 @@ async function handleTokenExchange(
     subjectPayload = await fastify.jwtUtils.verifyAccessToken(body.subject_token);
   } catch {
     await auditFailure('invalid_request: subject_token failed verification');
-    throw new BadRequestError('invalid_request: subject_token is not a valid access token');
+    throw new InvalidRequestError('subject_token is not a valid access token');
   }
   if (!subjectPayload.sub) {
     await auditFailure('invalid_request: subject_token missing sub');
-    throw new BadRequestError('invalid_request: subject_token has no subject');
+    throw new InvalidRequestError('subject_token has no subject');
+  }
+
+  // GATE 3b — token-confusion defence. `verifyAccessToken` proves the EdDSA
+  // signature + exp only; it does NOT assert issuer or token purpose. Without
+  // this check, ANY JWT QAuth signs with the same key (e.g. a future ID token)
+  // would verify and, if its `sub` resolved to a user, be accepted as a
+  // subject token. Require (a) our own issuer and (b) the access-token
+  // `token_use` marker. The marker is absent on legacy access tokens minted
+  // before it existed, so we accept its absence only when the structural
+  // access-token markers (`client_id` + `aud`) are present — never accept a
+  // token that positively declares a non-access `token_use`.
+  const expectedIssuer = fastify.jwtUtils.getIssuer();
+  const issuerOk = subjectPayload.iss === expectedIssuer;
+  const tokenUse = subjectPayload.token_use;
+  const isAccessToken =
+    tokenUse === 'access' ||
+    (tokenUse === undefined &&
+      subjectPayload.clientId !== undefined &&
+      subjectPayload.aud !== undefined);
+  if (!issuerOk || !isAccessToken) {
+    await auditFailure('invalid_request: subject_token is not a QAuth access token', {
+      issuerOk,
+      tokenUse: tokenUse ?? null,
+    });
+    throw new InvalidRequestError('subject_token is not a QAuth-issued access token');
   }
 
   // If an actor_token is supplied, verify it too. We do not trust the agent's
@@ -986,8 +1009,23 @@ async function handleTokenExchange(
       actorPayload = await fastify.jwtUtils.verifyAccessToken(body.actor_token);
     } catch {
       await auditFailure('invalid_request: actor_token failed verification');
-      throw new BadRequestError('invalid_request: actor_token is not a valid access token');
+      throw new InvalidRequestError('actor_token is not a valid access token');
     }
+  }
+
+  // GATE 3c — bind the subject token to the requesting agent (RFC 8693 leaves
+  // authorisation to AS policy; epic #181 default-deny). The subject token MUST
+  // have been minted for THIS agent: its `aud` must contain the agent's
+  // `client_id`. Without this, possession of ANY user's access token plus a
+  // known agent client_id would suffice to mint a delegated token. Combined
+  // with the confidential-client requirement (the agent proved its secret at
+  // the dispatch layer), this closes the unauthorized-delegation gap.
+  const subjectAudience = audToArray(subjectPayload.aud);
+  if (!subjectAudience.includes(client.clientId)) {
+    await auditFailure('invalid_request: subject_token not issued for this agent', {
+      subjectAudience,
+    });
+    throw new InvalidRequestError('subject_token was not issued for this client');
   }
 
   // The subject user must still exist and be enabled (RFC 9700 §4.14). We bind
@@ -996,11 +1034,11 @@ async function handleTokenExchange(
   const user = await fastify.repositories.users.findById(subjectPayload.sub);
   if (!user) {
     await auditFailure('invalid_request: subject user not found');
-    throw new BadRequestError('invalid_request: subject_token subject is unknown');
+    throw new InvalidRequestError('subject_token subject is unknown');
   }
   if (!user.enabled) {
     await auditFailure('invalid_request: subject user disabled', { userId: user.id });
-    throw new BadRequestError('invalid_request: subject_token subject is not active');
+    throw new InvalidRequestError('subject_token subject is not active');
   }
 
   // GATE 4a — scope narrowing. The delegated token's scope is the subject
@@ -1019,7 +1057,8 @@ async function handleTokenExchange(
       });
       throw new InvalidScopeError(`${extraneous.join(' ')} not in subject_token scope`);
     }
-    grantedScopes = requested;
+    // Dedupe so a repeated scope cannot bloat the minted claim.
+    grantedScopes = [...new Set(requested)];
   } else {
     grantedScopes = subjectScopes;
   }
@@ -1027,9 +1066,9 @@ async function handleTokenExchange(
   // GATE 4b — audience narrowing (RFC 8707 §2.2 + RFC 8693 `audience`). The
   // delegated token's `aud` is the subject token's `aud`, optionally narrowed
   // by `resource` and/or `audience`. Any value outside the subject token's
-  // audience set is rejected (`invalid_target`) — never widen.
-  const subjectAudience = audToArray(subjectPayload.aud);
-  const requestedTargets = [...(body.resource ?? []), ...(body.audience ?? [])];
+  // audience set is rejected (`invalid_target`) — never widen. Deduped to keep
+  // the minted claim bounded.
+  const requestedTargets = [...new Set([...(body.resource ?? []), ...(body.audience ?? [])])];
   let effectiveAudience: string[];
   if (requestedTargets.length > 0) {
     const extra = requestedTargets.filter((t) => !subjectAudience.includes(t));
@@ -1042,6 +1081,9 @@ async function handleTokenExchange(
     }
     effectiveAudience = requestedTargets;
   } else {
+    // Preserve the subject token's audience verbatim. The subject `aud` is
+    // always present (signing falls back to client_id) and was asserted to
+    // contain this agent above — so there is no agent-default fallback here.
     effectiveAudience = subjectAudience;
   }
 
@@ -1062,14 +1104,26 @@ async function handleTokenExchange(
       depth,
       max: MAX_DELEGATION_DEPTH,
     });
-    throw new BadRequestError('invalid_request: delegation chain exceeds the maximum depth');
+    throw new InvalidRequestError('delegation chain exceeds the maximum depth');
   }
 
   const scopeString = grantedScopes.length > 0 ? grantedScopes.join(' ') : undefined;
-  // Preserve the subject token's aud when no narrowing was requested; fall back
-  // to resolveAudience's client default only if the subject had no aud at all.
-  const aud =
-    effectiveAudience.length > 0 ? arrayToAud(effectiveAudience) : resolveAudience(client);
+  const aud = arrayToAud(effectiveAudience);
+
+  // Clamp lifespan so the delegated token NEVER outlives the subject token's
+  // authority (and so it cannot be re-exchanged to extend it indefinitely).
+  // `exp` is in seconds; verifyAccessToken already rejected an expired token,
+  // so remaining is > 0 here, but we guard against the boundary defensively.
+  const configuredLifespan = fastify.jwtUtils.getAccessTokenLifespan();
+  const subjectRemaining =
+    subjectPayload.exp !== undefined
+      ? subjectPayload.exp - Math.floor(Date.now() / 1000)
+      : configuredLifespan;
+  const accessTokenExpiresIn = Math.max(0, Math.min(configuredLifespan, subjectRemaining));
+  if (accessTokenExpiresIn <= 0) {
+    await auditFailure('invalid_request: subject_token has no remaining lifetime');
+    throw new InvalidRequestError('subject_token has expired');
+  }
 
   const accessToken = await fastify.jwtUtils.signAccessToken({
     sub: user.id,
@@ -1079,9 +1133,8 @@ async function handleTokenExchange(
     scope: scopeString,
     aud,
     act,
+    expiresInOverride: accessTokenExpiresIn,
   });
-
-  const accessTokenExpiresIn = fastify.jwtUtils.getAccessTokenLifespan();
 
   await fastify.repositories.auditLogs.create({
     userId: user.id,
@@ -1094,11 +1147,12 @@ async function handleTokenExchange(
     metadata: {
       grantType: 'token-exchange',
       actor: client.clientId,
-      delegationDepth: actDepth(act),
+      delegationDepth: depth,
       hasActorToken: body.actor_token !== undefined,
       actorTokenSubject: actorPayload?.sub,
       scope: scopeString,
       audience: effectiveAudience,
+      expiresIn: accessTokenExpiresIn,
     },
   });
 

--- a/apps/auth-server/src/app/schemas/oauth.ts
+++ b/apps/auth-server/src/app/schemas/oauth.ts
@@ -108,23 +108,86 @@ export const tokenExchangeRefreshBodySchema = z.object({
 });
 
 /**
+ * RFC 8693 OAuth 2.0 Token Exchange grant + token-type URIs.
+ *
+ * QAuth's agent-native on-behalf-of delegation (ADR-007 §2): an agent client
+ * exchanges a user's `subject_token` (and optionally an `actor_token`) for a
+ * delegated access token whose `sub` is the user and whose `act` claim
+ * identifies the agent. This is an MCP auth *extension* (ext-auth), not core.
+ */
+export const TOKEN_EXCHANGE_GRANT_TYPE = 'urn:ietf:params:oauth:grant-type:token-exchange';
+export const TOKEN_TYPE_ACCESS_TOKEN = 'urn:ietf:params:oauth:token-type:access_token';
+export const TOKEN_TYPE_REFRESH_TOKEN = 'urn:ietf:params:oauth:token-type:refresh_token';
+export const TOKEN_TYPE_JWT = 'urn:ietf:params:oauth:token-type:jwt';
+
+/**
+ * OAuth 2.0 Token Exchange body (POST /oauth/token, RFC 8693 §2.1).
+ *
+ * - `subject_token` / `subject_token_type` (REQUIRED): the token representing
+ *   the party on whose behalf the request is made (the end-user).
+ * - `actor_token` / `actor_token_type` (OPTIONAL): the token representing the
+ *   acting party. `actor_token_type` is REQUIRED when `actor_token` is present
+ *   (enforced in the handler so we can return a structured OAuth error).
+ * - `scope` / `resource` / `audience` (OPTIONAL): requested down-scoping /
+ *   audience targeting. Scope and audience are preserved or NARROWED, never
+ *   widened (handler-enforced).
+ * - `requested_token_type` (OPTIONAL): the desired issued-token type. Only
+ *   `...:access_token` is supported; validated in the handler.
+ *
+ * Token-type *values* are validated in the handler (not the schema) so an
+ * unsupported type surfaces as RFC 6749 §5.2 `invalid_request` rather than a
+ * generic Zod validation error, per RFC 8693 §2.2.2.
+ *
+ * `client_id` / `client_secret` are optional here for the same reason as the
+ * other grants — confidential clients may use `client_secret_basic`; agent
+ * public clients present only `client_id`. The handler authenticates the
+ * client and gates the grant on the agent classification (default-deny).
+ */
+export const tokenExchangeTokenExchangeBodySchema = z.object({
+  grant_type: z.literal(TOKEN_EXCHANGE_GRANT_TYPE),
+  subject_token: z.string().min(1).max(8192),
+  subject_token_type: z.string().min(1).max(256),
+  actor_token: z.string().min(1).max(8192).optional(),
+  actor_token_type: z.string().min(1).max(256).optional(),
+  requested_token_type: z.string().min(1).max(256).optional(),
+  client_id: z.string().min(1).optional(),
+  client_secret: z.string().min(1).optional(),
+  scope: z.string().max(2048).optional(),
+  // RFC 8693 §2.1 `audience` — logical target name(s). Accepted as string or
+  // array; the handler treats it together with `resource` for aud narrowing.
+  audience: z
+    .union([z.string().min(1).max(2048), z.array(z.string().min(1).max(2048)).max(10)])
+    .optional()
+    .transform((v) => (v === undefined ? undefined : Array.isArray(v) ? v : [v])),
+  // RFC 8707 §2: resource indicators; MUST be a subset of the subject token's
+  // audience. Enforced in the handler.
+  resource: resourceParamSchema,
+});
+
+/**
  * Discriminated union of supported token grant bodies.
  */
 export const tokenExchangeBodySchema = z.discriminatedUnion('grant_type', [
   tokenExchangeAuthCodeBodySchema,
   tokenExchangeClientCredsBodySchema,
   tokenExchangeRefreshBodySchema,
+  tokenExchangeTokenExchangeBodySchema,
 ]);
 
 export type TokenExchangeAuthCodeBody = z.infer<typeof tokenExchangeAuthCodeBodySchema>;
 export type TokenExchangeClientCredsBody = z.infer<typeof tokenExchangeClientCredsBodySchema>;
 export type TokenExchangeRefreshBody = z.infer<typeof tokenExchangeRefreshBodySchema>;
+export type TokenExchangeTokenExchangeBody = z.infer<typeof tokenExchangeTokenExchangeBodySchema>;
 export type TokenExchangeBody = z.infer<typeof tokenExchangeBodySchema>;
 
 /**
  * OAuth token response.
  * RFC 6749 5.1. `refresh_token` and `scope` are optional (client_credentials
  * grants MUST NOT include refresh_token per RFC 6749 4.4.3).
+ *
+ * `issued_token_type` (RFC 8693 §2.2.1) is REQUIRED in a token-exchange
+ * response and absent for the other grants; we always emit
+ * `...:access_token` for the delegated token-exchange path.
  */
 export const tokenExchangeResponseSchema = z.object({
   access_token: z.string(),
@@ -132,6 +195,7 @@ export const tokenExchangeResponseSchema = z.object({
   expires_in: z.number(),
   token_type: z.literal('Bearer'),
   scope: z.string().optional(),
+  issued_token_type: z.string().optional(),
 });
 
 export type TokenExchangeResponse = z.infer<typeof tokenExchangeResponseSchema>;

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -136,13 +136,13 @@ per-window caps).
 Full request/response detail and a worked end-to-end walkthrough live in the
 [OAuth 2.1 Flow](./oauth-flow.md) guide. Contract summary:
 
-| Endpoint                                                                    | Method | Body type | Purpose                                                       |
-| --------------------------------------------------------------------------- | ------ | --------- | ------------------------------------------------------------- |
-| [`/oauth/authorize`](./oauth-flow.md#2-redirect-the-user-to-oauthauthorize) | GET    | query     | Start `authorization_code` + PKCE (browser)                   |
-| [`/oauth/token`](./oauth-flow.md#3-exchange-the-code-for-tokens)            | POST   | form      | `authorization_code` / `refresh_token` / `client_credentials` |
-| [`/oauth/introspect`](./oauth-flow.md#token-introspection-rfc-7662)         | POST   | form      | Token introspection (RFC 7662) — confidential clients only    |
-| [`/oauth/userinfo`](./oauth-flow.md#userinfo-oidc)                          | GET    | —         | OIDC UserInfo (Bearer)                                        |
-| [`/oauth/register`](./oauth-flow.md#dynamic-client-registration-rfc-7591)   | POST   | JSON      | Dynamic Client Registration (RFC 7591, open mode)             |
+| Endpoint                                                                    | Method | Body type | Purpose                                                                                     |
+| --------------------------------------------------------------------------- | ------ | --------- | ------------------------------------------------------------------------------------------- |
+| [`/oauth/authorize`](./oauth-flow.md#2-redirect-the-user-to-oauthauthorize) | GET    | query     | Start `authorization_code` + PKCE (browser)                                                 |
+| [`/oauth/token`](./oauth-flow.md#3-exchange-the-code-for-tokens)            | POST   | form      | `authorization_code` / `refresh_token` / `client_credentials` / `token-exchange` (RFC 8693) |
+| [`/oauth/introspect`](./oauth-flow.md#token-introspection-rfc-7662)         | POST   | form      | Token introspection (RFC 7662) — confidential clients only                                  |
+| [`/oauth/userinfo`](./oauth-flow.md#userinfo-oidc)                          | GET    | —         | OIDC UserInfo (Bearer)                                                                      |
+| [`/oauth/register`](./oauth-flow.md#dynamic-client-registration-rfc-7591)   | POST   | JSON      | Dynamic Client Registration (RFC 7591, open mode)                                           |
 
 Key contract facts:
 
@@ -151,16 +151,23 @@ Key contract facts:
 - `client_credentials` tokens set `sub = client_id` and issue **no** refresh token.
 - Scopes are **deny-by-default** (client allowlist; DCR clients capped to the
   realm's `DEFAULT_DYNAMIC_REGISTRATION_SCOPES`).
+- The `urn:ietf:params:oauth:grant-type:token-exchange` grant (RFC 8693, ADR-007 §2)
+  lets an **agent** client delegate on behalf of a user: `sub` stays the user and
+  an `act` claim names the agent (nested for chained delegation). Agent-only and
+  default-deny; scope/audience are preserved or narrowed, never widened. See the
+  [Token Exchange](./oauth-flow.md#token-exchange--agent-on-behalf-of-delegation-rfc-8693)
+  section.
 
 ### Token response (`POST /oauth/token`, `200 OK`)
 
 ```json
 {
   "access_token": "eyJ…",
-  "refresh_token": "a1b2…", // omitted for client_credentials
+  "refresh_token": "a1b2…", // omitted for client_credentials and token-exchange
   "expires_in": 900,
   "token_type": "Bearer",
-  "scope": "openid profile email" // present when scopes granted
+  "scope": "openid profile email", // present when scopes granted
+  "issued_token_type": "urn:ietf:params:oauth:token-type:access_token" // token-exchange only (RFC 8693 §2.2.1)
 }
 ```
 

--- a/docs/oauth-flow.md
+++ b/docs/oauth-flow.md
@@ -43,11 +43,12 @@ curl -s http://localhost:3000/.well-known/oauth-authorization-server | jq
 
 ## Grant types
 
-| Grant                         | Subject (`sub`) | Refresh token?       | Use case                                   |
-| ----------------------------- | --------------- | -------------------- | ------------------------------------------ |
-| `authorization_code` (+ PKCE) | the end user    | yes                  | Apps acting **on behalf of a user**        |
-| `refresh_token`               | the end user    | yes (rotated)        | Renew an access token without re-prompting |
-| `client_credentials`          | the `client_id` | no (RFC 6749 §4.4.3) | **Machine-to-machine**, no user            |
+| Grant                                             | Subject (`sub`) | Refresh token?       | Use case                                            |
+| ------------------------------------------------- | --------------- | -------------------- | --------------------------------------------------- |
+| `authorization_code` (+ PKCE)                     | the end user    | yes                  | Apps acting **on behalf of a user**                 |
+| `refresh_token`                                   | the end user    | yes (rotated)        | Renew an access token without re-prompting          |
+| `client_credentials`                              | the `client_id` | no (RFC 6749 §4.4.3) | **Machine-to-machine**, no user                     |
+| `urn:ietf:params:oauth:grant-type:token-exchange` | the end user    | no                   | **Agent delegation** on behalf of a user (RFC 8693) |
 
 `response_type` is `code` only. There is no implicit or password grant
 (removed in OAuth 2.1).
@@ -228,6 +229,62 @@ curl -s -X POST http://localhost:3000/oauth/token \
 - Provision such clients with the seed script (it lets you set `scopes` and
   `audience` explicitly) — see the
   [MCP Quickstart, Option B](./mcp-quickstart.md#option-b--verify-the-handshake-with-curl-no-browser).
+
+---
+
+## Token Exchange — agent on-behalf-of delegation (RFC 8693)
+
+> ADR-007 §2 / agent-native authorization. On-behalf-of delegation is an MCP
+> auth **extension** ([ext-auth](https://github.com/modelcontextprotocol/ext-auth)),
+> not core MCP — QAuth provides it as a value-add.
+
+An **agent** client exchanges a user's access token (`subject_token`) for a
+delegated access token whose `sub` is the user and whose `act` (actor) claim
+identifies the agent. Chained delegation nests `act` (RFC 8693 §4.1).
+
+```bash
+curl -s -X POST http://localhost:3000/oauth/token \
+  -u "AGENT_CLIENT_ID:AGENT_CLIENT_SECRET" \
+  -H 'Content-Type: application/x-www-form-urlencoded' \
+  -d grant_type=urn:ietf:params:oauth:grant-type:token-exchange \
+  -d subject_token=USERS_ACCESS_TOKEN \
+  -d subject_token_type=urn:ietf:params:oauth:token-type:access_token \
+  -d 'scope=read:docs' | jq
+```
+
+Response (`issued_token_type` is required by RFC 8693 §2.2.1):
+
+```jsonc
+{
+  "access_token": "eyJ…", // sub = user, act = { "sub": "AGENT_CLIENT_ID" }
+  "issued_token_type": "urn:ietf:params:oauth:token-type:access_token",
+  "token_type": "Bearer",
+  "expires_in": 900,
+  "scope": "read:docs",
+}
+```
+
+Rules and guarantees:
+
+- **Agent-only, default-deny.** Only clients classified as agents
+  (`is_agent: true`) **and** granted the token-exchange grant type may use it.
+  Because `is_agent` is self-asserted, the server never trusts it alone — it
+  also verifies the subject token (signature / `iss` / `exp`), that the client
+  is enabled, and that the subject user exists and is enabled. Non-agent clients
+  get `unauthorized_client`.
+- **Down-scoping only.** `scope` must be a subset of the subject token's scope
+  (else `invalid_scope`); omit it to inherit the full set. `resource` /
+  `audience` must fall within the subject token's `aud` (else `invalid_target`).
+  Scope and audience are preserved or narrowed — **never widened**.
+- **Token types.** Only
+  `urn:ietf:params:oauth:token-type:access_token` is supported for
+  `subject_token_type` / `actor_token_type` / `requested_token_type`; anything
+  else returns `invalid_request`. An optional `actor_token` (the acting party)
+  requires `actor_token_type` when present.
+- **No refresh token** is issued — a delegated token is short-lived; the agent
+  re-exchanges as needed.
+- Every exchange (success and failure) is written to `audit_logs`, including the
+  actor and delegation depth.
 
 ---
 

--- a/docs/oauth-flow.md
+++ b/docs/oauth-flow.md
@@ -268,19 +268,32 @@ Rules and guarantees:
 
 - **Agent-only, default-deny.** Only clients classified as agents
   (`is_agent: true`) **and** granted the token-exchange grant type may use it.
-  Because `is_agent` is self-asserted, the server never trusts it alone — it
-  also verifies the subject token (signature / `iss` / `exp`), that the client
-  is enabled, and that the subject user exists and is enabled. Non-agent clients
-  get `unauthorized_client`.
+  Because `is_agent` is self-asserted, the server never trusts it alone.
+- **Confidential clients only.** The token-exchange grant requires confidential
+  client authentication (`client_secret_basic` / `client_secret_post`); a public
+  agent (`token_endpoint_auth_method=none`) is rejected with `invalid_client`.
+- **Subject token must be bound to the agent.** The `subject_token` must be a
+  QAuth-issued **access token** (verified EdDSA signature + `exp`, matching
+  issuer, and an `access`-use marker — ID tokens and other JWTs are rejected
+  with `invalid_request`) **and** its `aud` must contain the requesting agent's
+  `client_id` — i.e. the token was minted for this agent. Together with the
+  confidential-client requirement, this prevents an attacker from minting a
+  delegated token from any captured user token plus a known agent `client_id`.
+  The subject user must also exist and be enabled.
 - **Down-scoping only.** `scope` must be a subset of the subject token's scope
   (else `invalid_scope`); omit it to inherit the full set. `resource` /
   `audience` must fall within the subject token's `aud` (else `invalid_target`).
   Scope and audience are preserved or narrowed — **never widened**.
+- **Lifetime never exceeds the subject token.** The delegated token's
+  `expires_in` is clamped to `min(configured_lifespan, subject_token_remaining)`,
+  so delegation can never outlast the authority it derives from.
 - **Token types.** Only
   `urn:ietf:params:oauth:token-type:access_token` is supported for
   `subject_token_type` / `actor_token_type` / `requested_token_type`; anything
   else returns `invalid_request`. An optional `actor_token` (the acting party)
   requires `actor_token_type` when present.
+- **Bounded delegation depth.** Chained re-exchanges are capped (the nested
+  `act` chain may not exceed 4 actors); deeper requests get `invalid_request`.
 - **No refresh token** is issued — a delegated token is short-lived; the agent
   re-exchanges as needed.
 - Every exchange (success and failure) is written to `audit_logs`, including the

--- a/libs/fastify/plugins/jwt/src/lib/fastify-plugin-jwt.ts
+++ b/libs/fastify/plugins/jwt/src/lib/fastify-plugin-jwt.ts
@@ -75,7 +75,13 @@ export const jwtPlugin = fp<JwtPluginOptions>(
 
     const jwtUtils: JwtUtils = {
       async signAccessToken(payload) {
-        return signAccessToken(payload, privateKey, options.issuer, options.accessTokenLifespan);
+        // `expiresInOverride` lets callers shorten a token below the configured
+        // lifespan (e.g. RFC 8693 token-exchange clamps to the subject token's
+        // remaining lifetime). It can only narrow — the value is passed through
+        // verbatim and callers compute the clamped seconds. Never widens here.
+        const { expiresInOverride, ...claims } = payload;
+        const expiresIn = expiresInOverride ?? options.accessTokenLifespan;
+        return signAccessToken(claims, privateKey, options.issuer, expiresIn);
       },
       generateRefreshToken() {
         return generateRefreshToken();

--- a/libs/fastify/plugins/jwt/src/types.ts
+++ b/libs/fastify/plugins/jwt/src/types.ts
@@ -1,4 +1,4 @@
-import type { JWTPayload, PublicJwk } from '@qauth-labs/server-jwt';
+import type { ActClaim, JWTPayload, PublicJwk } from '@qauth-labs/server-jwt';
 import type { FastifyPluginOptions } from 'fastify';
 
 /**
@@ -30,10 +30,10 @@ export interface Jwks {
 }
 
 /**
- * JWT payload structure
+ * JWT payload structure and the RFC 8693 `act` (actor) claim shape.
  * Re-exported to avoid apps needing direct dependency on @qauth-labs/server-jwt
  */
-export type { JWTPayload };
+export type { ActClaim, JWTPayload };
 
 /**
  * JWT utilities interface
@@ -47,6 +47,10 @@ export interface JwtUtils {
    * login) pass `email` / `email_verified`. For client_credentials grants
    * omit them and set `sub` to the `clientId`. `scope` is space-separated
    * per RFC 6749. `aud` falls back to `clientId` when undefined.
+   *
+   * For the RFC 8693 token-exchange grant, pass `act` to stamp the acting
+   * agent into the delegated token (`sub` stays the end-user). `act` is
+   * omitted for every non-delegated token.
    */
   signAccessToken(payload: {
     sub: string;
@@ -55,6 +59,7 @@ export interface JwtUtils {
     clientId: string;
     scope?: string;
     aud?: string | string[];
+    act?: ActClaim;
   }): Promise<string>;
   /**
    * Generate a refresh token pair (token and hash)

--- a/libs/fastify/plugins/jwt/src/types.ts
+++ b/libs/fastify/plugins/jwt/src/types.ts
@@ -50,7 +50,8 @@ export interface JwtUtils {
    *
    * For the RFC 8693 token-exchange grant, pass `act` to stamp the acting
    * agent into the delegated token (`sub` stays the end-user). `act` is
-   * omitted for every non-delegated token.
+   * omitted for every non-delegated token. Pass `expiresInOverride` to clamp
+   * the delegated token's lifetime to the subject token's remaining lifetime.
    */
   signAccessToken(payload: {
     sub: string;
@@ -60,6 +61,13 @@ export interface JwtUtils {
     scope?: string;
     aud?: string | string[];
     act?: ActClaim;
+    /**
+     * Override the access-token lifespan (seconds). Intended to SHORTEN a token
+     * below the configured default — the token-exchange grant clamps the
+     * delegated token so it never outlives the subject token. Omitted for
+     * normal grants (uses the configured lifespan).
+     */
+    expiresInOverride?: number;
   }): Promise<string>;
   /**
    * Generate a refresh token pair (token and hash)

--- a/libs/server/jwt/src/lib/jwt-service.test.ts
+++ b/libs/server/jwt/src/lib/jwt-service.test.ts
@@ -41,6 +41,8 @@ describe('signAccessToken', () => {
     expect(decoded.iss).toBe('https://auth.example.com');
     expect(decoded.iat).toBeDefined();
     expect(decoded.exp).toBeDefined();
+    // Token-use marker is always stamped (token-confusion defence).
+    expect(decoded.token_use).toBe('access');
   });
 
   it('should set expiration time correctly', async () => {

--- a/libs/server/jwt/src/lib/jwt-service.test.ts
+++ b/libs/server/jwt/src/lib/jwt-service.test.ts
@@ -66,6 +66,31 @@ describe('signAccessToken', () => {
       expect(actualExpiration).toBeLessThanOrEqual(expiresIn + 1);
     }
   });
+
+  it('emits and round-trips a nested RFC 8693 act claim when provided', async () => {
+    const { privateKey, publicKey } = await generateEdDSAKeyPair();
+    const payload = {
+      sub: 'user-deleg',
+      clientId: 'agent-client',
+      act: { sub: 'agent-client', act: { sub: 'prior-agent' } },
+    };
+
+    const token = await signAccessToken(payload, privateKey, 'https://auth.example.com', 900);
+    const decoded = await verifyAccessToken(token, publicKey);
+
+    expect(decoded.sub).toBe('user-deleg');
+    expect(decoded.act).toEqual({ sub: 'agent-client', act: { sub: 'prior-agent' } });
+  });
+
+  it('omits the act claim when not provided (non-delegated token)', async () => {
+    const { privateKey, publicKey } = await generateEdDSAKeyPair();
+    const payload = { sub: 'user-plain', clientId: 'app-client' };
+
+    const token = await signAccessToken(payload, privateKey, 'https://auth.example.com', 900);
+    const decoded = await verifyAccessToken(token, publicKey);
+
+    expect(decoded.act).toBeUndefined();
+  });
 });
 
 describe('verifyAccessToken', () => {

--- a/libs/server/jwt/src/lib/jwt-service.ts
+++ b/libs/server/jwt/src/lib/jwt-service.ts
@@ -46,6 +46,12 @@ export async function signAccessToken(
   if (payload.scope !== undefined && payload.scope.length > 0) {
     claims['scope'] = payload.scope;
   }
+  // RFC 8693 §4.1: emit the `act` (actor) claim only on delegated tokens minted
+  // via token-exchange. It is additive — `sub` stays the end-user; `act`
+  // identifies the acting agent (nested for chained delegation).
+  if (payload.act !== undefined) {
+    claims['act'] = payload.act;
+  }
 
   let jwt = new SignJWT(claims)
     .setProtectedHeader({ alg: 'EdDSA' })
@@ -106,6 +112,9 @@ export async function verifyAccessToken(
       clientId: payload['client_id'] as string,
       scope: payload['scope'] as string | undefined,
       aud: payload.aud as string | string[] | undefined,
+      // RFC 8693 §4.1: surface any existing `act` chain so a subject token
+      // already carrying a delegation can be nested under the new actor.
+      act: payload['act'] as JWTPayload['act'],
       iat: payload.iat as number | undefined,
       exp: payload.exp as number | undefined,
       iss: payload.iss as string | undefined,

--- a/libs/server/jwt/src/lib/jwt-service.ts
+++ b/libs/server/jwt/src/lib/jwt-service.ts
@@ -36,6 +36,11 @@ export async function signAccessToken(
   const claims: Record<string, unknown> = {
     sub: payload.sub,
     client_id: payload.clientId,
+    // Token-use marker (token-confusion defence): every token minted by this
+    // function is an OAuth access token. Consumers that must accept ONLY access
+    // tokens — e.g. RFC 8693 token-exchange subject tokens — assert this so a
+    // differently-purposed JWT signed with the same key cannot be substituted.
+    token_use: 'access',
   };
   if (payload.email !== undefined) {
     claims['email'] = payload.email;
@@ -118,6 +123,7 @@ export async function verifyAccessToken(
       iat: payload.iat as number | undefined,
       exp: payload.exp as number | undefined,
       iss: payload.iss as string | undefined,
+      token_use: payload['token_use'] as string | undefined,
     };
   } catch (error) {
     if (error instanceof Error) {

--- a/libs/server/jwt/src/types/jwt-service.ts
+++ b/libs/server/jwt/src/types/jwt-service.ts
@@ -1,4 +1,25 @@
 /**
+ * RFC 8693 §4.1 `act` (actor) claim.
+ *
+ * Identifies the party acting on behalf of the subject. A delegation chain is
+ * expressed by nesting: the outermost `act` is the current (most recent)
+ * actor, and each nested `act` is a prior actor. The only claim REQUIRED by
+ * RFC 8693 is `sub`; additional identity claims MAY be present.
+ *
+ * @example
+ * ```jsonc
+ * // user delegated to agentA, which further delegated to agentB:
+ * { "sub": "user-uuid", "act": { "sub": "agentB", "act": { "sub": "agentA" } } }
+ * ```
+ */
+export interface ActClaim {
+  /** Identifier of the actor (for QAuth, the agent client's `client_id`). */
+  sub: string;
+  /** Nested prior actor in the delegation chain (RFC 8693 §4.1). */
+  act?: ActClaim;
+}
+
+/**
  * Payload for signing access tokens
  *
  * When `email` / `email_verified` are omitted, the token is a client-only
@@ -23,6 +44,13 @@ export interface SignAccessTokenPayload {
    * String or array of strings; falls back to `clientId` when absent.
    */
   aud?: string | string[];
+  /**
+   * RFC 8693 §4.1 `act` (actor) claim — present only on delegated tokens
+   * minted via the token-exchange grant. `sub` stays the end-user; `act`
+   * identifies the acting agent (nested for chained delegation). Omitted for
+   * all non-delegated tokens.
+   */
+  act?: ActClaim;
 }
 
 /**

--- a/libs/server/jwt/src/types/jwt-service.ts
+++ b/libs/server/jwt/src/types/jwt-service.ts
@@ -63,4 +63,12 @@ export interface JWTPayload extends SignAccessTokenPayload {
   exp?: number;
   /** Issuer */
   iss?: string;
+  /**
+   * Token-use marker. `signAccessToken` always stamps `'access'` so consumers
+   * can distinguish a genuine access token from any other JWT signed with the
+   * same key (token-confusion defence — e.g. an ID token must not be accepted
+   * as a `subject_token` at the token-exchange endpoint). Absent on legacy
+   * tokens minted before this marker existed.
+   */
+  token_use?: string;
 }

--- a/libs/shared/errors/src/lib/auth/index.ts
+++ b/libs/shared/errors/src/lib/auth/index.ts
@@ -3,6 +3,7 @@ export * from './email-not-verified.error';
 export * from './invalid-client.error';
 export * from './invalid-credentials.error';
 export * from './invalid-grant.error';
+export * from './invalid-request.error';
 export * from './invalid-scope.error';
 export * from './invalid-target.error';
 export * from './invalid-token.error';

--- a/libs/shared/errors/src/lib/auth/invalid-request.error.ts
+++ b/libs/shared/errors/src/lib/auth/invalid-request.error.ts
@@ -1,0 +1,26 @@
+/**
+ * Error thrown when an OAuth request is malformed or otherwise unacceptable
+ * (RFC 6749 §5.2 `invalid_request`, RFC 8693 §2.2.2) — e.g. an unsupported
+ * token type, an unverifiable / non-conformant `subject_token`, or a
+ * delegation chain that exceeds policy limits at the token endpoint.
+ *
+ * Human-readable detail lives in `errorDescription` so the wire response
+ * carries the bare `error: "invalid_request"` token plus a separate
+ * `error_description` field. OAuth client libraries key off the exact bare
+ * code (RFC 6749 §5.2), so the sentence MUST NOT be folded into `error`.
+ */
+export class InvalidRequestError extends Error {
+  readonly statusCode = 400;
+  readonly code = 'INVALID_REQUEST';
+  readonly errorDescription?: string;
+
+  constructor(errorDescription?: string) {
+    super('invalid_request');
+    this.name = 'InvalidRequestError';
+    this.errorDescription = errorDescription;
+    Object.setPrototypeOf(this, InvalidRequestError.prototype);
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, InvalidRequestError);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Implements **OAuth 2.0 Token Exchange (RFC 8693)** at `POST /oauth/token` (ADR-007 §2, epic #181). An **agent** client exchanges a user's `subject_token` (+ optional `actor_token`) for a delegated access token whose `sub` is the user and whose **`act`** claim identifies the agent — nested for chained delegation. On-behalf-of delegation is an MCP auth **extension** ([ext-auth](https://github.com/modelcontextprotocol/ext-auth)), not core MCP; QAuth ships it as a value-add.

`grant_type = urn:ietf:params:oauth:grant-type:token-exchange`.

## Security (default-deny — `is_agent` is self-asserted, never trusted alone)

Per epic #181, the exchange is gated on the agent classification **plus** independent server-side checks:

- **GATE 1** — `isAgentClient(client)` (fail-closed; a client that omits `is_agent` reads as non-agent) **and** the client must be granted the token-exchange grant type. Non-agent / non-granted → `unauthorized_client`, before any token verification or minting.
- **GATE 2** — only `urn:ietf:params:oauth:token-type:access_token` is accepted for `subject_token_type` / `requested_token_type` / `actor_token_type`; anything else → `invalid_request`. `actor_token_type` is required when `actor_token` is present (RFC 8693 §2.1).
- **GATE 3** — the subject token is verified (EdDSA signature + `exp`); the subject user must exist and be enabled (RFC 9700 §4.14). Unacceptable token → `invalid_request`.
- **GATE 4** — scope and audience (RFC 8707) are **preserved or narrowed, never widened**. Up-scoping → `invalid_scope`; out-of-set audience/resource → `invalid_target`. Delegation depth is bounded (`MAX_DELEGATION_DEPTH = 4`).

The `act` actor is always the authenticated agent's own `client_id` — never an unverified self-declaration from the actor token. Every exchange (success and failure) is written to `audit_logs`. No refresh token is issued (delegated tokens are short-lived).

## `act` claim shape (RFC 8693 §4.1)

Outermost `act` = current actor; prior delegations nested beneath:

```jsonc
{
  "sub": "user-uuid",                 // the end-user
  "act": {
    "sub": "agent-client",            // current acting agent
    "act": { "sub": "prior-agent" }   // earlier actor in the chain
  }
}
```

Response includes the RFC 8693 §2.2.1 `issued_token_type: urn:ietf:params:oauth:token-type:access_token`.

## Changes

- `schemas/oauth.ts` — token-exchange body added to the discriminated union; `issued_token_type` on the response; grant-type / token-type URN constants.
- `routes/oauth/token.ts` — `handleTokenExchange` dispatch + handler.
- `libs/server/jwt` + `libs/fastify/plugins/jwt` — `signAccessToken` accepts/emits an `act` claim; `verifyAccessToken` surfaces an existing `act` chain for nesting; `ActClaim` type.
- `helpers/discovery.ts` — advertise the grant in `grant_types_supported`.
- Tests: RFC 8693 success (correct `act`, narrowed scope/aud, chained nesting, actor-token) + errors (`invalid_request`, `invalid_scope`, `invalid_target`, unsupported token types, non-agent rejected, disabled user, over-deep chain); server-jwt `act` round-trip.
- Docs: `docs/oauth-flow.md` Token Exchange section + `docs/api-reference.md`.

## #184 integration follow-up

This handler does **generic** scope preservation/narrowing only — it deliberately does **not** touch `helpers/scope-modes.ts`, `client-auth.ts` scope-mode logic, or add a `max_agent_mode` column (owned by the parallel scope-modes PR #184). A `// TODO(#184)` marks where the narrowed scope set should additionally be clamped to the agent's `max_agent_mode` once #184 lands.

## Verification

`pnpm nx run-many -t lint typecheck test build -p auth-server infra-db` — green (also green for `server-jwt` / `fastify-plugin-jwt`).

Closes #183

https://claude.ai/code/session_01Re2rxPkdcgzJe7LSddhxv6