### PR TITLE
feat(oauth): step-up authentication before dangerous operations (#185)

### DIFF
--- a/apps/auth-server/src/app/constants/security.ts
+++ b/apps/auth-server/src/app/constants/security.ts
@@ -9,13 +9,19 @@ export const AUTHORIZATION_CODE_TTL_MS = 5 * 60 * 1000;
  * Step-up authentication freshness window in milliseconds (ADR-007 §2, #185).
  *
  * When a request triggers a fresh-authentication step-up (`prompt=login` or a
- * dangerous elevated scope), an authentication performed within this window is
- * accepted as "fresh". This both (a) prevents an infinite login→authorize→login
- * redirect loop after the user re-authenticates, and (b) bounds how long a
- * single re-authentication stays valid for issuing a dangerous/elevated grant.
- * Exact `max_age` requests are enforced against their own value and are NOT
- * widened by this window. Two minutes balances usability against the
- * "authenticate immediately before the dangerous operation" intent.
+ * dangerous scope), an authentication performed within this window is accepted
+ * as "fresh". This both (a) prevents an infinite login→authorize→login redirect
+ * loop after the user re-authenticates, and (b) bounds how long a single
+ * re-authentication stays valid for issuing a dangerous/elevated grant.
+ *
+ * Tradeoff: a dangerous scope is satisfied by ANY authentication within this
+ * window — including an unrelated login that happened ~110s earlier — so the
+ * window is a deliberate usability relaxation of the dangerous-op gate, not a
+ * guarantee of an immediate prompt. A relying party (e.g. `mcp-guard`) that
+ * needs *exact* immediacy must send `max_age` (e.g. `max_age=0`), which is
+ * enforced against its own value at OIDC second-granularity and is NOT widened
+ * by this window. Two minutes balances usability against the "authenticate
+ * shortly before the dangerous operation" intent.
  */
 export const STEP_UP_FRESH_AUTH_WINDOW_MS = 2 * 60 * 1000;
 

--- a/apps/auth-server/src/app/constants/security.ts
+++ b/apps/auth-server/src/app/constants/security.ts
@@ -6,6 +6,20 @@
 export const AUTHORIZATION_CODE_TTL_MS = 5 * 60 * 1000;
 
 /**
+ * Step-up authentication freshness window in milliseconds (ADR-007 §2, #185).
+ *
+ * When a request triggers a fresh-authentication step-up (`prompt=login` or a
+ * dangerous elevated scope), an authentication performed within this window is
+ * accepted as "fresh". This both (a) prevents an infinite login→authorize→login
+ * redirect loop after the user re-authenticates, and (b) bounds how long a
+ * single re-authentication stays valid for issuing a dangerous/elevated grant.
+ * Exact `max_age` requests are enforced against their own value and are NOT
+ * widened by this window. Two minutes balances usability against the
+ * "authenticate immediately before the dangerous operation" intent.
+ */
+export const STEP_UP_FRESH_AUTH_WINDOW_MS = 2 * 60 * 1000;
+
+/**
  * Minimum response time in milliseconds to prevent timing attacks
  * Used in authentication endpoints to prevent user enumeration
  */

--- a/apps/auth-server/src/app/helpers/client-auth.test.ts
+++ b/apps/auth-server/src/app/helpers/client-auth.test.ts
@@ -302,14 +302,13 @@ describe('enforceAgentScopeCap', () => {
     ).toThrow(InvalidScopeError);
   });
 
-  // Tracking marker so the client_credentials cap wiring cannot ship forgotten.
-  // token.ts is owned by the parallel token-exchange PR (#191, issue #183); the
-  // one-line integration is `validateScopes(body.scope, client.scopes,
-  // toAgentScopeContext(client))` on the client_credentials path. The helpers
-  // here (validateScopes' optional agent arg + toAgentScopeContext) are ready.
-  it.todo(
-    'TODO(#184): client_credentials grant must enforce the cap via validateScopes(..., toAgentScopeContext(client)) — wire in PR #191'
-  );
+  // #184 cap wiring is now live in routes/oauth/token.ts:
+  //   - client_credentials: validateScopes(body.scope, client.scopes,
+  //     toAgentScopeContext(client))
+  //   - token-exchange: enforceAgentScopeCap(grantedScopes,
+  //     toAgentScopeContext(client)) after scope narrowing
+  // The end-to-end enforcement is covered by token.test.ts ("agent scope-mode
+  // cap" suites); the unit behaviour of the helpers stays covered above.
 });
 
 describe('resolveAudience', () => {

--- a/apps/auth-server/src/app/helpers/step-up.test.ts
+++ b/apps/auth-server/src/app/helpers/step-up.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  elevatedScopes,
+  evaluateStepUp,
+  isDangerousScope,
+  parsePromptMode,
+  type StepUpInput,
+} from './step-up';
+
+describe('parsePromptMode', () => {
+  it('accepts the known OIDC prompt values', () => {
+    expect(parsePromptMode('login')).toBe('login');
+    expect(parsePromptMode('consent')).toBe('consent');
+    expect(parsePromptMode('none')).toBe('none');
+  });
+
+  it('returns null for absent / unknown values (fail-closed)', () => {
+    expect(parsePromptMode(undefined)).toBeNull();
+    expect(parsePromptMode('select_account')).toBeNull();
+    expect(parsePromptMode('LOGIN')).toBeNull();
+    expect(parsePromptMode('')).toBeNull();
+  });
+});
+
+describe('isDangerousScope', () => {
+  it('classifies write:* scopes as dangerous', () => {
+    expect(isDangerousScope('write:files')).toBe(true);
+    expect(isDangerousScope('write:anything')).toBe(true);
+  });
+
+  it('classifies the higher agent modes (admin/exec) as dangerous', () => {
+    expect(isDangerousScope('agent:admin')).toBe(true);
+    expect(isDangerousScope('agent:exec')).toBe(true);
+  });
+
+  it('does NOT classify read-only / readonly-mode scopes as dangerous', () => {
+    expect(isDangerousScope('read:files')).toBe(false);
+    expect(isDangerousScope('mcp:read')).toBe(false);
+    expect(isDangerousScope('agent:readonly')).toBe(false);
+    expect(isDangerousScope('openid')).toBe(false);
+  });
+});
+
+describe('elevatedScopes', () => {
+  it('returns scopes not covered by prior consent, deduped + order-preserving', () => {
+    expect(elevatedScopes(['mcp:read', 'mcp:write', 'mcp:write'], ['mcp:read'])).toEqual([
+      'mcp:write',
+    ]);
+  });
+
+  it('returns empty when the request is fully within the prior grant', () => {
+    expect(elevatedScopes(['mcp:read'], ['mcp:read', 'mcp:write'])).toEqual([]);
+  });
+
+  it('treats an empty prior consent as everything being elevated', () => {
+    expect(elevatedScopes(['mcp:read', 'mcp:write'], [])).toEqual(['mcp:read', 'mcp:write']);
+  });
+});
+
+describe('evaluateStepUp', () => {
+  const NOW = 1_000_000_000_000;
+  const base: StepUpInput = {
+    requestedScopes: [],
+    priorConsentScopes: [],
+    prompt: null,
+    maxAgeSeconds: null,
+    authTimeMs: NOW, // fresh by default
+    nowMs: NOW,
+    freshAuthWindowMs: 120_000,
+  };
+
+  it('no elevation, no prompt, no dangerous scope ⇒ no step-up', () => {
+    const d = evaluateStepUp({
+      ...base,
+      requestedScopes: ['mcp:read'],
+      priorConsentScopes: ['mcp:read'],
+    });
+    expect(d.requiresFreshLogin).toBe(false);
+    expect(d.requiresConsent).toBe(false);
+    expect(d.elevated).toEqual([]);
+  });
+
+  it('widening the scope set requires consent (incremental consent), not silent widening', () => {
+    const d = evaluateStepUp({
+      ...base,
+      requestedScopes: ['mcp:read', 'mcp:write'],
+      priorConsentScopes: ['mcp:read'],
+    });
+    expect(d.requiresConsent).toBe(true);
+    expect(d.elevated).toEqual(['mcp:write']);
+    // mcp:write is not dangerous → fresh login not forced by danger; session is
+    // fresh anyway.
+    expect(d.requiresFreshLogin).toBe(false);
+  });
+
+  it('a dangerous elevated scope forces a fresh login when the session is stale', () => {
+    const d = evaluateStepUp({
+      ...base,
+      requestedScopes: ['agent:exec'],
+      priorConsentScopes: [],
+      authTimeMs: NOW - 10 * 60 * 1000, // 10 min old, outside the 2 min window
+    });
+    expect(d.dangerous).toEqual(['agent:exec']);
+    expect(d.requiresFreshLogin).toBe(true);
+    expect(d.requiresConsent).toBe(true);
+  });
+
+  it('a dangerous elevated scope is satisfied by a recent (in-window) authentication', () => {
+    const d = evaluateStepUp({
+      ...base,
+      requestedScopes: ['write:files'],
+      priorConsentScopes: [],
+      authTimeMs: NOW - 30 * 1000, // 30s old, inside the 2 min window
+    });
+    expect(d.dangerous).toEqual(['write:files']);
+    // Re-auth just happened → not forced again (prevents the redirect loop).
+    expect(d.requiresFreshLogin).toBe(false);
+    // Still must be consented (it is an elevation).
+    expect(d.requiresConsent).toBe(true);
+  });
+
+  it('prompt=login forces a fresh login only when auth is outside the window', () => {
+    const stale = evaluateStepUp({
+      ...base,
+      prompt: 'login',
+      authTimeMs: NOW - 10 * 60 * 1000,
+    });
+    expect(stale.requiresFreshLogin).toBe(true);
+
+    const fresh = evaluateStepUp({ ...base, prompt: 'login', authTimeMs: NOW - 1000 });
+    expect(fresh.requiresFreshLogin).toBe(false);
+  });
+
+  it('prompt=consent forces consent even with no elevation', () => {
+    const d = evaluateStepUp({
+      ...base,
+      prompt: 'consent',
+      requestedScopes: ['mcp:read'],
+      priorConsentScopes: ['mcp:read'],
+    });
+    expect(d.requiresConsent).toBe(true);
+    expect(d.elevated).toEqual([]);
+  });
+
+  it('max_age=0 always forces a fresh login (any positive age exceeds 0), ignoring the window', () => {
+    const d = evaluateStepUp({
+      ...base,
+      maxAgeSeconds: 0,
+      authTimeMs: NOW - 1, // 1ms old — inside the freshness window, but max_age is exact
+    });
+    expect(d.requiresFreshLogin).toBe(true);
+  });
+
+  it('max_age is enforced exactly against its own value, not widened by the window', () => {
+    // 60s max_age, session 90s old → exceeded, even though the freshness window
+    // (120s) would have accepted it for prompt=login purposes.
+    const exceeded = evaluateStepUp({
+      ...base,
+      maxAgeSeconds: 60,
+      authTimeMs: NOW - 90 * 1000,
+    });
+    expect(exceeded.requiresFreshLogin).toBe(true);
+
+    const within = evaluateStepUp({ ...base, maxAgeSeconds: 60, authTimeMs: NOW - 30 * 1000 });
+    expect(within.requiresFreshLogin).toBe(false);
+  });
+});

--- a/apps/auth-server/src/app/helpers/step-up.test.ts
+++ b/apps/auth-server/src/app/helpers/step-up.test.ts
@@ -5,6 +5,8 @@ import {
   evaluateStepUp,
   isDangerousScope,
   parsePromptMode,
+  type StepUpDecision,
+  stepUpErrorForPromptNone,
   type StepUpInput,
 } from './step-up';
 
@@ -106,6 +108,23 @@ describe('evaluateStepUp', () => {
     expect(d.requiresConsent).toBe(true);
   });
 
+  it('a dangerous scope ALREADY covered by prior consent still forces fresh auth (no elevation needed)', () => {
+    // Should-fix #2: dangerous gating spans all requested scopes, not just the
+    // elevated subset, so a "remembered" dangerous grant cannot be replayed off
+    // a stale session without a fresh authentication.
+    const d = evaluateStepUp({
+      ...base,
+      requestedScopes: ['write:files'],
+      priorConsentScopes: ['write:files'], // already remembered → NOT elevated
+      authTimeMs: NOW - 10 * 60 * 1000, // stale
+    });
+    expect(d.elevated).toEqual([]); // nothing newly requested
+    expect(d.dangerous).toEqual(['write:files']); // but still dangerous
+    expect(d.requiresFreshLogin).toBe(true); // and still gated
+    // No elevation → no forced consent on its own (the danger drives login).
+    expect(d.requiresConsent).toBe(false);
+  });
+
   it('a dangerous elevated scope is satisfied by a recent (in-window) authentication', () => {
     const d = evaluateStepUp({
       ...base,
@@ -143,13 +162,25 @@ describe('evaluateStepUp', () => {
     expect(d.elevated).toEqual([]);
   });
 
-  it('max_age=0 always forces a fresh login (any positive age exceeds 0), ignoring the window', () => {
-    const d = evaluateStepUp({
+  // OIDC `auth_time` is second-granular: a just-completed login (sub-second
+  // age) MUST satisfy max_age=0 so the authorize→login→authorize round-trip
+  // terminates. A millisecond-precision comparison here would loop forever
+  // (the prior bug this test now guards against).
+  it('max_age=0 is satisfied by a sub-second-old authentication (no infinite loop)', () => {
+    const justLoggedIn = evaluateStepUp({
       ...base,
       maxAgeSeconds: 0,
-      authTimeMs: NOW - 1, // 1ms old — inside the freshness window, but max_age is exact
+      authTimeMs: NOW - 40, // 40ms old — floor(0.04s) = 0, so 0 > 0 is false
     });
-    expect(d.requiresFreshLogin).toBe(true);
+    expect(justLoggedIn.requiresFreshLogin).toBe(false);
+
+    // But an authentication a full second or more old DOES exceed max_age=0.
+    const oneSecondOld = evaluateStepUp({
+      ...base,
+      maxAgeSeconds: 0,
+      authTimeMs: NOW - 1500, // floor(1.5s) = 1 > 0
+    });
+    expect(oneSecondOld.requiresFreshLogin).toBe(true);
   });
 
   it('max_age is enforced exactly against its own value, not widened by the window', () => {
@@ -164,5 +195,31 @@ describe('evaluateStepUp', () => {
 
     const within = evaluateStepUp({ ...base, maxAgeSeconds: 60, authTimeMs: NOW - 30 * 1000 });
     expect(within.requiresFreshLogin).toBe(false);
+  });
+});
+
+describe('stepUpErrorForPromptNone', () => {
+  function decision(over: Partial<StepUpDecision>): StepUpDecision {
+    return {
+      elevated: [],
+      dangerous: [],
+      requiresFreshLogin: false,
+      requiresConsent: false,
+      ...over,
+    };
+  }
+
+  it('returns login_required when a fresh login is needed (takes precedence)', () => {
+    expect(
+      stepUpErrorForPromptNone(decision({ requiresFreshLogin: true, requiresConsent: true }))
+    ).toBe('login_required');
+  });
+
+  it('returns consent_required when only consent is needed', () => {
+    expect(stepUpErrorForPromptNone(decision({ requiresConsent: true }))).toBe('consent_required');
+  });
+
+  it('returns null when no interaction is required (request may proceed)', () => {
+    expect(stepUpErrorForPromptNone(decision({}))).toBeNull();
   });
 });

--- a/apps/auth-server/src/app/helpers/step-up.ts
+++ b/apps/auth-server/src/app/helpers/step-up.ts
@@ -27,9 +27,11 @@ import { AGENT_MODE_SCOPES } from './scope-modes';
  *   - `login`   — force a fresh end-user authentication.
  *   - `consent` — force the consent screen even if a prior grant would cover
  *     the request (used to re-affirm an elevation).
- *   - `none`    — caller asserts no UI; we still fail-closed and refuse to
- *     silently elevate (the route maps this to an interaction-required style
- *     error rather than auto-widening).
+ *   - `none`    — caller asserts no UI may be shown (OIDC Core §3.1.2.1). When
+ *     step-up would otherwise display UI, the route MUST instead return the
+ *     matching OIDC error (`login_required` / `consent_required` /
+ *     `interaction_required`) — see {@link stepUpErrorForPromptNone}. We never
+ *     silently elevate.
  */
 export type PromptMode = 'login' | 'consent' | 'none';
 
@@ -122,13 +124,19 @@ export interface StepUpInput {
 export interface StepUpDecision {
   /** The newly-requested (elevated) scopes that drove the decision. */
   elevated: string[];
-  /** The elevated scopes classified dangerous (subset of `elevated`). */
+  /**
+   * The requested scopes classified dangerous (`write:*` / `agent:admin` /
+   * `agent:exec`). NB: computed over ALL requested scopes, NOT just elevated
+   * ones — a dangerous scope already covered by a prior "remembered" consent
+   * still requires fresh auth, so the skip-consent fast path can never mint a
+   * dangerous-scope code off a stale grant (see rule 3).
+   */
   dangerous: string[];
   /**
    * The current session must re-authenticate before a code is issued. Driven
-   * by `prompt=login`, a `max_age` the session age exceeds, OR a dangerous
-   * elevation (default-deny: a dangerous new scope always forces fresh auth,
-   * regardless of any client-supplied signal).
+   * by `prompt=login`, a `max_age` the session age exceeds, OR any dangerous
+   * scope being granted (default-deny: a dangerous scope always forces fresh
+   * auth, regardless of prior consent or any client-supplied signal).
    */
   requiresFreshLogin: boolean;
   /**
@@ -147,37 +155,73 @@ export interface StepUpDecision {
  *  1. Any scope newly requested beyond the prior consent is an `elevated`
  *     scope ⇒ `requiresConsent` (re-affirm the wider set; never auto-widen).
  *  2. `prompt=consent` ⇒ `requiresConsent` even with no elevation.
- *  3. A dangerous elevated scope ⇒ `requiresFreshLogin` — a state-changing /
- *     privileged capability is only granted right after the user proves
- *     presence. This is the "dangerous operation" gate and needs no client
- *     opt-in.
+ *  3. Any dangerous scope being granted (whether newly elevated OR already
+ *     covered by a remembered prior consent) ⇒ `requiresFreshLogin` — a
+ *     state-changing / privileged capability is only granted right after the
+ *     user proves presence. This is the "dangerous operation" gate; it needs
+ *     no client opt-in and a stale prior grant cannot satisfy it. Both the
+ *     authorize skip-consent path and the consent mint path share this, so
+ *     they agree.
  *  4. `prompt=login` ⇒ `requiresFreshLogin`.
- *  5. `max_age` present and the session is older than it ⇒ `requiresFreshLogin`
- *     (`max_age=0` ⇒ always, since any positive age exceeds 0).
+ *  5. `max_age` present and the authentication is older than it ⇒
+ *     `requiresFreshLogin`. Age is floored to whole seconds to match OIDC
+ *     `auth_time` granularity (OIDC Core §2), so a just-completed login (a
+ *     sub-second-old session) satisfies even `max_age=0` — `0 > 0` is false.
+ *     This is what makes the `authorize → login → authorize` round-trip
+ *     TERMINATE instead of looping forever.
  *
- * A request that is fully within an existing grant, with no prompt/max_age and
- * no dangerous scope, yields no step-up (`requiresFreshLogin=false`,
- * `requiresConsent=false`) and the ordinary skip-consent fast path applies.
+ * The `prompt=login` / dangerous-scope requirement (3, 4) additionally honours
+ * the freshness window: an authentication newer than `freshAuthWindowMs` counts
+ * as fresh, so the post-login return trip is not bounced again. `max_age` (5)
+ * is enforced exactly against its own value and is NOT widened by that window.
+ *
+ * A request fully within an existing grant, with no prompt/max_age and no
+ * dangerous scope, yields no step-up and the ordinary skip-consent fast path
+ * applies.
  */
 export function evaluateStepUp(input: StepUpInput): StepUpDecision {
   const elevated = elevatedScopes(input.requestedScopes, input.priorConsentScopes);
-  const dangerous = elevated.filter(isDangerousScope);
+  // Dangerous classification spans ALL requested scopes (rule 3), not only the
+  // elevated subset — a remembered dangerous scope must still force fresh auth.
+  const dangerous = input.requestedScopes.filter(isDangerousScope);
 
   const requiresConsent = elevated.length > 0 || input.prompt === 'consent';
 
   const authAgeMs = input.nowMs - input.authTimeMs;
 
-  // `prompt=login` and dangerous elevations demand a *fresh* authentication,
-  // but one performed within the freshness window counts — otherwise the
-  // post-login return trip would re-trigger the same requirement and loop.
+  // `prompt=login` and dangerous scopes demand a *fresh* authentication, but
+  // one performed within the freshness window counts — otherwise the post-login
+  // return trip would re-trigger the same requirement and loop.
   const authIsFresh = authAgeMs <= input.freshAuthWindowMs;
   const loginRequirement = (dangerous.length > 0 || input.prompt === 'login') && !authIsFresh;
 
-  // `max_age` is enforced exactly against the request value (not widened by
-  // the freshness window). `max_age=0` ⇒ any positive age fails.
-  const maxAgeExceeded = input.maxAgeSeconds !== null && authAgeMs > input.maxAgeSeconds * 1000;
+  // `max_age` is enforced exactly against the request value (not widened by the
+  // freshness window) BUT at OIDC second-granularity: floor the age to whole
+  // seconds so a just-completed login satisfies `max_age=0` (`0 > 0` is false)
+  // and the re-auth round-trip terminates instead of looping forever.
+  const authAgeSeconds = Math.floor(authAgeMs / 1000);
+  const maxAgeExceeded = input.maxAgeSeconds !== null && authAgeSeconds > input.maxAgeSeconds;
 
   const requiresFreshLogin = loginRequirement || maxAgeExceeded;
 
   return { elevated, dangerous, requiresFreshLogin, requiresConsent };
+}
+
+/**
+ * OIDC `prompt=none` error mapping (OIDC Core §3.1.2.1). When the caller forbids
+ * UI but a step-up decision would otherwise display the login or consent screen,
+ * the route MUST return one of these bare error codes instead (delivered as an
+ * `error=` redirect to the client). Returns `null` when no interaction is
+ * required (the request may proceed without UI).
+ *
+ * Precedence: a fresh-authentication requirement is reported as `login_required`
+ * even if consent is also pending — the user cannot consent before
+ * (re-)authenticating. `interaction_required` is the generic fallback.
+ */
+export function stepUpErrorForPromptNone(
+  decision: StepUpDecision
+): 'login_required' | 'consent_required' | 'interaction_required' | null {
+  if (decision.requiresFreshLogin) return 'login_required';
+  if (decision.requiresConsent) return 'consent_required';
+  return null;
 }

--- a/apps/auth-server/src/app/helpers/step-up.ts
+++ b/apps/auth-server/src/app/helpers/step-up.ts
@@ -1,0 +1,183 @@
+import { AGENT_MODE_SCOPES } from './scope-modes';
+
+/**
+ * Step-up authentication before dangerous operations (ADR-007 §2, issue #185).
+ *
+ * `mcp-guard` already emits the runtime `403 insufficient_scope` +
+ * `WWW-Authenticate` challenge when a resource needs a scope the presented
+ * token lacks (shipped in T1). THIS module is the **authorization-server**
+ * half of that loop: when a client comes back to `/oauth/authorize` asking for
+ * an *increased* scope set (e.g. `mcp:read` → `mcp:read mcp:write`, or
+ * `agent:readonly` → `agent:exec`), QAuth must NOT silently widen an existing
+ * grant from a prior consent / live session. Crossing into a more-privileged
+ * scope set is treated as a step-up: it requires a **fresh authentication**
+ * and/or an **explicit re-consent**, per MCP 2025-11-25 incremental consent.
+ *
+ * The policy is deliberately small and legible, and DEFAULT-DENY in the spirit
+ * of epic #181: we never trust a self-asserted client signal to decide whether
+ * an elevation is "safe". The decision is driven only by (a) the scopes being
+ * newly requested versus what a prior consent already covers, (b) whether any
+ * newly-requested scope is classified dangerous server-side, and (c) the
+ * standard OIDC `prompt` / `max_age` request parameters.
+ */
+
+/**
+ * OIDC `prompt` values we honour (OIDC Core §3.1.2.1). `select_account` is not
+ * meaningful for QAuth (single account per session) and is treated as absent.
+ *   - `login`   — force a fresh end-user authentication.
+ *   - `consent` — force the consent screen even if a prior grant would cover
+ *     the request (used to re-affirm an elevation).
+ *   - `none`    — caller asserts no UI; we still fail-closed and refuse to
+ *     silently elevate (the route maps this to an interaction-required style
+ *     error rather than auto-widening).
+ */
+export type PromptMode = 'login' | 'consent' | 'none';
+
+/** Parse the raw `prompt` query param into a known {@link PromptMode} or null. */
+export function parsePromptMode(value: string | undefined): PromptMode | null {
+  if (value === 'login' || value === 'consent' || value === 'none') return value;
+  return null;
+}
+
+/**
+ * Scopes that are "dangerous" — performing or enabling a state-changing /
+ * privileged action — and therefore require step-up (a fresh authentication)
+ * before a token carrying them may be issued through an *elevation*.
+ *
+ * The classification is intentionally conservative and server-side only:
+ *   - any `write:*` scope (mutating access),
+ *   - the higher agent scope modes `agent:admin` and `agent:exec` (Admin can
+ *     administer; Exec takes actions — both are action-taking per
+ *     scope-modes.ts). `agent:readonly` is NOT dangerous.
+ *
+ * This is the single policy hook for "what counts as dangerous": extend
+ * {@link DANGEROUS_EXACT_SCOPES} or {@link DANGEROUS_SCOPE_PREFIXES} here and
+ * every step-up decision picks it up. Deployments that need a different policy
+ * override this one function rather than sprinkling scope checks across routes.
+ */
+const DANGEROUS_SCOPE_PREFIXES: readonly string[] = ['write:'];
+
+const DANGEROUS_EXACT_SCOPES: ReadonlySet<string> = new Set<string>([
+  AGENT_MODE_SCOPES.admin,
+  AGENT_MODE_SCOPES.exec,
+]);
+
+/** True iff `scope` is classified dangerous (see {@link DANGEROUS_SCOPE_PREFIXES}). */
+export function isDangerousScope(scope: string): boolean {
+  if (DANGEROUS_EXACT_SCOPES.has(scope)) return true;
+  return DANGEROUS_SCOPE_PREFIXES.some((prefix) => scope.startsWith(prefix));
+}
+
+/**
+ * The subset of `requested` scopes that are NOT already covered by a prior
+ * consent — i.e. the scopes this request would *newly* grant (the elevation).
+ * Order-preserving, de-duplicated. An empty result means the request is fully
+ * within an existing grant (no elevation).
+ */
+export function elevatedScopes(
+  requested: readonly string[],
+  priorConsent: readonly string[]
+): string[] {
+  const have = new Set(priorConsent);
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const s of requested) {
+    if (have.has(s)) continue;
+    if (seen.has(s)) continue;
+    seen.add(s);
+    out.push(s);
+  }
+  return out;
+}
+
+/** Inputs to {@link evaluateStepUp}. All times are epoch milliseconds. */
+export interface StepUpInput {
+  /** Scopes requested now (already filtered to the client's allowlist). */
+  requestedScopes: readonly string[];
+  /** Scopes an active, non-revoked prior consent already covers (empty if none). */
+  priorConsentScopes: readonly string[];
+  /** Parsed OIDC `prompt`, or null when absent. */
+  prompt: PromptMode | null;
+  /**
+   * Parsed OIDC `max_age` in SECONDS, or null when absent. `0` demands a
+   * brand-new authentication (re-auth on every elevation), matching the
+   * `max_age=0` step-up idiom.
+   */
+  maxAgeSeconds: number | null;
+  /** When the current session authenticated (session.createdAt), epoch ms. */
+  authTimeMs: number;
+  /** "Now", epoch ms — injected for deterministic tests. */
+  nowMs: number;
+  /**
+   * Freshness window in MILLISECONDS for the `prompt=login` / dangerous-scope
+   * step-up: an authentication newer than this is accepted as "fresh", so a
+   * user who just re-authenticated for the elevation is not bounced back to
+   * the login page again (which would loop forever). `max_age` is handled
+   * separately and exactly — it is NOT widened by this window.
+   */
+  freshAuthWindowMs: number;
+}
+
+/** The step-up decision. */
+export interface StepUpDecision {
+  /** The newly-requested (elevated) scopes that drove the decision. */
+  elevated: string[];
+  /** The elevated scopes classified dangerous (subset of `elevated`). */
+  dangerous: string[];
+  /**
+   * The current session must re-authenticate before a code is issued. Driven
+   * by `prompt=login`, a `max_age` the session age exceeds, OR a dangerous
+   * elevation (default-deny: a dangerous new scope always forces fresh auth,
+   * regardless of any client-supplied signal).
+   */
+  requiresFreshLogin: boolean;
+  /**
+   * The consent screen must be shown (the skip-consent fast path is forbidden).
+   * Driven by `prompt=consent` OR any elevation at all — a new scope set must
+   * be explicitly re-consented, never silently widened from a prior grant.
+   */
+  requiresConsent: boolean;
+}
+
+/**
+ * Decide whether this authorization request is an elevation that needs
+ * step-up, and if so what kind. Pure + deterministic (time is injected).
+ *
+ * Rules (all default-deny / fail-closed):
+ *  1. Any scope newly requested beyond the prior consent is an `elevated`
+ *     scope ⇒ `requiresConsent` (re-affirm the wider set; never auto-widen).
+ *  2. `prompt=consent` ⇒ `requiresConsent` even with no elevation.
+ *  3. A dangerous elevated scope ⇒ `requiresFreshLogin` — a state-changing /
+ *     privileged capability is only granted right after the user proves
+ *     presence. This is the "dangerous operation" gate and needs no client
+ *     opt-in.
+ *  4. `prompt=login` ⇒ `requiresFreshLogin`.
+ *  5. `max_age` present and the session is older than it ⇒ `requiresFreshLogin`
+ *     (`max_age=0` ⇒ always, since any positive age exceeds 0).
+ *
+ * A request that is fully within an existing grant, with no prompt/max_age and
+ * no dangerous scope, yields no step-up (`requiresFreshLogin=false`,
+ * `requiresConsent=false`) and the ordinary skip-consent fast path applies.
+ */
+export function evaluateStepUp(input: StepUpInput): StepUpDecision {
+  const elevated = elevatedScopes(input.requestedScopes, input.priorConsentScopes);
+  const dangerous = elevated.filter(isDangerousScope);
+
+  const requiresConsent = elevated.length > 0 || input.prompt === 'consent';
+
+  const authAgeMs = input.nowMs - input.authTimeMs;
+
+  // `prompt=login` and dangerous elevations demand a *fresh* authentication,
+  // but one performed within the freshness window counts — otherwise the
+  // post-login return trip would re-trigger the same requirement and loop.
+  const authIsFresh = authAgeMs <= input.freshAuthWindowMs;
+  const loginRequirement = (dangerous.length > 0 || input.prompt === 'login') && !authIsFresh;
+
+  // `max_age` is enforced exactly against the request value (not widened by
+  // the freshness window). `max_age=0` ⇒ any positive age fails.
+  const maxAgeExceeded = input.maxAgeSeconds !== null && authAgeMs > input.maxAgeSeconds * 1000;
+
+  const requiresFreshLogin = loginRequirement || maxAgeExceeded;
+
+  return { elevated, dangerous, requiresFreshLogin, requiresConsent };
+}

--- a/apps/auth-server/src/app/routes/oauth/authorize.test.ts
+++ b/apps/auth-server/src/app/routes/oauth/authorize.test.ts
@@ -667,16 +667,138 @@ describe('GET /oauth/authorize — step-up authentication (ADR-007 §2, #185)', 
     expect(fastify.repositories.authorizationCodes.create).not.toHaveBeenCalled();
   });
 
-  it('max_age=0 forces fresh auth even on an otherwise-skippable request', async () => {
+  it('max_age=0 forces fresh auth when the session is a second or more old', async () => {
     const { fastify, state } = await run({
       client: CLIENT,
       scope: 'email',
       priorConsent: ['email'],
-      createdAt: Date.now() - 5000,
+      createdAt: Date.now() - 5000, // 5s old → floor(5) = 5 > 0
       maxAge: '0',
       sid: 'sid-su-6',
     });
     expect(state.redirected).toContain('/ui/login?return_to=');
     expect(fastify.repositories.authorizationCodes.create).not.toHaveBeenCalled();
+  });
+
+  // BLOCKER #1 regression: the authorize → login → authorize round-trip for
+  // max_age=0 MUST terminate. After login re-mints the session, the second
+  // authorize sees a sub-second-old auth_time; with OIDC second-granularity
+  // (floor), max_age=0 is satisfied (0 > 0 is false) and a code is minted
+  // rather than bouncing to /ui/login again forever.
+  it('max_age=0 TERMINATES: a just-logged-in (sub-second) session mints the code', async () => {
+    const { fastify, state } = await run({
+      client: CLIENT,
+      scope: 'email',
+      priorConsent: ['email'],
+      createdAt: Date.now() - 40, // 40ms old, simulating the post-login return trip
+      maxAge: '0',
+      sid: 'sid-su-6b',
+    });
+    expect(state.redirected).not.toContain('/ui/login');
+    expect(state.redirected).toContain('code=');
+    expect(fastify.repositories.authorizationCodes.create).toHaveBeenCalledOnce();
+  });
+
+  // Should-fix #2: a dangerous scope already covered by a remembered prior
+  // consent must STILL force fresh auth on the authorize skip-consent path — it
+  // cannot be replayed off a stale grant. (Previously this minted directly.)
+  it('forces fresh auth for a REMEMBERED dangerous scope on a stale session (no replay)', async () => {
+    const { fastify, state } = await run({
+      scope: 'write:foo',
+      priorConsent: ['write:foo'], // remembered → would otherwise skip consent
+      createdAt: Date.now() - 10 * MINUTE,
+      sid: 'sid-su-7',
+    });
+    expect(state.redirected).toContain('/ui/login?return_to=');
+    expect(fastify.repositories.authorizationCodes.create).not.toHaveBeenCalled();
+  });
+
+  // OIDC Core §3.1.2.1: prompt=none must NOT show UI; an interaction need is
+  // reported as the matching error to the client instead.
+  it('prompt=none returns login_required (no UI) when a dangerous scope needs fresh auth', async () => {
+    const { fastify, state } = await run({
+      scope: 'write:foo',
+      priorConsent: ['write:foo'],
+      createdAt: Date.now() - 10 * MINUTE,
+      prompt: 'none',
+      sid: 'sid-su-8',
+    });
+    expect(state.redirected).toContain('https://example.com/cb');
+    expect(state.redirected).toContain('error=login_required');
+    expect(state.redirected).not.toContain('/ui/login');
+    expect(state.redirected).not.toContain('/ui/consent');
+    expect(fastify.repositories.authorizationCodes.create).not.toHaveBeenCalled();
+  });
+
+  it('prompt=none returns consent_required (no UI) for a non-dangerous elevation', async () => {
+    const { fastify, state } = await run({
+      client: CLIENT,
+      scope: 'read:foo email',
+      priorConsent: ['email'], // read:foo is a new, non-dangerous elevation
+      createdAt: Date.now() - 1000,
+      prompt: 'none',
+      sid: 'sid-su-9',
+    });
+    expect(state.redirected).toContain('error=consent_required');
+    expect(state.redirected).not.toContain('/ui/consent');
+    expect(fastify.repositories.authorizationCodes.create).not.toHaveBeenCalled();
+  });
+
+  it('prompt=none proceeds (mints a code) when no interaction is required', async () => {
+    const { fastify, state } = await run({
+      client: CLIENT,
+      scope: 'email',
+      priorConsent: ['email'],
+      createdAt: Date.now() - 1000,
+      prompt: 'none',
+      sid: 'sid-su-10',
+    });
+    expect(state.redirected).toContain('code=');
+    expect(fastify.repositories.authorizationCodes.create).toHaveBeenCalledOnce();
+  });
+});
+
+describe('GET /oauth/authorize — Bearer path step-up (ADR-007 §2, #185)', () => {
+  // The Bearer (legacy first-party) path cannot run interactive step-up, so a
+  // dangerous scope on it is refused rather than minted with no fresh auth.
+  const DANGEROUS_CLIENT = {
+    ...CLIENT,
+    clientId: 'app-bearer',
+    scopes: ['read:foo', 'write:foo', 'email'],
+  };
+
+  async function runBearer(scope: string) {
+    const { fastify, ctx } = makeFastify();
+    await authorizeRoute(fastify);
+    (fastify.repositories.oauthClients.findByClientId as unknown as Mock).mockResolvedValue(
+      DANGEROUS_CLIENT
+    );
+    // No browser session; a valid Bearer token resolves the user.
+    (fastify.sessionUtils.getSession as unknown as Mock).mockResolvedValue(null);
+    (fastify.jwtUtils.extractFromHeader as unknown as Mock).mockReturnValue('bearer.token');
+    (fastify.jwtUtils.verifyAccessToken as unknown as Mock).mockResolvedValue({ sub: 'user-1' });
+    const { reply, state } = createReply();
+    await ctx.handler!(
+      {
+        query: { ...BASE_QUERY, client_id: 'app-bearer', scope },
+        url: `/oauth/authorize?response_type=code&client_id=app-bearer&scope=${encodeURIComponent(scope)}`,
+        headers: { authorization: 'Bearer bearer.token' },
+        ip: '127.0.0.1',
+      },
+      reply
+    );
+    return { fastify, state };
+  }
+
+  it('refuses a dangerous scope on the Bearer path with access_denied (no interactive step-up)', async () => {
+    const { fastify, state } = await runBearer('write:foo');
+    expect(state.redirected).toContain('error=access_denied');
+    expect(fastify.repositories.authorizationCodes.create).not.toHaveBeenCalled();
+  });
+
+  it('still mints a code for a non-dangerous scope on the Bearer path', async () => {
+    const { fastify, state } = await runBearer('email');
+    expect(state.redirected).toContain('code=');
+    expect(fastify.repositories.authorizationCodes.create).toHaveBeenCalledOnce();
   });
 });

--- a/apps/auth-server/src/app/routes/oauth/authorize.test.ts
+++ b/apps/auth-server/src/app/routes/oauth/authorize.test.ts
@@ -532,3 +532,151 @@ describe('GET /oauth/authorize — agent scope-mode cap (ADR-007 §2, #184)', ()
     expect(fastify.repositories.authorizationCodes.create).not.toHaveBeenCalled();
   });
 });
+
+describe('GET /oauth/authorize — step-up authentication (ADR-007 §2, #185)', () => {
+  // Client whose allowlist includes a dangerous (write:*) scope.
+  const DANGEROUS_CLIENT = {
+    ...CLIENT,
+    clientId: 'app-danger',
+    scopes: ['read:foo', 'write:foo', 'email'],
+  };
+
+  const MINUTE = 60 * 1000;
+
+  async function run(opts: {
+    client?: typeof CLIENT;
+    scope: string;
+    priorConsent?: string[] | null;
+    createdAt: number;
+    prompt?: string;
+    maxAge?: string;
+    sid: string;
+  }) {
+    const client = opts.client ?? DANGEROUS_CLIENT;
+    const { fastify, ctx } = makeFastify();
+    await authorizeRoute(fastify);
+    (fastify.repositories.oauthClients.findByClientId as unknown as Mock).mockResolvedValue(client);
+    (fastify.jwtUtils.extractFromHeader as unknown as Mock).mockReturnValue(null);
+    (fastify.repositories.oauthConsents.findActive as unknown as Mock).mockResolvedValue(
+      opts.priorConsent === null || opts.priorConsent === undefined
+        ? undefined
+        : { scopes: opts.priorConsent, revokedAt: null }
+    );
+    const { signSessionId } = await import('../../helpers/session-cookie');
+    const signed = signSessionId(opts.sid);
+    (fastify.sessionUtils.getSession as unknown as Mock).mockResolvedValue({
+      userId: 'user-1',
+      email: 'a@b.com',
+      sessionId: opts.sid,
+      createdAt: opts.createdAt,
+    });
+    const clientId = (client as { clientId: string }).clientId;
+    const query: Record<string, unknown> = {
+      ...BASE_QUERY,
+      client_id: clientId,
+      scope: opts.scope,
+    };
+    if (opts.prompt) query.prompt = opts.prompt;
+    if (opts.maxAge) query.max_age = Number(opts.maxAge);
+    const urlParams = new URLSearchParams({
+      response_type: 'code',
+      client_id: clientId,
+      scope: opts.scope,
+      ...(opts.prompt ? { prompt: opts.prompt } : {}),
+      ...(opts.maxAge ? { max_age: opts.maxAge } : {}),
+    });
+    const { reply, state } = createReply();
+    await ctx.handler!(
+      {
+        query,
+        url: `/oauth/authorize?${urlParams.toString()}`,
+        headers: { cookie: `__Host-qauth_session=${signed}` },
+        ip: '127.0.0.1',
+      },
+      reply
+    );
+    return { fastify, state };
+  }
+
+  it('forces a fresh login for a dangerous elevation on a stale session', async () => {
+    const { fastify, state } = await run({
+      scope: 'write:foo',
+      priorConsent: null,
+      createdAt: Date.now() - 10 * MINUTE,
+      sid: 'sid-su-1',
+    });
+    expect(state.redirected).toContain('/ui/login?return_to=');
+    expect(fastify.repositories.authorizationCodes.create).not.toHaveBeenCalled();
+    const events = (fastify.repositories.auditLogs.create as unknown as Mock).mock.calls.map(
+      (c) => (c[0] as { event: string }).event
+    );
+    expect(events).toContain('oauth.stepup.required');
+  });
+
+  it('sends a non-dangerous elevation to the consent screen (incremental consent), not silently widened', async () => {
+    // Prior consent covers read:foo; the request adds write:foo? No — use a
+    // non-dangerous widening: prior covers email, request adds read:foo.
+    const { fastify, state } = await run({
+      client: CLIENT,
+      scope: 'read:foo email',
+      priorConsent: ['email'],
+      createdAt: Date.now() - 10 * MINUTE,
+      sid: 'sid-su-2',
+    });
+    // read:foo is a NEW (elevated) scope → must re-consent, not skip.
+    expect(state.redirected).toContain('/ui/consent?');
+    expect(fastify.repositories.authorizationCodes.create).not.toHaveBeenCalled();
+  });
+
+  it('skips step-up when the request is fully within the prior grant and not dangerous', async () => {
+    const { fastify, state } = await run({
+      client: CLIENT,
+      scope: 'email',
+      priorConsent: ['email', 'read:foo'],
+      createdAt: Date.now() - 10 * MINUTE,
+      sid: 'sid-su-3',
+    });
+    // No elevation, no danger, no prompt → code issued directly.
+    expect(fastify.repositories.authorizationCodes.create).toHaveBeenCalledOnce();
+    expect(state.redirected).toContain('code=');
+  });
+
+  it('does NOT loop: a dangerous elevation on a FRESH session proceeds to consent', async () => {
+    const { fastify, state } = await run({
+      scope: 'write:foo',
+      priorConsent: null,
+      createdAt: Date.now() - 5000, // fresh
+      sid: 'sid-su-4',
+    });
+    // Fresh auth satisfies the login requirement; the elevation still needs
+    // consent (no prior grant), so we land on the consent screen — not login.
+    expect(state.redirected).toContain('/ui/consent?');
+    expect(fastify.repositories.authorizationCodes.create).not.toHaveBeenCalled();
+  });
+
+  it('prompt=login forces fresh auth even for a covered, non-dangerous scope', async () => {
+    const { fastify, state } = await run({
+      client: CLIENT,
+      scope: 'email',
+      priorConsent: ['email'],
+      createdAt: Date.now() - 10 * MINUTE,
+      prompt: 'login',
+      sid: 'sid-su-5',
+    });
+    expect(state.redirected).toContain('/ui/login?return_to=');
+    expect(fastify.repositories.authorizationCodes.create).not.toHaveBeenCalled();
+  });
+
+  it('max_age=0 forces fresh auth even on an otherwise-skippable request', async () => {
+    const { fastify, state } = await run({
+      client: CLIENT,
+      scope: 'email',
+      priorConsent: ['email'],
+      createdAt: Date.now() - 5000,
+      maxAge: '0',
+      sid: 'sid-su-6',
+    });
+    expect(state.redirected).toContain('/ui/login?return_to=');
+    expect(fastify.repositories.authorizationCodes.create).not.toHaveBeenCalled();
+  });
+});

--- a/apps/auth-server/src/app/routes/oauth/authorize.ts
+++ b/apps/auth-server/src/app/routes/oauth/authorize.ts
@@ -13,7 +13,12 @@ import { canSkipConsent, filterRequestedScopes } from '../../helpers/consent';
 import { getOrCreateSystemClient } from '../../helpers/oauth-client';
 import { buildRedirectUrl } from '../../helpers/oauth-redirect';
 import { getOrCreateDefaultRealm } from '../../helpers/realm';
-import { evaluateStepUp, parsePromptMode } from '../../helpers/step-up';
+import {
+  evaluateStepUp,
+  isDangerousScope,
+  parsePromptMode,
+  stepUpErrorForPromptNone,
+} from '../../helpers/step-up';
 import { type AuthorizeQuery, authorizeQuerySchema } from '../../schemas/oauth';
 
 /**
@@ -268,6 +273,45 @@ export default async function (fastify: FastifyInstance) {
       // requested scope on the auth-code flow.
       const scopes = filterRequestedScopes(query.scope, client);
 
+      // ADR-007 §2 (#185): step-up on the legacy Bearer path. The Bearer path
+      // authenticates the user from an existing access token and CANNOT run an
+      // interactive step-up (no login / consent screen for a machine caller),
+      // so it must not be a back door that mints a dangerous-scope code with no
+      // fresh authentication. Default-deny: a Bearer authorize request carrying
+      // any dangerous scope (write:* / agent:admin / agent:exec) is refused
+      // with `access_denied` and the client is told to use the interactive
+      // browser flow (which enforces the dangerous-op re-auth gate). Bearer is
+      // legacy first-party and not exposed to dynamically-registered clients,
+      // so this only affects first-party callers requesting dangerous scopes.
+      if (!browserSession) {
+        const bearerDangerous = scopes.filter(isDangerousScope);
+        if (bearerDangerous.length > 0) {
+          await fastify.repositories.auditLogs.create({
+            userId,
+            oauthClientId: client.id,
+            event: 'oauth.stepup.required',
+            eventType: 'auth',
+            success: false,
+            ipAddress: request.ip,
+            userAgent: request.headers['user-agent'] || null,
+            metadata: {
+              client_id: query.client_id,
+              reason: 'bearer_path_dangerous_scope_requires_interactive_stepup',
+              dangerous: bearerDangerous,
+            },
+          });
+          return reply.redirect(
+            buildRedirectUrl(redirectUri, {
+              error: 'access_denied',
+              error_description:
+                'dangerous scopes require interactive step-up; use the browser authorization flow',
+              state: state ?? undefined,
+            }),
+            302
+          );
+        }
+      }
+
       // Browser-driven flow: show the consent screen unless a previous
       // grant already covers the requested scopes. Bearer-token callers
       // skip the consent step entirely — they are first-party and the
@@ -298,7 +342,41 @@ export default async function (fastify: FastifyInstance) {
           freshAuthWindowMs: STEP_UP_FRESH_AUTH_WINDOW_MS,
         });
 
-        if (stepUp.requiresFreshLogin) {
+        // OIDC Core §3.1.2.1: `prompt=none` forbids ANY user-facing UI. If
+        // step-up would otherwise show the login or consent screen, return the
+        // matching bare OIDC error to the client instead of redirecting to UI.
+        if (prompt === 'none') {
+          const oidcError = stepUpErrorForPromptNone(stepUp);
+          if (oidcError) {
+            await fastify.repositories.auditLogs.create({
+              userId,
+              oauthClientId: client.id,
+              event: 'oauth.stepup.required',
+              eventType: 'auth',
+              success: false,
+              ipAddress: request.ip,
+              userAgent: request.headers['user-agent'] || null,
+              metadata: {
+                client_id: query.client_id,
+                reason: 'prompt_none_interaction_required',
+                error: oidcError,
+                elevated: stepUp.elevated,
+                dangerous: stepUp.dangerous,
+              },
+            });
+            return reply.redirect(
+              buildRedirectUrl(redirectUri, {
+                error: oidcError,
+                error_description: 'step-up interaction is required but prompt=none was requested',
+                state: state ?? undefined,
+              }),
+              302
+            );
+          }
+          // No interaction required → fall through to ordinary issuance.
+        }
+
+        if (prompt !== 'none' && stepUp.requiresFreshLogin) {
           // Force a fresh end-user authentication: bounce through /ui/login,
           // which always mints a brand-new session (session-fixation defense),
           // resetting auth_time so the elevation is granted only right after
@@ -328,7 +406,11 @@ export default async function (fastify: FastifyInstance) {
         // Re-consent when the request elevates scope or explicitly asks for it,
         // even if a prior grant would otherwise let us skip the screen — a
         // wider scope set must be explicitly re-affirmed, never auto-widened.
-        if (stepUp.requiresConsent || !canSkipConsent(existingConsent, client, scopes)) {
+        // (`prompt=none` already returned consent_required above if needed.)
+        if (
+          prompt !== 'none' &&
+          (stepUp.requiresConsent || !canSkipConsent(existingConsent, client, scopes))
+        ) {
           if (stepUp.elevated.length > 0) {
             await fastify.repositories.auditLogs.create({
               userId,

--- a/apps/auth-server/src/app/routes/oauth/authorize.ts
+++ b/apps/auth-server/src/app/routes/oauth/authorize.ts
@@ -5,7 +5,7 @@ import type { FastifyInstance } from 'fastify';
 import { ZodTypeProvider } from 'fastify-type-provider-zod';
 
 import { env } from '../../../config/env';
-import { AUTHORIZATION_CODE_TTL_MS } from '../../constants';
+import { AUTHORIZATION_CODE_TTL_MS, STEP_UP_FRESH_AUTH_WINDOW_MS } from '../../constants';
 import { resolveBrowserSession } from '../../helpers/browser-session';
 import { findExceedingAgentScopesForClient, resolveAudience } from '../../helpers/client-auth';
 import { resolveClient } from '../../helpers/client-resolution';
@@ -13,6 +13,7 @@ import { canSkipConsent, filterRequestedScopes } from '../../helpers/consent';
 import { getOrCreateSystemClient } from '../../helpers/oauth-client';
 import { buildRedirectUrl } from '../../helpers/oauth-redirect';
 import { getOrCreateDefaultRealm } from '../../helpers/realm';
+import { evaluateStepUp, parsePromptMode } from '../../helpers/step-up';
 import { type AuthorizeQuery, authorizeQuerySchema } from '../../schemas/oauth';
 
 /**
@@ -276,7 +277,75 @@ export default async function (fastify: FastifyInstance) {
           userId,
           client.id
         );
-        if (!canSkipConsent(existingConsent, client, scopes)) {
+
+        // ADR-007 §2 (#185): step-up authentication before dangerous
+        // operations / on elevation. A request that widens the granted scope
+        // set (incremental consent, MCP 2025-11-25), or that asks for a
+        // dangerous scope (write:* / agent:admin / agent:exec), or that sends
+        // `prompt`/`max_age`, must NOT be served from the existing session +
+        // prior consent silently. We re-authenticate and/or re-consent. The
+        // decision is default-deny: a dangerous elevation forces a fresh login
+        // with no client opt-in required.
+        const prompt = parsePromptMode(query.prompt);
+        const stepUp = evaluateStepUp({
+          requestedScopes: scopes,
+          priorConsentScopes:
+            existingConsent && existingConsent.revokedAt === null ? existingConsent.scopes : [],
+          prompt,
+          maxAgeSeconds: query.max_age ?? null,
+          authTimeMs: browserSession.createdAt,
+          nowMs: Date.now(),
+          freshAuthWindowMs: STEP_UP_FRESH_AUTH_WINDOW_MS,
+        });
+
+        if (stepUp.requiresFreshLogin) {
+          // Force a fresh end-user authentication: bounce through /ui/login,
+          // which always mints a brand-new session (session-fixation defense),
+          // resetting auth_time so the elevation is granted only right after
+          // the user proves presence. The full authorize URL (incl. prompt /
+          // max_age / scope / PKCE) is preserved so the round-trip is lossless.
+          await fastify.repositories.auditLogs.create({
+            userId,
+            oauthClientId: client.id,
+            event: 'oauth.stepup.required',
+            eventType: 'auth',
+            success: false,
+            ipAddress: request.ip,
+            userAgent: request.headers['user-agent'] || null,
+            metadata: {
+              client_id: query.client_id,
+              reason: 'fresh_authentication_required',
+              elevated: stepUp.elevated,
+              dangerous: stepUp.dangerous,
+              prompt: prompt ?? null,
+              maxAge: query.max_age ?? null,
+            },
+          });
+          const returnTo = `${request.url}`;
+          return reply.redirect(`/ui/login?return_to=${encodeURIComponent(returnTo)}`, 302);
+        }
+
+        // Re-consent when the request elevates scope or explicitly asks for it,
+        // even if a prior grant would otherwise let us skip the screen — a
+        // wider scope set must be explicitly re-affirmed, never auto-widened.
+        if (stepUp.requiresConsent || !canSkipConsent(existingConsent, client, scopes)) {
+          if (stepUp.elevated.length > 0) {
+            await fastify.repositories.auditLogs.create({
+              userId,
+              oauthClientId: client.id,
+              event: 'oauth.stepup.required',
+              eventType: 'auth',
+              success: false,
+              ipAddress: request.ip,
+              userAgent: request.headers['user-agent'] || null,
+              metadata: {
+                client_id: query.client_id,
+                reason: 'incremental_consent_required',
+                elevated: stepUp.elevated,
+                dangerous: stepUp.dangerous,
+              },
+            });
+          }
           return reply.redirect(`/ui/consent${request.url.slice(request.url.indexOf('?'))}`, 302);
         }
       }

--- a/apps/auth-server/src/app/routes/oauth/token.test.ts
+++ b/apps/auth-server/src/app/routes/oauth/token.test.ts
@@ -752,6 +752,110 @@ describe('POST /oauth/token route — client_credentials grant', () => {
       'match-client'
     );
   });
+
+  // ADR-007 §2 (#184): agent scope-mode cap on the client_credentials path.
+  // The cap is enforced via validateScopes(..., toAgentScopeContext(client))
+  // and is deny-by-default — a non-agent client (or one without/over its
+  // server-side max_agent_mode) can never mint a machine token carrying a
+  // reserved agent-mode scope, even when that scope is in its raw allowlist.
+  describe('agent scope-mode cap (#184 wiring)', () => {
+    function ccAgentClient(opts: { isAgent?: boolean; maxAgentMode?: string | null }) {
+      return {
+        id: 'cc-agent-uuid',
+        clientId: 'cc-agent',
+        clientSecretHash: 'hash',
+        enabled: true,
+        grantTypes: ['client_credentials'],
+        // Raw allowlist deliberately INCLUDES agent:exec to prove the cap, not
+        // the allowlist, is what blocks an over-mode request.
+        scopes: ['read:foo', 'agent:readonly', 'agent:exec'],
+        audience: null,
+        isAgent: opts.isAgent ?? true,
+        maxAgentMode: opts.maxAgentMode ?? null,
+      };
+    }
+
+    function ccRequest(scope: string) {
+      return {
+        body: {
+          grant_type: 'client_credentials',
+          client_id: 'cc-agent',
+          client_secret: 'secret',
+          scope,
+        },
+        ip: '127.0.0.1',
+        headers: { 'user-agent': 'vitest' },
+      };
+    }
+
+    it('issues an agent-mode scope within the cap (readonly ⊆ admin)', async () => {
+      const { fastify, ctx } = createFastifyStub();
+      await tokenRoute(fastify);
+      const handler = ctx.handler;
+      (fastify.repositories.oauthClients.findByClientId as unknown as Mock).mockResolvedValue(
+        ccAgentClient({ maxAgentMode: 'admin' })
+      );
+      (fastify.passwordHasher.verifyPassword as unknown as Mock).mockResolvedValue(true);
+      (fastify.jwtUtils.signAccessToken as unknown as Mock).mockResolvedValue('jwt');
+
+      if (!handler) throw new Error('Handler missing');
+      const result = await handler(ccRequest('agent:readonly'), createReply());
+
+      expect(result).toMatchObject({ scope: 'agent:readonly', token_type: 'Bearer' });
+      expect(fastify.jwtUtils.signAccessToken).toHaveBeenCalledWith(
+        expect.objectContaining({ scope: 'agent:readonly' })
+      );
+    });
+
+    it('rejects an agent-mode scope above the cap (exec > readonly) with invalid_scope', async () => {
+      const { fastify, ctx } = createFastifyStub();
+      await tokenRoute(fastify);
+      const handler = ctx.handler;
+      (fastify.repositories.oauthClients.findByClientId as unknown as Mock).mockResolvedValue(
+        ccAgentClient({ maxAgentMode: 'readonly' })
+      );
+      (fastify.passwordHasher.verifyPassword as unknown as Mock).mockResolvedValue(true);
+
+      if (!handler) throw new Error('Handler missing');
+      await expect(handler(ccRequest('agent:exec'), createReply())).rejects.toThrow(
+        InvalidScopeError
+      );
+      expect(fastify.jwtUtils.signAccessToken).not.toHaveBeenCalled();
+    });
+
+    it('rejects ANY agent-mode scope for a non-agent client (default-deny, fail-closed)', async () => {
+      const { fastify, ctx } = createFastifyStub();
+      await tokenRoute(fastify);
+      const handler = ctx.handler;
+      // isAgent:false even though a cap is set and the scope is allowlisted.
+      (fastify.repositories.oauthClients.findByClientId as unknown as Mock).mockResolvedValue(
+        ccAgentClient({ isAgent: false, maxAgentMode: 'exec' })
+      );
+      (fastify.passwordHasher.verifyPassword as unknown as Mock).mockResolvedValue(true);
+
+      if (!handler) throw new Error('Handler missing');
+      await expect(handler(ccRequest('agent:readonly'), createReply())).rejects.toThrow(
+        InvalidScopeError
+      );
+      expect(fastify.jwtUtils.signAccessToken).not.toHaveBeenCalled();
+    });
+
+    it('rejects an agent-mode scope when the agent has no cap configured (null = deny)', async () => {
+      const { fastify, ctx } = createFastifyStub();
+      await tokenRoute(fastify);
+      const handler = ctx.handler;
+      (fastify.repositories.oauthClients.findByClientId as unknown as Mock).mockResolvedValue(
+        ccAgentClient({ isAgent: true, maxAgentMode: null })
+      );
+      (fastify.passwordHasher.verifyPassword as unknown as Mock).mockResolvedValue(true);
+
+      if (!handler) throw new Error('Handler missing');
+      await expect(handler(ccRequest('agent:readonly'), createReply())).rejects.toThrow(
+        InvalidScopeError
+      );
+      expect(fastify.jwtUtils.signAccessToken).not.toHaveBeenCalled();
+    });
+  });
 });
 
 describe('POST /oauth/token route — authorization_code grant', () => {
@@ -1434,6 +1538,7 @@ describe('POST /oauth/token route — token-exchange grant (RFC 8693, ADR-007 §
       isAgent?: boolean;
       confidential?: boolean;
       grantTypes?: string[];
+      maxAgentMode?: string | null;
       subjectScope?: string;
       subjectAud?: string | string[] | undefined;
       subjectAct?: unknown;
@@ -1456,6 +1561,7 @@ describe('POST /oauth/token route — token-exchange grant (RFC 8693, ADR-007 §
       scopes: [] as string[],
       audience: null,
       isAgent: opts.isAgent ?? true,
+      maxAgentMode: opts.maxAgentMode ?? null,
       tokenEndpointAuthMethod: opts.confidential === false ? 'none' : 'client_secret_post',
     };
 
@@ -1791,5 +1897,58 @@ describe('POST /oauth/token route — token-exchange grant (RFC 8693, ADR-007 §
       expect((err as InvalidRequestError).message).toBe('invalid_request');
       expect((err as InvalidRequestError).errorDescription).toBeTruthy();
     }
+  });
+
+  // ADR-007 §2 (#184): GATE 4c — the (narrowed) delegated scope is additionally
+  // clamped to the agent's server-side max_agent_mode. A capped agent must not
+  // be able to launder a higher-mode reserved scope through delegation even
+  // when the subject token (issued under a broader prior grant) still carries
+  // it. Fail-closed via toAgentScopeContext.
+  describe('agent scope-mode cap (#184 wiring)', () => {
+    it('mints a delegated agent-mode scope within the cap (readonly ⊆ exec)', async () => {
+      const { fastify, ctx } = setupExchangeStub({
+        maxAgentMode: 'exec',
+        subjectScope: 'read:docs agent:readonly',
+      });
+      const result = await invoke(fastify, ctx, exchangeRequest());
+      expect(result).toMatchObject({ scope: 'read:docs agent:readonly' });
+      expect(fastify.jwtUtils.signAccessToken).toHaveBeenCalledWith(
+        expect.objectContaining({ scope: 'read:docs agent:readonly' })
+      );
+    });
+
+    it('rejects a delegated agent-mode scope above the cap (subject has exec, agent capped readonly)', async () => {
+      // The subject token legitimately carries agent:exec (minted under a broader
+      // grant), but THIS agent is capped at readonly — the clamp must reject it
+      // rather than mint an exec delegated token.
+      const { fastify, ctx } = setupExchangeStub({
+        maxAgentMode: 'readonly',
+        subjectScope: 'read:docs agent:exec',
+      });
+      await expect(invoke(fastify, ctx, exchangeRequest())).rejects.toThrow(InvalidScopeError);
+      expect(fastify.jwtUtils.signAccessToken).not.toHaveBeenCalled();
+    });
+
+    it('rejects a delegated agent-mode scope when the agent has no cap (null = deny)', async () => {
+      const { fastify, ctx } = setupExchangeStub({
+        maxAgentMode: null,
+        subjectScope: 'agent:readonly',
+      });
+      await expect(invoke(fastify, ctx, exchangeRequest())).rejects.toThrow(InvalidScopeError);
+      expect(fastify.jwtUtils.signAccessToken).not.toHaveBeenCalled();
+    });
+
+    it('still rejects when the request narrows to an over-cap agent-mode scope', async () => {
+      // Subject carries both readonly+exec; the request explicitly narrows to
+      // exec, which exceeds the readonly cap → invalid_scope.
+      const { fastify, ctx } = setupExchangeStub({
+        maxAgentMode: 'readonly',
+        subjectScope: 'agent:readonly agent:exec',
+      });
+      await expect(invoke(fastify, ctx, exchangeRequest({ scope: 'agent:exec' }))).rejects.toThrow(
+        InvalidScopeError
+      );
+      expect(fastify.jwtUtils.signAccessToken).not.toHaveBeenCalled();
+    });
   });
 });

--- a/apps/auth-server/src/app/routes/oauth/token.ts
+++ b/apps/auth-server/src/app/routes/oauth/token.ts
@@ -19,9 +19,11 @@ import { MIN_RESPONSE_TIME_MS } from '../../constants';
 import {
   authenticateClient,
   authenticateClientPublicOrConfidential,
+  enforceAgentScopeCap,
   extractClientCredentials,
   type OAuthClientLike,
   resolveAudience,
+  toAgentScopeContext,
   validateScopes,
 } from '../../helpers/client-auth';
 import { isAgentClient } from '../../helpers/client-resolution';
@@ -448,10 +450,16 @@ async function handleClientCredentials(
     throw new UnauthorizedClientError();
   }
 
-  // Validate requested scopes against client.scopes allowlist.
+  // Validate requested scopes against client.scopes allowlist, additionally
+  // clamping any reserved agent-mode scope (`agent:readonly|admin|exec`) to the
+  // agent client's server-side `max_agent_mode` (ADR-007 §2, #184 — wired now
+  // that #182/#183/#184 are merged). Deny-by-default + fail-closed via
+  // `toAgentScopeContext`: a non-agent client (incl. one that omitted
+  // `is_agent`) or one over its cap can never mint a machine token carrying an
+  // agent-mode scope, even if that scope also sits in its raw allowlist.
   let grantedScopes: string[];
   try {
-    grantedScopes = validateScopes(body.scope, client.scopes);
+    grantedScopes = validateScopes(body.scope, client.scopes, toAgentScopeContext(client));
   } catch (err) {
     await fastify.repositories.auditLogs.create({
       userId: null,
@@ -895,10 +903,12 @@ const MAX_DELEGATION_DEPTH = 4;
  * No refresh token is issued — a delegated token is intentionally short-lived
  * and the agent re-exchanges as needed.
  *
- * TODO(#184): scope modes (ReadOnly / Admin / Exec) are owned by the parallel
- * scope-mode PR. This handler does generic scope preservation/narrowing only;
- * once #184 lands, the narrowed scope set should additionally be clamped to
- * the agent's `max_agent_mode`. The two integrate at that point.
+ * GATE 4c — agent scope-mode cap (ADR-007 §2, #184, wired now that #182/#183/
+ * #184 are merged): on top of the generic preserve/narrow logic, any reserved
+ * agent-mode scope (`agent:readonly|admin|exec`) that survives narrowing is
+ * additionally clamped to the requesting agent's server-side `max_agent_mode`.
+ * Fail-closed via `toAgentScopeContext`: a capped agent cannot launder a
+ * higher-mode scope through delegation even when the subject token carried it.
  */
 async function handleTokenExchange(
   ctx: HandlerContext<TokenExchangeTokenExchangeBody>
@@ -1061,6 +1071,23 @@ async function handleTokenExchange(
     grantedScopes = [...new Set(requested)];
   } else {
     grantedScopes = subjectScopes;
+  }
+
+  // GATE 4c — clamp the (narrowed) scope set to the agent's server-side
+  // `max_agent_mode` (ADR-007 §2, #184). A reserved agent-mode scope is
+  // permitted ONLY when this client is a verified agent within its cap; a
+  // capped agent must not be able to mint a higher-mode delegated token even
+  // when the subject token (issued under a broader prior grant) still carries
+  // it. Fail-closed via `toAgentScopeContext`. `enforceAgentScopeCap` throws
+  // the same `InvalidScopeError` shape as the up-scoping check above.
+  try {
+    enforceAgentScopeCap(grantedScopes, toAgentScopeContext(client));
+  } catch (err) {
+    await auditFailure('invalid_scope: delegated scope exceeds the agent scope mode', {
+      grantedScopes,
+      maxAgentMode: client.maxAgentMode ?? null,
+    });
+    throw err;
   }
 
   // GATE 4b — audience narrowing (RFC 8707 §2.2 + RFC 8693 `audience`). The

--- a/apps/auth-server/src/app/routes/ui/consent.test.ts
+++ b/apps/auth-server/src/app/routes/ui/consent.test.ts
@@ -558,3 +558,163 @@ describe('UI /ui/consent — agent scope-mode cap (ADR-007 §2, #184)', () => {
     expect(state.body).toBeUndefined();
   });
 });
+
+describe('UI /ui/consent — step-up authentication (ADR-007 §2, #185)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // Client whose allowlist includes a DANGEROUS scope (write:foo). Used to
+  // prove the mint path forces a fresh authentication before a dangerous grant.
+  const DANGEROUS_CLIENT = {
+    ...CLIENT,
+    scopes: ['read:foo', 'write:foo', 'email'],
+  };
+
+  const MINUTE = 60 * 1000;
+
+  function postBody(overrides: Record<string, unknown> = {}) {
+    return {
+      decision: 'allow',
+      allow_forever: '1',
+      csrf_token: 'csrf-su',
+      client_id: 'app-123',
+      redirect_uri: 'https://example.com/cb',
+      state: 'xyz',
+      scope: 'write:foo',
+      code_challenge: 'A'.repeat(43),
+      code_challenge_method: 'S256',
+      response_type: 'code',
+      ...overrides,
+    };
+  }
+
+  function session(createdAt: number) {
+    return {
+      userId: 'user-1',
+      email: 'a@b.com',
+      sessionId: 'sid-su',
+      csrfToken: 'csrf-su',
+      createdAt,
+    };
+  }
+
+  it('refuses to mint a code for a dangerous scope on a STALE session and bounces to /ui/login', async () => {
+    const { fastify, ctx } = makeFastify();
+    await consentRoute(fastify);
+    const { signSessionId } = await import('../../helpers/session-cookie');
+    const signed = signSessionId('sid-su');
+    // Session authenticated 10 minutes ago — outside the 2-minute fresh window.
+    (fastify.sessionUtils.getSession as unknown as Mock).mockResolvedValue(
+      session(Date.now() - 10 * MINUTE)
+    );
+    (fastify.repositories.oauthClients.findByClientId as unknown as Mock).mockResolvedValue(
+      DANGEROUS_CLIENT
+    );
+
+    const { reply, state } = createReply();
+    await ctx.post!(
+      {
+        body: postBody(),
+        headers: { cookie: `__Host-qauth_session=${signed}` },
+        ip: '127.0.0.1',
+      },
+      reply
+    );
+
+    // Bounced to login (fresh-auth required); NO code, NO grant persisted.
+    expect(state.redirected).toContain('/ui/login?return_to=');
+    // The dangerous scope survives the round-trip; the return_to is itself
+    // URL-encoded, so `scope=write:foo` appears doubly-encoded.
+    expect(decodeURIComponent(state.redirected as string)).toContain('scope=write%3Afoo');
+    expect(fastify.repositories.authorizationCodes.create).not.toHaveBeenCalled();
+    expect(fastify.repositories.oauthConsents.upsertGrant).not.toHaveBeenCalled();
+    // The step-up requirement is audited.
+    const events = (fastify.repositories.auditLogs.create as unknown as Mock).mock.calls.map(
+      (c) => (c[0] as { event: string }).event
+    );
+    expect(events).toContain('oauth.stepup.required');
+  });
+
+  it('mints a dangerous-scope code on a FRESH session and audits the elevation', async () => {
+    const { fastify, ctx } = makeFastify();
+    await consentRoute(fastify);
+    const { signSessionId } = await import('../../helpers/session-cookie');
+    const signed = signSessionId('sid-su');
+    // Authenticated 5 seconds ago — within the fresh-auth window.
+    (fastify.sessionUtils.getSession as unknown as Mock).mockResolvedValue(
+      session(Date.now() - 5000)
+    );
+    (fastify.repositories.oauthClients.findByClientId as unknown as Mock).mockResolvedValue(
+      DANGEROUS_CLIENT
+    );
+
+    const { reply, state } = createReply();
+    await ctx.post!(
+      {
+        body: postBody(),
+        headers: { cookie: `__Host-qauth_session=${signed}` },
+        ip: '127.0.0.1',
+      },
+      reply
+    );
+
+    expect(state.redirected).toContain('https://example.com/cb');
+    expect(state.redirected).toContain('code=');
+    expect(fastify.repositories.authorizationCodes.create).toHaveBeenCalledOnce();
+    const events = (fastify.repositories.auditLogs.create as unknown as Mock).mock.calls.map(
+      (c) => (c[0] as { event: string }).event
+    );
+    expect(events).toContain('oauth.stepup.elevation');
+    expect(events).toContain('oauth.consent.granted');
+  });
+
+  it('forces fresh auth for prompt=login on a stale session even with a non-dangerous scope', async () => {
+    const { fastify, ctx } = makeFastify();
+    await consentRoute(fastify);
+    const { signSessionId } = await import('../../helpers/session-cookie');
+    const signed = signSessionId('sid-su');
+    (fastify.sessionUtils.getSession as unknown as Mock).mockResolvedValue(
+      session(Date.now() - 10 * MINUTE)
+    );
+    (fastify.repositories.oauthClients.findByClientId as unknown as Mock).mockResolvedValue(CLIENT);
+
+    const { reply, state } = createReply();
+    await ctx.post!(
+      {
+        body: postBody({ scope: 'email', prompt: 'login' }),
+        headers: { cookie: `__Host-qauth_session=${signed}` },
+        ip: '127.0.0.1',
+      },
+      reply
+    );
+
+    expect(state.redirected).toContain('/ui/login?return_to=');
+    expect(fastify.repositories.authorizationCodes.create).not.toHaveBeenCalled();
+  });
+
+  it('mints a non-dangerous scope without step-up on a stale session (no over-gating)', async () => {
+    const { fastify, ctx } = makeFastify();
+    await consentRoute(fastify);
+    const { signSessionId } = await import('../../helpers/session-cookie');
+    const signed = signSessionId('sid-su');
+    (fastify.sessionUtils.getSession as unknown as Mock).mockResolvedValue(
+      session(Date.now() - 10 * MINUTE)
+    );
+    (fastify.repositories.oauthClients.findByClientId as unknown as Mock).mockResolvedValue(CLIENT);
+
+    const { reply, state } = createReply();
+    await ctx.post!(
+      {
+        body: postBody({ scope: 'email' }),
+        headers: { cookie: `__Host-qauth_session=${signed}` },
+        ip: '127.0.0.1',
+      },
+      reply
+    );
+
+    expect(state.redirected).toContain('https://example.com/cb');
+    expect(state.redirected).toContain('code=');
+    expect(fastify.repositories.authorizationCodes.create).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/auth-server/src/app/routes/ui/consent.ts
+++ b/apps/auth-server/src/app/routes/ui/consent.ts
@@ -573,6 +573,11 @@ export default async function (fastify: FastifyInstance) {
       // resetting auth_time). Prior consent is intentionally NOT consulted here
       // — every scope about to be minted is treated as needing the gate, so the
       // dangerous-op re-auth cannot be skipped by a stale prior grant.
+      // Only `requiresFreshLogin` is consulted on this mint path: the user is
+      // actively consenting (this IS the consent screen submit), so
+      // `requiresConsent` — always true here given `priorConsentScopes: []` —
+      // is irrelevant. We just need to confirm the authentication is fresh
+      // enough for whatever (incl. dangerous) scopes are about to be granted.
       const prompt = parsePromptMode(body.prompt);
       const stepUp = evaluateStepUp({
         requestedScopes: scopes,

--- a/apps/auth-server/src/app/routes/ui/consent.ts
+++ b/apps/auth-server/src/app/routes/ui/consent.ts
@@ -6,7 +6,7 @@ import { ZodTypeProvider } from 'fastify-type-provider-zod';
 import { z } from 'zod';
 
 import { env } from '../../../config/env';
-import { AUTHORIZATION_CODE_TTL_MS } from '../../constants';
+import { AUTHORIZATION_CODE_TTL_MS, STEP_UP_FRESH_AUTH_WINDOW_MS } from '../../constants';
 import { resolveBrowserSession } from '../../helpers/browser-session';
 import { findExceedingAgentScopesForClient } from '../../helpers/client-auth';
 import { resolveClient } from '../../helpers/client-resolution';
@@ -26,6 +26,7 @@ import {
   csrfTokensEqual,
   generateCsrfToken,
 } from '../../helpers/session-cookie';
+import { evaluateStepUp, isDangerousScope, parsePromptMode } from '../../helpers/step-up';
 import { authorizeQuerySchema, resourceParamSchema } from '../../schemas/oauth';
 
 /**
@@ -68,6 +69,12 @@ const consentFormSchema = z.object({
   code_challenge: z.string().min(43).max(128),
   code_challenge_method: z.literal('S256'),
   response_type: z.literal('code'),
+  // ADR-007 §2 (#185): step-up params carried through so the POST mint path
+  // re-evaluates them server-side (the hidden `scope` field is
+  // attacker-controlled, so the dangerous-elevation re-auth gate must run HERE
+  // too, not only pre-consent). Empty string ⇒ treated as absent.
+  prompt: z.enum(['none', 'login', 'consent']).optional(),
+  max_age: z.coerce.number().int().min(0).max(315360000).optional(),
   // RFC 8707: carried through as hidden form field(s). POST body transforms
   // work (unlike GET querystrings), so `resourceParamSchema` populates an
   // array on `body.resource`.
@@ -76,7 +83,7 @@ const consentFormSchema = z.object({
 
 type ConsentForm = z.infer<typeof consentFormSchema>;
 
-function buildAuthorizeUrl(query: Record<string, string | string[] | undefined>): string {
+function buildAuthorizeUrl(query: Record<string, string | string[] | number | undefined>): string {
   const u = new URL('/oauth/authorize', 'http://placeholder');
   for (const [k, v] of Object.entries(query)) {
     if (v == null) continue;
@@ -86,8 +93,11 @@ function buildAuthorizeUrl(query: Record<string, string | string[] | undefined>)
       for (const entry of v) {
         if (entry !== '') u.searchParams.append(k, entry);
       }
-    } else if (v !== '') {
-      u.searchParams.set(k, v);
+    } else {
+      // `max_age` arrives as a number from the parsed query; stringify before
+      // appending. Empty strings are dropped to keep the URL clean.
+      const s = String(v);
+      if (s !== '') u.searchParams.set(k, s);
     }
   }
   // Return only the path + query portion; login's return_to rejects absolute.
@@ -394,6 +404,10 @@ export default async function (fastify: FastifyInstance) {
             code_challenge: query.code_challenge,
             code_challenge_method: query.code_challenge_method,
             response_type: query.response_type,
+            // ADR-007 §2 (#185): preserve the step-up params so the POST mint
+            // path re-evaluates them server-side.
+            prompt: query.prompt,
+            max_age: query.max_age !== undefined ? String(query.max_age) : undefined,
           },
           // RFC 8707: parsed directly from request.url (see
           // parseResourceFromUrl). Rendered as one hidden <input
@@ -448,6 +462,10 @@ export default async function (fastify: FastifyInstance) {
           code_challenge: body.code_challenge,
           code_challenge_method: body.code_challenge_method,
           response_type: body.response_type,
+          // ADR-007 §2 (#185): carry the step-up params back so /oauth/authorize
+          // re-applies them after the login round-trip.
+          prompt: body.prompt,
+          max_age: body.max_age !== undefined ? String(body.max_age) : undefined,
         });
         return reply.redirect(`/ui/login?return_to=${encodeURIComponent(returnTo)}`, 302);
       }
@@ -543,10 +561,64 @@ export default async function (fastify: FastifyInstance) {
         );
       }
 
+      const scopes = filterRequestedScopes(body.scope, client);
+
+      // ADR-007 §2 (#185): step-up gate on the mint path. Re-authentication is
+      // enforced HERE, not only pre-consent, because the hidden `scope`/`prompt`/
+      // `max_age` fields are attacker-controllable and the CSRF token binds the
+      // session, not the scope. A dangerous scope (write:* / agent:admin /
+      // agent:exec), `prompt=login`, or an exceeded `max_age` must be backed by
+      // a fresh authentication: if the session is stale we refuse to mint the
+      // code and bounce through /ui/login (which re-mints the session,
+      // resetting auth_time). Prior consent is intentionally NOT consulted here
+      // — every scope about to be minted is treated as needing the gate, so the
+      // dangerous-op re-auth cannot be skipped by a stale prior grant.
+      const prompt = parsePromptMode(body.prompt);
+      const stepUp = evaluateStepUp({
+        requestedScopes: scopes,
+        priorConsentScopes: [],
+        prompt,
+        maxAgeSeconds: body.max_age ?? null,
+        authTimeMs: session.createdAt,
+        nowMs: Date.now(),
+        freshAuthWindowMs: STEP_UP_FRESH_AUTH_WINDOW_MS,
+      });
+      if (stepUp.requiresFreshLogin) {
+        await fastify.repositories.auditLogs.create({
+          userId: session.userId,
+          oauthClientId: client.id,
+          event: 'oauth.stepup.required',
+          eventType: 'auth',
+          success: false,
+          ipAddress: request.ip,
+          userAgent: request.headers['user-agent'] || null,
+          metadata: {
+            client_id: body.client_id,
+            reason: 'fresh_authentication_required',
+            dangerous: stepUp.dangerous,
+            prompt: prompt ?? null,
+            maxAge: body.max_age ?? null,
+          },
+        });
+        const returnTo = buildAuthorizeUrl({
+          client_id: body.client_id,
+          redirect_uri: body.redirect_uri,
+          state: body.state,
+          scope: body.scope,
+          nonce: body.nonce,
+          code_challenge: body.code_challenge,
+          code_challenge_method: body.code_challenge_method,
+          response_type: body.response_type,
+          prompt: body.prompt,
+          max_age: body.max_age !== undefined ? String(body.max_age) : undefined,
+          resource: body.resource,
+        });
+        return reply.redirect(`/ui/login?return_to=${encodeURIComponent(returnTo)}`, 302);
+      }
+
       // Allow: persist the grant if the user checked the box, then issue a
       // code. The grant upsert merges with any prior record so subsequent
       // requests with a subset of these scopes skip the screen.
-      const scopes = filterRequestedScopes(body.scope, client);
       if (body.allow_forever === '1') {
         await fastify.repositories.oauthConsents.upsertGrant(
           session.userId,
@@ -586,6 +658,29 @@ export default async function (fastify: FastifyInstance) {
       }
       if (!code) throw new Error('Unreachable');
 
+      // ADR-007 §2 (#185): every elevation that grants a dangerous scope is
+      // audited as a distinct step-up event (in addition to the normal
+      // consent.granted record), with the fresh `auth_time` so an operator can
+      // see the dangerous grant was minted right after a re-authentication.
+      const dangerousGranted = scopes.filter(isDangerousScope);
+      if (dangerousGranted.length > 0) {
+        await fastify.repositories.auditLogs.create({
+          userId: session.userId,
+          oauthClientId: client.id,
+          event: 'oauth.stepup.elevation',
+          eventType: 'auth',
+          success: true,
+          ipAddress: request.ip,
+          userAgent: request.headers['user-agent'] || null,
+          metadata: {
+            client_id: body.client_id,
+            dangerousScopes: dangerousGranted,
+            scopes,
+            authTime: session.createdAt,
+          },
+        });
+      }
+
       await fastify.repositories.auditLogs.create({
         userId: session.userId,
         oauthClientId: client.id,
@@ -598,6 +693,7 @@ export default async function (fastify: FastifyInstance) {
           client_id: body.client_id,
           scopes,
           remembered: body.allow_forever === '1',
+          dangerousScopes: dangerousGranted,
         },
       });
 

--- a/apps/auth-server/src/app/schemas/oauth.ts
+++ b/apps/auth-server/src/app/schemas/oauth.ts
@@ -36,6 +36,13 @@ export const authorizeQuerySchema = z.object({
   state: z.string().max(255).optional(),
   scope: z.string().optional(),
   nonce: z.string().max(255).optional(),
+  // OIDC Core §3.1.2.1 step-up parameters (ADR-007 §2, #185). `prompt` forces
+  // a fresh authentication (`login`) or re-consent (`consent`); `max_age`
+  // bounds, in seconds, how old the existing authentication may be before a
+  // re-authentication is required (`0` ⇒ always re-authenticate). Only the
+  // values QAuth acts on are accepted; anything else is rejected at the edge.
+  prompt: z.enum(['none', 'login', 'consent']).optional(),
+  max_age: z.coerce.number().int().min(0).max(315360000).optional(),
   resource: resourceParamSchema,
 });
 


### PR DESCRIPTION
## Summary

Implements **step-up authentication before dangerous operations** (ADR-007 §2, epic #181) — the **authorization-server** half of the `mcp-guard` `403 insufficient_scope` → re-authorize → retry loop. A client may re-authorize for an increased scope set (incremental consent, MCP 2025-11-25) or a higher agent mode, but **only through a fresh authentication / explicit consent** — never a silent widening of an existing session or prior consent. Honors the epic #181 default-deny requirement: elevation never trusts a self-asserted client signal.

Also folds in the **two `TODO(#184)` scope-cap wirings** that were blocked until #182/#183/#184 merged (now all on `main`).

`Closes #185`

## Part A — Step-up (#185)

New pure helper `helpers/step-up.ts`:
- **`isDangerousScope()`** — the single policy hook for "dangerous": `write:*` scopes and the higher agent modes `agent:admin` / `agent:exec` (`agent:readonly` is not dangerous).
- **`evaluateStepUp()`** — default-deny decision:
  - Any scope beyond the active prior consent is an *elevation* ⇒ **re-consent** (never auto-widen).
  - A dangerous elevation, `prompt=login`, or an exceeded `max_age` ⇒ **fresh login**.
  - A recent (in-window) authentication satisfies the login requirement, so the post-login return trip does not loop; `max_age` is enforced exactly and is **not** widened by the freshness window (`STEP_UP_FRESH_AUTH_WINDOW_MS`, 2 min).

Wiring:
- **schema** — accept OIDC `prompt` (`none|login|consent`) and `max_age` on `/oauth/authorize`, carried through `/ui/consent` as hidden fields.
- **`/oauth/authorize`** — on a browser session, evaluate step-up against the active prior consent; force `/ui/login` (a fresh login always mints a new session ⇒ fresh `auth_time`) or `/ui/consent` as required; audit `oauth.stepup.required`.
- **`/ui/consent` POST** — re-evaluate step-up on the code-minting path (the hidden `scope`/`prompt`/`max_age` fields are attacker-controllable, so the dangerous-op re-auth gate runs here too, not only pre-consent); audit `oauth.stepup.elevation` on every dangerous grant.

The `mcp-guard` 403 → re-authorize → retry loop now closes end-to-end: the resource server's scope challenge sends the client back to `/oauth/authorize` with the wider scope (optionally `prompt=consent`/`max_age=0`), which forces fresh consent/auth before minting the elevated code.

## Part B — resolved `TODO(#184)` wirings

Both markers are **gone**, replaced with real enforcement using #184's helpers (`toAgentScopeContext`, `enforceAgentScopeCap`, `validateScopes`' agent arg):
1. **`client_credentials`** (`handleClientCredentials`) — `validateScopes(body.scope, client.scopes, toAgentScopeContext(client))` clamps reserved agent-mode scopes to the agent's `max_agent_mode`.
2. **token-exchange** (`handleTokenExchange`) — GATE 4c: `enforceAgentScopeCap` on the narrowed delegated scope so a capped agent cannot launder a higher-mode scope through delegation.

Both are deny-by-default + fail-closed. The `it.todo` tracking marker in `client-auth.test.ts` is replaced by end-to-end tests in `token.test.ts`.

## Tests
- `step-up.test.ts` — helper unit tests (dangerous classification, elevation, prompt/max_age/freshness window).
- `authorize.test.ts` / `consent.test.ts` — elevation requires fresh consent (cannot silently widen), dangerous-op gating forces fresh login on a stale session, no-loop on a fresh session, `prompt=login` / `max_age=0`, audit emitted.
- `token.test.ts` — both `#184` wirings (capped agent's `client_credentials` + token-exchange scope clamped; in-cap allowed; non-agent / null-cap denied).

## CI
`pnpm nx run-many -t lint typecheck test build -p auth-server infra-db` — **green**.

https://claude.ai/code/session_01Re2rxPkdcgzJe7LSddhxv6
