### PR TITLE
feat(db): per-agent action audit (ADR-007 §2)

### DIFF
--- a/apps/auth-server/src/app/helpers/agent-audit.test.ts
+++ b/apps/auth-server/src/app/helpers/agent-audit.test.ts
@@ -1,0 +1,50 @@
+import type { ActClaim } from '@qauth-labs/fastify-plugin-jwt';
+import { describe, expect, it } from 'vitest';
+
+import { delegationChainColumn, flattenActChain } from './agent-audit';
+
+describe('flattenActChain (ADR-007 §2, #186)', () => {
+  it('returns [] for undefined', () => {
+    expect(flattenActChain(undefined)).toEqual([]);
+  });
+
+  it('flattens a single actor', () => {
+    expect(flattenActChain({ sub: 'agentA' })).toEqual(['agentA']);
+  });
+
+  it('flattens a nested chain, outermost (most recent) actor first', () => {
+    const act: ActClaim = { sub: 'agentB', act: { sub: 'agentA' } };
+    expect(flattenActChain(act)).toEqual(['agentB', 'agentA']);
+  });
+
+  it('takes ONLY the sub (public client_id) from each link', () => {
+    // Even if extra claims were present, only `sub` is read — no token/secret
+    // material can leak into the persisted chain.
+    const act = { sub: 'agentB', extra: 'secret', act: { sub: 'agentA' } } as unknown as ActClaim;
+    expect(flattenActChain(act)).toEqual(['agentB', 'agentA']);
+  });
+
+  it('skips links with a missing/empty sub without breaking the walk', () => {
+    const act = { sub: '', act: { sub: 'agentA' } } as ActClaim;
+    expect(flattenActChain(act)).toEqual(['agentA']);
+  });
+
+  it('is bounded by maxDepth against a hostile/over-deep chain', () => {
+    let act: ActClaim = { sub: 'a0' };
+    for (let i = 1; i <= 50; i++) act = { sub: `a${i}`, act };
+    expect(flattenActChain(act, 4)).toHaveLength(4);
+  });
+});
+
+describe('delegationChainColumn (ADR-007 §2, #186)', () => {
+  it('returns null when there is no delegation (keeps the column NULL)', () => {
+    expect(delegationChainColumn(undefined)).toBeNull();
+  });
+
+  it('returns the chain array when delegated', () => {
+    expect(delegationChainColumn({ sub: 'agentB', act: { sub: 'agentA' } })).toEqual([
+      'agentB',
+      'agentA',
+    ]);
+  });
+});

--- a/apps/auth-server/src/app/helpers/agent-audit.ts
+++ b/apps/auth-server/src/app/helpers/agent-audit.ts
@@ -1,0 +1,48 @@
+/**
+ * Per-agent action audit helpers (ADR-007 §2, issue #186).
+ *
+ * Turns the RFC 8693 `act` (actor) delegation chain into an accountable,
+ * queryable record on `audit_logs`. These helpers extract ONLY public client
+ * identifiers from the chain — never any token, secret, or subject material —
+ * so the resulting audit fields are safe to persist and to surface in a future
+ * developer-portal "agent activity" view.
+ */
+
+import type { ActClaim } from '@qauth-labs/fastify-plugin-jwt';
+
+/**
+ * Flatten an RFC 8693 `act` delegation chain into the ordered list of actor
+ * `client_id`s. Index 0 is the most recent (outermost) actor — the agent that
+ * performed THIS action — and each following entry is a prior actor, walking
+ * the nested `act` chain.
+ *
+ * Only the `sub` (the actor's `client_id`, a public identifier) is taken from
+ * each link; no other claim is read. Returns an empty array for `undefined`.
+ *
+ * A defensive depth bound mirrors the minting-side `MAX_DELEGATION_DEPTH` so a
+ * malformed or hostile chain cannot cause unbounded work here.
+ *
+ * @example
+ * // { sub: 'agentB', act: { sub: 'agentA' } } → ['agentB', 'agentA']
+ */
+export function flattenActChain(act: ActClaim | undefined, maxDepth = 16): string[] {
+  const chain: string[] = [];
+  let cursor: ActClaim | undefined = act;
+  while (cursor && chain.length < maxDepth) {
+    if (typeof cursor.sub === 'string' && cursor.sub.length > 0) {
+      chain.push(cursor.sub);
+    }
+    cursor = cursor.act;
+  }
+  return chain;
+}
+
+/**
+ * Convenience: the flattened chain as an `audit_logs.delegation_chain` value —
+ * the array when non-empty, or `null` when there was no delegation (keeps the
+ * column NULL for ordinary, non-delegated entries rather than `[]`).
+ */
+export function delegationChainColumn(act: ActClaim | undefined): string[] | null {
+  const chain = flattenActChain(act);
+  return chain.length > 0 ? chain : null;
+}

--- a/apps/auth-server/src/app/helpers/agent-audit.ts
+++ b/apps/auth-server/src/app/helpers/agent-audit.ts
@@ -11,6 +11,17 @@
 import type { ActClaim } from '@qauth-labs/fastify-plugin-jwt';
 
 /**
+ * Maximum delegation depth (number of nested `act` actors) QAuth will mint —
+ * the single source of truth shared by the token-exchange minting gate
+ * (`token.ts`) and the audit-chain flattener below. Each re-exchange nests
+ * another `act`, growing the JWT unboundedly; this cap bounds token size (DoS)
+ * and keeps provenance legible. A chain that would exceed it is rejected at
+ * mint time, so a *verified* QAuth token never carries more than this many
+ * actors.
+ */
+export const MAX_DELEGATION_DEPTH = 4;
+
+/**
  * Flatten an RFC 8693 `act` delegation chain into the ordered list of actor
  * `client_id`s. Index 0 is the most recent (outermost) actor — the agent that
  * performed THIS action — and each following entry is a prior actor, walking
@@ -19,13 +30,17 @@ import type { ActClaim } from '@qauth-labs/fastify-plugin-jwt';
  * Only the `sub` (the actor's `client_id`, a public identifier) is taken from
  * each link; no other claim is read. Returns an empty array for `undefined`.
  *
- * A defensive depth bound mirrors the minting-side `MAX_DELEGATION_DEPTH` so a
- * malformed or hostile chain cannot cause unbounded work here.
+ * The depth bound is {@link MAX_DELEGATION_DEPTH} — the same cap the minting
+ * gate enforces — so a verified token's chain is never truncated, while a
+ * malformed or hostile chain still cannot cause unbounded work here.
  *
  * @example
  * // { sub: 'agentB', act: { sub: 'agentA' } } → ['agentB', 'agentA']
  */
-export function flattenActChain(act: ActClaim | undefined, maxDepth = 16): string[] {
+export function flattenActChain(
+  act: ActClaim | undefined,
+  maxDepth = MAX_DELEGATION_DEPTH
+): string[] {
   const chain: string[] = [];
   let cursor: ActClaim | undefined = act;
   while (cursor && chain.length < maxDepth) {

--- a/apps/auth-server/src/app/helpers/scope-modes.test.ts
+++ b/apps/auth-server/src/app/helpers/scope-modes.test.ts
@@ -5,6 +5,7 @@ import {
   AGENT_MODES,
   agentModeForScope,
   findExceedingAgentScopes,
+  highestAgentModeInScopes,
   isAgentModeScope,
   isModeWithinCap,
   parseAgentMode,
@@ -117,5 +118,26 @@ describe('findExceedingAgentScopes — deny-by-default enforcement', () => {
       'agent:admin',
       'agent:exec',
     ]);
+  });
+});
+
+describe('highestAgentModeInScopes — audit attribution (ADR-007 §2, #186)', () => {
+  it('returns null when no agent-mode scope is present', () => {
+    expect(highestAgentModeInScopes(['read:foo', 'email'])).toBeNull();
+    expect(highestAgentModeInScopes([])).toBeNull();
+  });
+
+  it('returns the single mode present', () => {
+    expect(highestAgentModeInScopes(['read:foo', 'agent:readonly'])).toBe('readonly');
+    expect(highestAgentModeInScopes(['agent:admin'])).toBe('admin');
+  });
+
+  it('returns the HIGHEST mode when several are present', () => {
+    expect(highestAgentModeInScopes(['agent:readonly', 'agent:exec', 'agent:admin'])).toBe('exec');
+    expect(highestAgentModeInScopes(['agent:readonly', 'agent:admin'])).toBe('admin');
+  });
+
+  it('ignores non-reserved agent:* scopes', () => {
+    expect(highestAgentModeInScopes(['agent:other', 'read:foo'])).toBeNull();
   });
 });

--- a/apps/auth-server/src/app/helpers/scope-modes.ts
+++ b/apps/auth-server/src/app/helpers/scope-modes.ts
@@ -108,6 +108,28 @@ export function isModeWithinCap(mode: AgentMode, cap: AgentMode | null): boolean
 }
 
 /**
+ * The HIGHEST agent scope mode present in a granted scope set, or `null` when
+ * the set carries no reserved agent-mode scope. Used for audit attribution
+ * (#186): records the effective mode an agent acted under (e.g. a token
+ * granting both `agent:readonly` and `agent:exec` is attributed as `exec`).
+ *
+ * This is a read-only summarizer over an ALREADY-AUTHORISED scope set — it
+ * does not gate anything (the cap is enforced upstream); it only labels the
+ * audit row. Returns `null` (not a default mode) when no mode scope is present.
+ */
+export function highestAgentModeInScopes(scopes: readonly string[]): AgentMode | null {
+  let highest: AgentMode | null = null;
+  for (const scope of scopes) {
+    const mode = agentModeForScope(scope);
+    if (mode === null) continue;
+    if (highest === null || AGENT_MODE_RANK[mode] > AGENT_MODE_RANK[highest]) {
+      highest = mode;
+    }
+  }
+  return highest;
+}
+
+/**
  * Enforce the agent scope-mode cap against a set of already-parsed scopes,
  * BEFORE the ordinary allowlist machinery runs.
  *

--- a/apps/auth-server/src/app/helpers/scope-modes.ts
+++ b/apps/auth-server/src/app/helpers/scope-modes.ts
@@ -116,6 +116,12 @@ export function isModeWithinCap(mode: AgentMode, cap: AgentMode | null): boolean
  * This is a read-only summarizer over an ALREADY-AUTHORISED scope set — it
  * does not gate anything (the cap is enforced upstream); it only labels the
  * audit row. Returns `null` (not a default mode) when no mode scope is present.
+ *
+ * Recording only the single highest mode is intentional: it is the effective
+ * privilege ceiling the action ran under (and matches the cap rank used by
+ * `enforceAgentScopeCap`). No information is lost — the FULL granted scope set,
+ * including every `agent:*` scope, is preserved verbatim in the audit row's
+ * `metadata.scope`; `scope_mode` is the queryable rollup over that detail.
  */
 export function highestAgentModeInScopes(scopes: readonly string[]): AgentMode | null {
   let highest: AgentMode | null = null;

--- a/apps/auth-server/src/app/routes/oauth/token.test.ts
+++ b/apps/auth-server/src/app/routes/oauth/token.test.ts
@@ -833,6 +833,40 @@ describe('POST /oauth/token route — client_credentials grant', () => {
       );
     });
 
+    it('per-agent audit (#186): client_credentials success persists no secret/token material', async () => {
+      const { fastify, ctx } = createFastifyStub();
+      await tokenRoute(fastify);
+      const handler = ctx.handler;
+      (fastify.repositories.oauthClients.findByClientId as unknown as Mock).mockResolvedValue(
+        ccAgentClient({ maxAgentMode: 'exec' })
+      );
+      (fastify.passwordHasher.verifyPassword as unknown as Mock).mockResolvedValue(true);
+      (fastify.jwtUtils.signAccessToken as unknown as Mock).mockResolvedValue('cc-access.jwt');
+
+      if (!handler) throw new Error('Handler missing');
+      await handler(
+        {
+          body: {
+            grant_type: 'client_credentials',
+            client_id: 'cc-agent',
+            client_secret: 'cc-super-secret',
+            scope: 'agent:exec',
+          },
+          ip: '127.0.0.1',
+          headers: { 'user-agent': 'vitest' },
+        },
+        createReply()
+      );
+
+      const successCall = (
+        fastify.repositories.auditLogs.create as unknown as Mock
+      ).mock.calls.find(([arg]) => arg?.event === 'oauth.token.exchange.success');
+      expect(successCall).toBeDefined();
+      const serialized = JSON.stringify(successCall?.[0]);
+      expect(serialized).not.toContain('cc-super-secret');
+      expect(serialized).not.toContain('cc-access.jwt');
+    });
+
     it('per-agent audit (#186): NON-agent client_credentials success records no agent attribution', async () => {
       const { fastify, ctx } = createFastifyStub();
       await tokenRoute(fastify);

--- a/apps/auth-server/src/app/routes/oauth/token.test.ts
+++ b/apps/auth-server/src/app/routes/oauth/token.test.ts
@@ -807,6 +807,76 @@ describe('POST /oauth/token route — client_credentials grant', () => {
       );
     });
 
+    it('per-agent audit (#186): agent client_credentials success attributes actor + scope mode', async () => {
+      const { fastify, ctx } = createFastifyStub();
+      await tokenRoute(fastify);
+      const handler = ctx.handler;
+      (fastify.repositories.oauthClients.findByClientId as unknown as Mock).mockResolvedValue(
+        ccAgentClient({ maxAgentMode: 'exec' })
+      );
+      (fastify.passwordHasher.verifyPassword as unknown as Mock).mockResolvedValue(true);
+      (fastify.jwtUtils.signAccessToken as unknown as Mock).mockResolvedValue('jwt');
+
+      if (!handler) throw new Error('Handler missing');
+      await handler(ccRequest('agent:exec'), createReply());
+
+      // No subject user (machine token) and no delegation chain, but the agent
+      // and its effective scope mode are attributed for the agent-activity view.
+      expect(fastify.repositories.auditLogs.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: 'oauth.token.exchange.success',
+          success: true,
+          userId: null,
+          actorClientId: 'cc-agent',
+          scopeMode: 'exec',
+        })
+      );
+    });
+
+    it('per-agent audit (#186): NON-agent client_credentials success records no agent attribution', async () => {
+      const { fastify, ctx } = createFastifyStub();
+      await tokenRoute(fastify);
+      const handler = ctx.handler;
+      const plainClient = {
+        id: 'plain-uuid',
+        clientId: 'plain-machine',
+        clientSecretHash: 'hash',
+        enabled: true,
+        grantTypes: ['client_credentials'],
+        scopes: ['read:foo'],
+        audience: null,
+        isAgent: false,
+      };
+      (fastify.repositories.oauthClients.findByClientId as unknown as Mock).mockResolvedValue(
+        plainClient
+      );
+      (fastify.passwordHasher.verifyPassword as unknown as Mock).mockResolvedValue(true);
+      (fastify.jwtUtils.signAccessToken as unknown as Mock).mockResolvedValue('jwt');
+
+      if (!handler) throw new Error('Handler missing');
+      await handler(
+        {
+          body: {
+            grant_type: 'client_credentials',
+            client_id: 'plain-machine',
+            client_secret: 'secret',
+            scope: 'read:foo',
+          },
+          ip: '127.0.0.1',
+          headers: { 'user-agent': 'vitest' },
+        },
+        createReply()
+      );
+
+      expect(fastify.repositories.auditLogs.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: 'oauth.token.exchange.success',
+          actorClientId: null,
+          scopeMode: null,
+        })
+      );
+    });
+
     it('rejects an agent-mode scope above the cap (exec > readonly) with invalid_scope', async () => {
       const { fastify, ctx } = createFastifyStub();
       await tokenRoute(fastify);
@@ -1675,6 +1745,50 @@ describe('POST /oauth/token route — token-exchange grant (RFC 8693, ADR-007 §
     const { fastify, ctx } = setupExchangeStub({ subjectAct: deepAct });
     await expect(invoke(fastify, ctx, exchangeRequest())).rejects.toThrow(InvalidRequestError);
     expect(fastify.jwtUtils.signAccessToken).not.toHaveBeenCalled();
+  });
+
+  it('per-agent audit (#186): success row carries actor + subject + act chain + scope mode', async () => {
+    // Agent capped at exec, subject token grants agent:exec; on-behalf-of of the
+    // end-user with a prior actor already in the chain.
+    const { fastify, ctx, client, user } = setupExchangeStub({
+      maxAgentMode: 'exec',
+      subjectScope: 'read:docs agent:exec',
+      subjectAct: { sub: 'prior-agent' },
+    });
+
+    await invoke(fastify, ctx, exchangeRequest());
+
+    expect(fastify.repositories.auditLogs.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'oauth.token.exchange.success',
+        eventType: 'token',
+        success: true,
+        // Subject = the end-user the agent acted on behalf of.
+        userId: user.id,
+        // Actor = the authenticated agent's client_id (denormalized, queryable).
+        actorClientId: client.clientId,
+        // Flattened RFC 8693 `act` chain: outermost (this agent) first.
+        delegationChain: [client.clientId, 'prior-agent'],
+        // Highest agent scope mode present in the granted set.
+        scopeMode: 'exec',
+      })
+    );
+  });
+
+  it('per-agent audit (#186): never persists token/secret material in audit fields', async () => {
+    const { fastify, ctx } = setupExchangeStub({ subjectScope: 'read:docs' });
+
+    await invoke(fastify, ctx, exchangeRequest({ client_secret: 'super-secret' }));
+
+    const successCall = (fastify.repositories.auditLogs.create as unknown as Mock).mock.calls.find(
+      ([arg]) => arg?.event === 'oauth.token.exchange.success'
+    );
+    expect(successCall).toBeDefined();
+    const serialized = JSON.stringify(successCall?.[0]);
+    // No subject/actor token, no client secret, no raw delegated token.
+    expect(serialized).not.toContain('subject.jwt.token');
+    expect(serialized).not.toContain('super-secret');
+    expect(serialized).not.toContain('delegated.jwt');
   });
 
   it('narrows scope to a subset of the subject token scope', async () => {

--- a/apps/auth-server/src/app/routes/oauth/token.ts
+++ b/apps/auth-server/src/app/routes/oauth/token.ts
@@ -16,7 +16,7 @@ import { ZodTypeProvider } from 'fastify-type-provider-zod';
 
 import { env } from '../../../config/env';
 import { MIN_RESPONSE_TIME_MS } from '../../constants';
-import { flattenActChain } from '../../helpers/agent-audit';
+import { flattenActChain, MAX_DELEGATION_DEPTH } from '../../helpers/agent-audit';
 import {
   authenticateClient,
   authenticateClientPublicOrConfidential,
@@ -872,15 +872,6 @@ function actDepth(act: ActClaim | undefined): number {
   }
   return depth;
 }
-
-/**
- * Maximum delegation depth (number of nested `act` actors) we will mint. Each
- * additional hop appends a nested `act`, growing the JWT unboundedly; an
- * attacker chaining re-exchanges could otherwise inflate token size (DoS) and
- * obscure provenance. A small cap bounds both. Re-exchanging an already-deep
- * delegated token past the limit → `invalid_request`.
- */
-const MAX_DELEGATION_DEPTH = 4;
 
 /**
  * Handle the OAuth 2.0 Token Exchange grant (RFC 8693) — QAuth's agent

--- a/apps/auth-server/src/app/routes/oauth/token.ts
+++ b/apps/auth-server/src/app/routes/oauth/token.ts
@@ -16,6 +16,7 @@ import { ZodTypeProvider } from 'fastify-type-provider-zod';
 
 import { env } from '../../../config/env';
 import { MIN_RESPONSE_TIME_MS } from '../../constants';
+import { flattenActChain } from '../../helpers/agent-audit';
 import {
   authenticateClient,
   authenticateClientPublicOrConfidential,
@@ -28,6 +29,7 @@ import {
 } from '../../helpers/client-auth';
 import { isAgentClient } from '../../helpers/client-resolution';
 import { getOrCreateDefaultRealm } from '../../helpers/realm';
+import { highestAgentModeInScopes } from '../../helpers/scope-modes';
 import { ensureMinimumResponseTime } from '../../helpers/timing';
 import {
   TOKEN_EXCHANGE_GRANT_TYPE,
@@ -539,9 +541,18 @@ async function handleClientCredentials(
 
   const accessTokenExpiresIn = fastify.jwtUtils.getAccessTokenLifespan();
 
+  // Per-agent action audit (ADR-007 §2, #186). client_credentials has no
+  // subject user and no on-behalf-of `act` chain — the agent acts as itself —
+  // so we attribute the agent and the effective scope mode but leave
+  // `delegationChain`/`userId` null. Only an agent client (fail-closed
+  // `isAgentClient`) is attributed; an ordinary machine client records no
+  // agent fields, keeping existing behavior for non-agent clients unchanged.
+  const isAgent = isAgentClient(client);
   await fastify.repositories.auditLogs.create({
     userId: null,
     oauthClientId: client.id,
+    actorClientId: isAgent ? client.clientId : null,
+    scopeMode: isAgent ? highestAgentModeInScopes(grantedScopes) : null,
     event: 'oauth.token.exchange.success',
     eventType: 'token',
     success: true,
@@ -1163,9 +1174,18 @@ async function handleTokenExchange(
     expiresInOverride: accessTokenExpiresIn,
   });
 
+  // Per-agent action audit (ADR-007 §2, #186). The delegated token was minted
+  // on behalf of `user` BY this agent — record the attribution as structured,
+  // queryable columns (agent client_id, the flattened `act` delegation chain,
+  // and the effective agent scope mode) on top of the existing metadata. Only
+  // public identifiers are stored; no subject/actor token, secret, or scope
+  // secret is ever persisted.
   await fastify.repositories.auditLogs.create({
     userId: user.id,
     oauthClientId: client.id,
+    actorClientId: client.clientId,
+    delegationChain: flattenActChain(act),
+    scopeMode: highestAgentModeInScopes(grantedScopes),
     event: 'oauth.token.exchange.success',
     eventType: 'token',
     success: true,

--- a/apps/auth-server/src/app/routes/ui/consent.test.ts
+++ b/apps/auth-server/src/app/routes/ui/consent.test.ts
@@ -707,6 +707,13 @@ describe('UI /ui/consent — step-up authentication (ADR-007 §2, #185)', () => 
       actorClientId: 'app-123',
       scopeMode: 'exec',
     });
+    // No-leak: the step-up elevation row must carry no session/CSRF secret,
+    // no minted code, and no token material — only public identifiers.
+    const serialized = JSON.stringify(elevation);
+    expect(serialized).not.toContain('csrf-su');
+    expect(serialized).not.toContain('sid-su');
+    expect(serialized).not.toContain(signed);
+    expect(serialized).not.toContain('code=');
   });
 
   it('per-agent audit (#186): elevation by a NON-agent client records no agent attribution', async () => {

--- a/apps/auth-server/src/app/routes/ui/consent.test.ts
+++ b/apps/auth-server/src/app/routes/ui/consent.test.ts
@@ -669,6 +669,76 @@ describe('UI /ui/consent — step-up authentication (ADR-007 §2, #185)', () => 
     expect(events).toContain('oauth.consent.granted');
   });
 
+  it('per-agent audit (#186): elevation by an agent client attributes actor + scope mode', async () => {
+    const { fastify, ctx } = makeFastify();
+    await consentRoute(fastify);
+    const { signSessionId } = await import('../../helpers/session-cookie');
+    const signed = signSessionId('sid-su');
+    (fastify.sessionUtils.getSession as unknown as Mock).mockResolvedValue(
+      session(Date.now() - 5000)
+    );
+    // An EXEC-capped agent elevating to the dangerous `agent:exec` scope.
+    const EXEC_AGENT = {
+      ...DANGEROUS_CLIENT,
+      isAgent: true,
+      maxAgentMode: 'exec' as const,
+      scopes: ['read:foo', 'agent:exec', 'email'],
+    };
+    (fastify.repositories.oauthClients.findByClientId as unknown as Mock).mockResolvedValue(
+      EXEC_AGENT
+    );
+
+    const { reply, state } = createReply();
+    await ctx.post!(
+      {
+        body: postBody({ scope: 'agent:exec' }),
+        headers: { cookie: `__Host-qauth_session=${signed}` },
+        ip: '127.0.0.1',
+      },
+      reply
+    );
+
+    expect(state.redirected).toContain('code=');
+    const elevation = (fastify.repositories.auditLogs.create as unknown as Mock).mock.calls
+      .map((c) => c[0])
+      .find((a) => a?.event === 'oauth.stepup.elevation');
+    expect(elevation).toMatchObject({
+      userId: 'user-1',
+      actorClientId: 'app-123',
+      scopeMode: 'exec',
+    });
+  });
+
+  it('per-agent audit (#186): elevation by a NON-agent client records no agent attribution', async () => {
+    const { fastify, ctx } = makeFastify();
+    await consentRoute(fastify);
+    const { signSessionId } = await import('../../helpers/session-cookie');
+    const signed = signSessionId('sid-su');
+    (fastify.sessionUtils.getSession as unknown as Mock).mockResolvedValue(
+      session(Date.now() - 5000)
+    );
+    (fastify.repositories.oauthClients.findByClientId as unknown as Mock).mockResolvedValue(
+      DANGEROUS_CLIENT
+    );
+
+    const { reply, state } = createReply();
+    await ctx.post!(
+      {
+        body: postBody(),
+        headers: { cookie: `__Host-qauth_session=${signed}` },
+        ip: '127.0.0.1',
+      },
+      reply
+    );
+
+    expect(state.redirected).toContain('code=');
+    const elevation = (fastify.repositories.auditLogs.create as unknown as Mock).mock.calls
+      .map((c) => c[0])
+      .find((a) => a?.event === 'oauth.stepup.elevation');
+    // Non-agent client: the elevation is still audited, but with no agent fields.
+    expect(elevation).toMatchObject({ actorClientId: null, scopeMode: null });
+  });
+
   it('forces fresh auth for prompt=login on a stale session even with a non-dangerous scope', async () => {
     const { fastify, ctx } = makeFastify();
     await consentRoute(fastify);

--- a/apps/auth-server/src/app/routes/ui/consent.ts
+++ b/apps/auth-server/src/app/routes/ui/consent.ts
@@ -9,7 +9,7 @@ import { env } from '../../../config/env';
 import { AUTHORIZATION_CODE_TTL_MS, STEP_UP_FRESH_AUTH_WINDOW_MS } from '../../constants';
 import { resolveBrowserSession } from '../../helpers/browser-session';
 import { findExceedingAgentScopesForClient } from '../../helpers/client-auth';
-import { resolveClient } from '../../helpers/client-resolution';
+import { isAgentClient, resolveClient } from '../../helpers/client-resolution';
 import {
   canSkipConsent,
   describeScope,
@@ -21,6 +21,7 @@ import {
 import { html, render, safe } from '../../helpers/html';
 import { buildRedirectUrl } from '../../helpers/oauth-redirect';
 import { getOrCreateDefaultRealm } from '../../helpers/realm';
+import { highestAgentModeInScopes } from '../../helpers/scope-modes';
 import {
   type BrowserSessionData,
   csrfTokensEqual,
@@ -669,9 +670,19 @@ export default async function (fastify: FastifyInstance) {
       // see the dangerous grant was minted right after a re-authentication.
       const dangerousGranted = scopes.filter(isDangerousScope);
       if (dangerousGranted.length > 0) {
+        // Per-agent action audit (ADR-007 §2, #186). When the elevating client
+        // is an agent (fail-closed `isAgentClient`), attribute the elevation to
+        // it and record the effective agent scope mode so the dangerous grant
+        // is accountable in the agent-activity view. A non-agent client records
+        // no agent fields (existing behavior unchanged). This is a user-driven
+        // consent elevation, not on-behalf-of delegation, so there is no `act`
+        // chain.
+        const elevatingAgent = isAgentClient(client);
         await fastify.repositories.auditLogs.create({
           userId: session.userId,
           oauthClientId: client.id,
+          actorClientId: elevatingAgent ? client.clientId : null,
+          scopeMode: elevatingAgent ? highestAgentModeInScopes(scopes) : null,
           event: 'oauth.stepup.elevation',
           eventType: 'auth',
           success: true,

--- a/libs/infra/db/drizzle/0006_lame_peter_parker.sql
+++ b/libs/infra/db/drizzle/0006_lame_peter_parker.sql
@@ -1,5 +1,0 @@
-ALTER TYPE "public"."audit_event_type" ADD VALUE 'agent';--> statement-breakpoint
-ALTER TABLE "audit_logs" ADD COLUMN "actor_client_id" varchar(255);--> statement-breakpoint
-ALTER TABLE "audit_logs" ADD COLUMN "delegation_chain" jsonb;--> statement-breakpoint
-ALTER TABLE "audit_logs" ADD COLUMN "scope_mode" "agent_mode";--> statement-breakpoint
-CREATE INDEX "idx_audit_logs_actor_client_id" ON "audit_logs" USING btree ("actor_client_id","created_at") WHERE "audit_logs"."actor_client_id" IS NOT NULL;

--- a/libs/infra/db/drizzle/0006_lame_peter_parker.sql
+++ b/libs/infra/db/drizzle/0006_lame_peter_parker.sql
@@ -1,0 +1,5 @@
+ALTER TYPE "public"."audit_event_type" ADD VALUE 'agent';--> statement-breakpoint
+ALTER TABLE "audit_logs" ADD COLUMN "actor_client_id" varchar(255);--> statement-breakpoint
+ALTER TABLE "audit_logs" ADD COLUMN "delegation_chain" jsonb;--> statement-breakpoint
+ALTER TABLE "audit_logs" ADD COLUMN "scope_mode" "agent_mode";--> statement-breakpoint
+CREATE INDEX "idx_audit_logs_actor_client_id" ON "audit_logs" USING btree ("actor_client_id","created_at") WHERE "audit_logs"."actor_client_id" IS NOT NULL;

--- a/libs/infra/db/drizzle/0006_open_wolfsbane.sql
+++ b/libs/infra/db/drizzle/0006_open_wolfsbane.sql
@@ -1,0 +1,6 @@
+ALTER TYPE "public"."audit_event_type" ADD VALUE 'agent';--> statement-breakpoint
+ALTER TABLE "audit_logs" ADD COLUMN "actor_client_id" varchar(255);--> statement-breakpoint
+ALTER TABLE "audit_logs" ADD COLUMN "delegation_chain" jsonb;--> statement-breakpoint
+ALTER TABLE "audit_logs" ADD COLUMN "scope_mode" "agent_mode";--> statement-breakpoint
+CREATE INDEX "idx_audit_logs_actor_client_id" ON "audit_logs" USING btree ("actor_client_id","created_at") WHERE "audit_logs"."actor_client_id" IS NOT NULL;--> statement-breakpoint
+ALTER TABLE "audit_logs" ADD CONSTRAINT "audit_logs_delegation_chain_is_array" CHECK ("audit_logs"."delegation_chain" IS NULL OR jsonb_typeof("audit_logs"."delegation_chain") = 'array');

--- a/libs/infra/db/drizzle/meta/0006_snapshot.json
+++ b/libs/infra/db/drizzle/meta/0006_snapshot.json
@@ -1,0 +1,2181 @@
+{
+  "id": "6ba97109-f6f9-405d-ad68-31c7f2135507",
+  "prevId": "bc158bc3-6e4e-456c-97ca-b83157a55ae5",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_client_id": {
+          "name": "oauth_client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event": {
+          "name": "event",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "audit_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_client_id": {
+          "name": "actor_client_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delegation_chain": {
+          "name": "delegation_chain",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope_mode": {
+          "name": "scope_mode",
+          "type": "agent_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(EXTRACT(EPOCH FROM NOW())::bigint * 1000)"
+        }
+      },
+      "indexes": {
+        "idx_audit_logs_user_id": {
+          "name": "idx_audit_logs_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_logs_oauth_client_id": {
+          "name": "idx_audit_logs_oauth_client_id",
+          "columns": [
+            {
+              "expression": "oauth_client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_logs_event_type": {
+          "name": "idx_audit_logs_event_type",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_logs_event": {
+          "name": "idx_audit_logs_event",
+          "columns": [
+            {
+              "expression": "event",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_logs_created_at": {
+          "name": "idx_audit_logs_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_logs_user_event": {
+          "name": "idx_audit_logs_user_event",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_logs_failed": {
+          "name": "idx_audit_logs_failed",
+          "columns": [
+            {
+              "expression": "event",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"audit_logs\".\"success\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_logs_ip_address": {
+          "name": "idx_audit_logs_ip_address",
+          "columns": [
+            {
+              "expression": "ip_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_logs_actor_client_id": {
+          "name": "idx_audit_logs_actor_client_id",
+          "columns": [
+            {
+              "expression": "actor_client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"audit_logs\".\"actor_client_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_logs_user_id_users_id_fk": {
+          "name": "audit_logs_user_id_users_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "audit_logs_oauth_client_id_oauth_clients_id_fk": {
+          "name": "audit_logs_oauth_client_id_oauth_clients_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "oauth_clients",
+          "columnsFrom": ["oauth_client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_consents": {
+      "name": "oauth_consents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oauth_client_id": {
+          "name": "oauth_client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "realm_id": {
+          "name": "realm_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(EXTRACT(EPOCH FROM NOW())::bigint * 1000)"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_oauth_consents_user_client_active": {
+          "name": "idx_oauth_consents_user_client_active",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "oauth_client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"oauth_consents\".\"revoked_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_oauth_consents_user_id": {
+          "name": "idx_oauth_consents_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_oauth_consents_client_id": {
+          "name": "idx_oauth_consents_client_id",
+          "columns": [
+            {
+              "expression": "oauth_client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_oauth_consents_realm_id": {
+          "name": "idx_oauth_consents_realm_id",
+          "columns": [
+            {
+              "expression": "realm_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_consents_user_id_users_id_fk": {
+          "name": "oauth_consents_user_id_users_id_fk",
+          "tableFrom": "oauth_consents",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_consents_oauth_client_id_oauth_clients_id_fk": {
+          "name": "oauth_consents_oauth_client_id_oauth_clients_id_fk",
+          "tableFrom": "oauth_consents",
+          "tableTo": "oauth_clients",
+          "columnsFrom": ["oauth_client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_consents_realm_id_realms_id_fk": {
+          "name": "oauth_consents_realm_id_realms_id_fk",
+          "tableFrom": "oauth_consents",
+          "tableTo": "realms",
+          "columnsFrom": ["realm_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_clients": {
+      "name": "oauth_clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "realm_id": {
+          "name": "realm_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret_hash": {
+          "name": "client_secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "audience": {
+          "name": "audience",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "require_pkce": {
+          "name": "require_pkce",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "token_endpoint_auth_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'client_secret_post'"
+        },
+        "grant_types": {
+          "name": "grant_types",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[\"authorization_code\",\"refresh_token\"]'::jsonb"
+        },
+        "response_types": {
+          "name": "response_types",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[\"code\"]'::jsonb"
+        },
+        "developer_id": {
+          "name": "developer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_agent": {
+          "name": "is_agent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "max_agent_mode": {
+          "name": "max_agent_mode",
+          "type": "agent_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dynamic_registered_at": {
+          "name": "dynamic_registered_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(EXTRACT(EPOCH FROM NOW())::bigint * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(EXTRACT(EPOCH FROM NOW())::bigint * 1000)"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_oauth_clients_realm_client_id_unique": {
+          "name": "idx_oauth_clients_realm_client_id_unique",
+          "columns": [
+            {
+              "expression": "realm_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_oauth_clients_client_id": {
+          "name": "idx_oauth_clients_client_id",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_oauth_clients_realm_id": {
+          "name": "idx_oauth_clients_realm_id",
+          "columns": [
+            {
+              "expression": "realm_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_oauth_clients_developer_id": {
+          "name": "idx_oauth_clients_developer_id",
+          "columns": [
+            {
+              "expression": "developer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_oauth_clients_enabled": {
+          "name": "idx_oauth_clients_enabled",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"oauth_clients\".\"enabled\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_oauth_clients_realm_client_id_enabled": {
+          "name": "idx_oauth_clients_realm_client_id_enabled",
+          "columns": [
+            {
+              "expression": "realm_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_clients_realm_id_realms_id_fk": {
+          "name": "oauth_clients_realm_id_realms_id_fk",
+          "tableFrom": "oauth_clients",
+          "tableTo": "realms",
+          "columnsFrom": ["realm_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_clients_developer_id_users_id_fk": {
+          "name": "oauth_clients_developer_id_users_id_fk",
+          "tableFrom": "oauth_clients",
+          "tableTo": "users",
+          "columnsFrom": ["developer_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "oauth_clients_audience_is_array": {
+          "name": "oauth_clients_audience_is_array",
+          "value": "\"oauth_clients\".\"audience\" IS NULL OR jsonb_typeof(\"oauth_clients\".\"audience\") = 'array'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.realms": {
+      "name": "realms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "access_token_lifespan": {
+          "name": "access_token_lifespan",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 900
+        },
+        "refresh_token_lifespan": {
+          "name": "refresh_token_lifespan",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 604800
+        },
+        "ssl_required": {
+          "name": "ssl_required",
+          "type": "ssl_required",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'external'"
+        },
+        "verify_email": {
+          "name": "verify_email",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "registration_allowed": {
+          "name": "registration_allowed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "login_with_email_allowed": {
+          "name": "login_with_email_allowed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "duplicate_emails_allowed": {
+          "name": "duplicate_emails_allowed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "password_policy": {
+          "name": "password_policy",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sso_idle_timeout": {
+          "name": "sso_idle_timeout",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sso_max_lifespan": {
+          "name": "sso_max_lifespan",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoke_refresh_token": {
+          "name": "revoke_refresh_token",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "refresh_token_max_reuse": {
+          "name": "refresh_token_max_reuse",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "default_locale": {
+          "name": "default_locale",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supported_locales": {
+          "name": "supported_locales",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "dynamic_registration_allowed_scopes": {
+          "name": "dynamic_registration_allowed_scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(EXTRACT(EPOCH FROM NOW())::bigint * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(EXTRACT(EPOCH FROM NOW())::bigint * 1000)"
+        }
+      },
+      "indexes": {
+        "idx_realms_enabled": {
+          "name": "idx_realms_enabled",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"realms\".\"enabled\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "realms_name_unique": {
+          "name": "realms_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "realm_id": {
+          "name": "realm_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_normalized": {
+          "name": "email_normalized",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(EXTRACT(EPOCH FROM NOW())::bigint * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(EXTRACT(EPOCH FROM NOW())::bigint * 1000)"
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_users_realm_email_normalized_unique": {
+          "name": "idx_users_realm_email_normalized_unique",
+          "columns": [
+            {
+              "expression": "realm_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email_normalized",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_email": {
+          "name": "idx_users_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_realm_id": {
+          "name": "idx_users_realm_id",
+          "columns": [
+            {
+              "expression": "realm_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_enabled": {
+          "name": "idx_users_enabled",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"users\".\"enabled\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_realm_email_enabled": {
+          "name": "idx_users_realm_email_enabled",
+          "columns": [
+            {
+              "expression": "realm_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email_normalized",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_realm_id_realms_id_fk": {
+          "name": "users_realm_id_realms_id_fk",
+          "tableFrom": "users",
+          "tableTo": "realms",
+          "columnsFrom": ["realm_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roles": {
+      "name": "roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "realm_id": {
+          "name": "realm_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_client_id": {
+          "name": "oauth_client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(EXTRACT(EPOCH FROM NOW())::bigint * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(EXTRACT(EPOCH FROM NOW())::bigint * 1000)"
+        }
+      },
+      "indexes": {
+        "idx_roles_realm_name_unique": {
+          "name": "idx_roles_realm_name_unique",
+          "columns": [
+            {
+              "expression": "realm_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "oauth_client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_roles_name": {
+          "name": "idx_roles_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_roles_realm_id": {
+          "name": "idx_roles_realm_id",
+          "columns": [
+            {
+              "expression": "realm_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_roles_oauth_client_id": {
+          "name": "idx_roles_oauth_client_id",
+          "columns": [
+            {
+              "expression": "oauth_client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "roles_realm_id_realms_id_fk": {
+          "name": "roles_realm_id_realms_id_fk",
+          "tableFrom": "roles",
+          "tableTo": "realms",
+          "columnsFrom": ["realm_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "roles_oauth_client_id_oauth_clients_id_fk": {
+          "name": "roles_oauth_client_id_oauth_clients_id_fk",
+          "tableFrom": "roles",
+          "tableTo": "oauth_clients",
+          "columnsFrom": ["oauth_client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_roles": {
+      "name": "user_roles",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigned_at": {
+          "name": "assigned_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(EXTRACT(EPOCH FROM NOW())::bigint * 1000)"
+        },
+        "assigned_by": {
+          "name": "assigned_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_user_roles_user_id": {
+          "name": "idx_user_roles_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_roles_role_id": {
+          "name": "idx_user_roles_role_id",
+          "columns": [
+            {
+              "expression": "role_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_roles_user_id_users_id_fk": {
+          "name": "user_roles_user_id_users_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_roles_role_id_roles_id_fk": {
+          "name": "user_roles_role_id_roles_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "roles",
+          "columnsFrom": ["role_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_roles_assigned_by_users_id_fk": {
+          "name": "user_roles_assigned_by_users_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "users",
+          "columnsFrom": ["assigned_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_roles_pk": {
+          "name": "user_roles_pk",
+          "columns": ["user_id", "role_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oauth_client_id": {
+          "name": "oauth_client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_hash": {
+          "name": "access_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_hash": {
+          "name": "refresh_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(EXTRACT(EPOCH FROM NOW())::bigint * 1000)"
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(EXTRACT(EPOCH FROM NOW())::bigint * 1000)"
+        }
+      },
+      "indexes": {
+        "idx_sessions_user_id": {
+          "name": "idx_sessions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sessions_active": {
+          "name": "idx_sessions_active",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"sessions\".\"revoked\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sessions_expires_at": {
+          "name": "idx_sessions_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sessions_access_token_hash": {
+          "name": "idx_sessions_access_token_hash",
+          "columns": [
+            {
+              "expression": "access_token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sessions_oauth_client_id": {
+          "name": "idx_sessions_oauth_client_id",
+          "columns": [
+            {
+              "expression": "oauth_client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sessions_oauth_client_id_oauth_clients_id_fk": {
+          "name": "sessions_oauth_client_id_oauth_clients_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "oauth_clients",
+          "columnsFrom": ["oauth_client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.authorization_codes": {
+      "name": "authorization_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oauth_client_id": {
+          "name": "oauth_client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge": {
+          "name": "code_challenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge_method": {
+          "name": "code_challenge_method",
+          "type": "code_challenge_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'S256'"
+        },
+        "nonce": {
+          "name": "nonce",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "resource": {
+          "name": "resource",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used": {
+          "name": "used",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(EXTRACT(EPOCH FROM NOW())::bigint * 1000)"
+        }
+      },
+      "indexes": {
+        "idx_authorization_codes_active": {
+          "name": "idx_authorization_codes_active",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"authorization_codes\".\"used\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_authorization_codes_expires_at": {
+          "name": "idx_authorization_codes_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_authorization_codes_user_id": {
+          "name": "idx_authorization_codes_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_authorization_codes_oauth_client_id": {
+          "name": "idx_authorization_codes_oauth_client_id",
+          "columns": [
+            {
+              "expression": "oauth_client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "authorization_codes_oauth_client_id_oauth_clients_id_fk": {
+          "name": "authorization_codes_oauth_client_id_oauth_clients_id_fk",
+          "tableFrom": "authorization_codes",
+          "tableTo": "oauth_clients",
+          "columnsFrom": ["oauth_client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "authorization_codes_user_id_users_id_fk": {
+          "name": "authorization_codes_user_id_users_id_fk",
+          "tableFrom": "authorization_codes",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "authorization_codes_code_unique": {
+          "name": "authorization_codes_code_unique",
+          "nullsNotDistinct": false,
+          "columns": ["code"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_verification_tokens": {
+      "name": "email_verification_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used": {
+          "name": "used",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(EXTRACT(EPOCH FROM NOW())::bigint * 1000)"
+        }
+      },
+      "indexes": {
+        "idx_email_verification_tokens_user_id": {
+          "name": "idx_email_verification_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_email_verification_tokens_active": {
+          "name": "idx_email_verification_tokens_active",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"email_verification_tokens\".\"used\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_email_verification_tokens_expires_at": {
+          "name": "idx_email_verification_tokens_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_verification_tokens_user_id_users_id_fk": {
+          "name": "email_verification_tokens_user_id_users_id_fk",
+          "tableFrom": "email_verification_tokens",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "email_verification_tokens_token_hash_unique": {
+          "name": "email_verification_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.refresh_tokens": {
+      "name": "refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oauth_client_id": {
+          "name": "oauth_client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "family_id": {
+          "name": "family_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "resource": {
+          "name": "resource",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_reason": {
+          "name": "revoked_reason",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_token_hash": {
+          "name": "previous_token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(EXTRACT(EPOCH FROM NOW())::bigint * 1000)"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_refresh_tokens_active": {
+          "name": "idx_refresh_tokens_active",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"refresh_tokens\".\"revoked\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_refresh_tokens_expires_at": {
+          "name": "idx_refresh_tokens_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_refresh_tokens_user_id": {
+          "name": "idx_refresh_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_refresh_tokens_oauth_client_id": {
+          "name": "idx_refresh_tokens_oauth_client_id",
+          "columns": [
+            {
+              "expression": "oauth_client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_refresh_tokens_user_active": {
+          "name": "idx_refresh_tokens_user_active",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"refresh_tokens\".\"revoked\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_refresh_tokens_family_id": {
+          "name": "idx_refresh_tokens_family_id",
+          "columns": [
+            {
+              "expression": "family_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "refresh_tokens_user_id_users_id_fk": {
+          "name": "refresh_tokens_user_id_users_id_fk",
+          "tableFrom": "refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "refresh_tokens_oauth_client_id_oauth_clients_id_fk": {
+          "name": "refresh_tokens_oauth_client_id_oauth_clients_id_fk",
+          "tableFrom": "refresh_tokens",
+          "tableTo": "oauth_clients",
+          "columnsFrom": ["oauth_client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "refresh_tokens_token_hash_unique": {
+          "name": "refresh_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.agent_mode": {
+      "name": "agent_mode",
+      "schema": "public",
+      "values": ["readonly", "admin", "exec"]
+    },
+    "public.audit_event_type": {
+      "name": "audit_event_type",
+      "schema": "public",
+      "values": ["auth", "token", "client", "security", "user", "realm", "agent"]
+    },
+    "public.code_challenge_method": {
+      "name": "code_challenge_method",
+      "schema": "public",
+      "values": ["S256"]
+    },
+    "public.grant_type": {
+      "name": "grant_type",
+      "schema": "public",
+      "values": ["authorization_code", "refresh_token", "client_credentials"]
+    },
+    "public.response_type": {
+      "name": "response_type",
+      "schema": "public",
+      "values": ["code"]
+    },
+    "public.ssl_required": {
+      "name": "ssl_required",
+      "schema": "public",
+      "values": ["none", "external", "all"]
+    },
+    "public.token_endpoint_auth_method": {
+      "name": "token_endpoint_auth_method",
+      "schema": "public",
+      "values": ["client_secret_post", "client_secret_basic", "private_key_jwt", "none"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/libs/infra/db/drizzle/meta/0006_snapshot.json
+++ b/libs/infra/db/drizzle/meta/0006_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "id": "6ba97109-f6f9-405d-ad68-31c7f2135507",
+  "id": "0b64f09c-13ff-480f-8c51-cb7a0aa33807",
   "prevId": "bc158bc3-6e4e-456c-97ca-b83157a55ae5",
   "version": "7",
   "dialect": "postgresql",
@@ -278,7 +278,12 @@
       "compositePrimaryKeys": {},
       "uniqueConstraints": {},
       "policies": {},
-      "checkConstraints": {},
+      "checkConstraints": {
+        "audit_logs_delegation_chain_is_array": {
+          "name": "audit_logs_delegation_chain_is_array",
+          "value": "\"audit_logs\".\"delegation_chain\" IS NULL OR jsonb_typeof(\"audit_logs\".\"delegation_chain\") = 'array'"
+        }
+      },
       "isRLSEnabled": false
     },
     "public.oauth_consents": {

--- a/libs/infra/db/drizzle/meta/_journal.json
+++ b/libs/infra/db/drizzle/meta/_journal.json
@@ -47,8 +47,8 @@
     {
       "idx": 6,
       "version": "7",
-      "when": 1782387336527,
-      "tag": "0006_lame_peter_parker",
+      "when": 1782388437344,
+      "tag": "0006_open_wolfsbane",
       "breakpoints": true
     }
   ]

--- a/libs/infra/db/drizzle/meta/_journal.json
+++ b/libs/infra/db/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1782381503568,
       "tag": "0005_agent_scope_mode",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1782387336527,
+      "tag": "0006_lame_peter_parker",
+      "breakpoints": true
     }
   ]
 }

--- a/libs/infra/db/src/lib/repositories/audit-logs.repository.ts
+++ b/libs/infra/db/src/lib/repositories/audit-logs.repository.ts
@@ -2,7 +2,7 @@ import { and, desc, eq, InferInsertModel, InferSelectModel } from 'drizzle-orm';
 
 import { DbClient } from '../db';
 import { auditLogs } from '../schema/audit';
-import { users } from '../schema/core';
+import { oauthClients, users } from '../schema/core';
 
 export type AuditLog = InferSelectModel<typeof auditLogs>;
 export type NewAuditLog = InferInsertModel<typeof auditLogs>;
@@ -187,22 +187,36 @@ export function createAuditLogsRepository(defaultDb: DbClient) {
     },
 
     /**
-     * Find audit logs attributed to a specific agent (by its `client_id`
-     * STRING), newest first. This is the query foundation for the future
-     * developer-portal "agent activity" view (ADR-007 §2, #186): every entry
-     * an agent produced acting on behalf of a user, with the subject (`userId`),
-     * delegation chain (`delegationChain`), and scope mode (`scopeMode`)
-     * available on each row.
+     * Find audit logs attributed to a specific agent WITHIN a realm, newest
+     * first. This is the query foundation for the future developer-portal
+     * "agent activity" view (ADR-007 §2, #186): every entry an agent produced
+     * acting on behalf of a user, with the subject (`userId`), delegation chain
+     * (`delegationChain`), and scope mode (`scopeMode`) available on each row.
      *
-     * Matches on the denormalized `actorClientId` (not the FK) so attribution
-     * survives deletion of the client row.
+     * Security: REALM-ISOLATED. `client_id` is unique only PER realm
+     * (`idx_oauth_clients_realm_client_id_unique` on `(realm_id, client_id)`;
+     * the standalone `idx_oauth_clients_client_id` is non-unique), so two
+     * realms can each own a client called `agent-a`. Matching the denormalized
+     * `actor_client_id` string ALONE would return rows from every realm that
+     * owns that `client_id` — a cross-tenant leak. We therefore inner-join
+     * `oauth_clients` on the FK and require `realm_id = $realmId`, mirroring the
+     * realm guard on `findByRealmId` / `findByRealmAndUserId`.
      *
+     * Trade-off: the join is on the `set null` FK (`oauthClientId`), so rows
+     * whose client row was later deleted are NOT returned (they have no realm
+     * to scope to). For a tenant-scoped activity view excluding such orphaned
+     * rows is the safe default — never leak them across realms. The
+     * denormalized `actorClientId` column still preserves the attribution on
+     * the row itself for any non-realm-scoped administrative query.
+     *
+     * @param realmId - Realm ID the agent belongs to (isolation boundary)
      * @param actorClientId - The agent's `client_id` string
      * @param options - Query options (pagination, filters)
      * @param tx - Optional transaction client
-     * @returns Array of audit logs attributed to the agent
+     * @returns Array of audit logs attributed to the agent in this realm
      */
-    async findByActorClientId(
+    async findByRealmAndActorClientId(
+      realmId: string,
       actorClientId: string,
       options: FindAuditLogsOptions = {},
       tx?: DbClient
@@ -210,7 +224,10 @@ export function createAuditLogsRepository(defaultDb: DbClient) {
       const invoker = tx ?? defaultDb;
       const { limit = 50, offset = 0, descending = true, eventType, success } = options;
 
-      const conditions = [eq(auditLogs.actorClientId, actorClientId)];
+      const conditions = [
+        eq(auditLogs.actorClientId, actorClientId),
+        eq(oauthClients.realmId, realmId),
+      ];
       if (eventType !== undefined) {
         conditions.push(eq(auditLogs.eventType, eventType));
       }
@@ -219,17 +236,20 @@ export function createAuditLogsRepository(defaultDb: DbClient) {
       }
 
       const baseQuery = invoker
-        .select()
+        .select({ auditLog: auditLogs })
         .from(auditLogs)
+        .innerJoin(oauthClients, eq(auditLogs.oauthClientId, oauthClients.id))
         .where(and(...conditions))
         .limit(limit)
         .offset(offset);
 
       if (descending) {
-        return baseQuery.orderBy(desc(auditLogs.createdAt));
+        const result = await baseQuery.orderBy(desc(auditLogs.createdAt));
+        return result.map((row) => row.auditLog);
       }
 
-      return baseQuery;
+      const result = await baseQuery;
+      return result.map((row) => row.auditLog);
     },
   };
 }

--- a/libs/infra/db/src/lib/repositories/audit-logs.repository.ts
+++ b/libs/infra/db/src/lib/repositories/audit-logs.repository.ts
@@ -10,7 +10,7 @@ export type NewAuditLog = InferInsertModel<typeof auditLogs>;
 /**
  * Audit event type enum values
  */
-export type AuditEventType = 'auth' | 'token' | 'client' | 'security' | 'user' | 'realm';
+export type AuditEventType = 'auth' | 'token' | 'client' | 'security' | 'user' | 'realm' | 'agent';
 
 /**
  * Options for querying audit logs
@@ -184,6 +184,52 @@ export function createAuditLogsRepository(defaultDb: DbClient) {
 
       const result = await baseQuery;
       return result.map((row) => row.auditLog);
+    },
+
+    /**
+     * Find audit logs attributed to a specific agent (by its `client_id`
+     * STRING), newest first. This is the query foundation for the future
+     * developer-portal "agent activity" view (ADR-007 §2, #186): every entry
+     * an agent produced acting on behalf of a user, with the subject (`userId`),
+     * delegation chain (`delegationChain`), and scope mode (`scopeMode`)
+     * available on each row.
+     *
+     * Matches on the denormalized `actorClientId` (not the FK) so attribution
+     * survives deletion of the client row.
+     *
+     * @param actorClientId - The agent's `client_id` string
+     * @param options - Query options (pagination, filters)
+     * @param tx - Optional transaction client
+     * @returns Array of audit logs attributed to the agent
+     */
+    async findByActorClientId(
+      actorClientId: string,
+      options: FindAuditLogsOptions = {},
+      tx?: DbClient
+    ): Promise<AuditLog[]> {
+      const invoker = tx ?? defaultDb;
+      const { limit = 50, offset = 0, descending = true, eventType, success } = options;
+
+      const conditions = [eq(auditLogs.actorClientId, actorClientId)];
+      if (eventType !== undefined) {
+        conditions.push(eq(auditLogs.eventType, eventType));
+      }
+      if (success !== undefined) {
+        conditions.push(eq(auditLogs.success, success));
+      }
+
+      const baseQuery = invoker
+        .select()
+        .from(auditLogs)
+        .where(and(...conditions))
+        .limit(limit)
+        .offset(offset);
+
+      if (descending) {
+        return baseQuery.orderBy(desc(auditLogs.createdAt));
+      }
+
+      return baseQuery;
     },
   };
 }

--- a/libs/infra/db/src/lib/repositories/repositories.integration.test.ts
+++ b/libs/infra/db/src/lib/repositories/repositories.integration.test.ts
@@ -539,7 +539,7 @@ describe('repository integration (real Postgres)', () => {
       expect(row.scopeMode).toBeNull();
     });
 
-    it('findByActorClientId returns only an agent’s actions, newest first', async () => {
+    it('findByRealmAndActorClientId returns only an agent’s actions, newest first', async () => {
       const realm = await seedRealm('agent-activity-realm');
       const subject = await seedUser(realm.id, 'activity@example.com');
       const agentA = await seedClient(realm.id, 'agent-a');
@@ -581,7 +581,7 @@ describe('repository integration (real Postgres)', () => {
         createdAt: 1_500,
       });
 
-      const activity = await audit.findByActorClientId('agent-a');
+      const activity = await audit.findByRealmAndActorClientId(realm.id, 'agent-a');
       expect(activity).toHaveLength(2);
       // Newest first (created_at desc).
       expect(activity[0].event).toBe('oauth.stepup.elevation');
@@ -591,9 +591,55 @@ describe('repository integration (real Postgres)', () => {
       expect(activity.every((r) => r.actorClientId === 'agent-a')).toBe(true);
 
       // eventType filter narrows within the agent's activity.
-      const tokenOnly = await audit.findByActorClientId('agent-a', { eventType: 'token' });
+      const tokenOnly = await audit.findByRealmAndActorClientId(realm.id, 'agent-a', {
+        eventType: 'token',
+      });
       expect(tokenOnly).toHaveLength(1);
       expect(tokenOnly[0].event).toBe('oauth.token.exchange.success');
+    });
+
+    it('findByRealmAndActorClientId is REALM-ISOLATED — same client_id in two realms does not leak', async () => {
+      // Two realms each own a client called `agent-shared` (client_id is unique
+      // only per realm). Each agent acts once; a query scoped to realm A must
+      // return ONLY realm A's row, never realm B's.
+      const realmA = await seedRealm('iso-realm-a');
+      const realmB = await seedRealm('iso-realm-b');
+      const userA = await seedUser(realmA.id, 'a@example.com');
+      const userB = await seedUser(realmB.id, 'b@example.com');
+      const clientA = await seedClient(realmA.id, 'agent-shared');
+      const clientB = await seedClient(realmB.id, 'agent-shared');
+      const audit = createAuditLogsRepository(db().database.db);
+
+      await audit.create({
+        userId: userA.id,
+        oauthClientId: clientA.id,
+        actorClientId: 'agent-shared',
+        delegationChain: ['agent-shared'],
+        scopeMode: 'readonly',
+        event: 'oauth.token.exchange.success',
+        eventType: 'token',
+        success: true,
+      });
+      await audit.create({
+        userId: userB.id,
+        oauthClientId: clientB.id,
+        actorClientId: 'agent-shared',
+        delegationChain: ['agent-shared'],
+        scopeMode: 'exec',
+        event: 'oauth.token.exchange.success',
+        eventType: 'token',
+        success: true,
+      });
+
+      const activityA = await audit.findByRealmAndActorClientId(realmA.id, 'agent-shared');
+      expect(activityA).toHaveLength(1);
+      expect(activityA[0].userId).toBe(userA.id);
+      expect(activityA[0].scopeMode).toBe('readonly');
+
+      const activityB = await audit.findByRealmAndActorClientId(realmB.id, 'agent-shared');
+      expect(activityB).toHaveLength(1);
+      expect(activityB[0].userId).toBe(userB.id);
+      expect(activityB[0].scopeMode).toBe('exec');
     });
   });
 });

--- a/libs/infra/db/src/lib/repositories/repositories.integration.test.ts
+++ b/libs/infra/db/src/lib/repositories/repositories.integration.test.ts
@@ -24,6 +24,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 
 import { oauthConsents, refreshTokens } from '../schema';
 import {
+  createAuditLogsRepository,
   createAuthorizationCodesRepository,
   createOAuthClientsRepository,
   createOAuthConsentsRepository,
@@ -470,6 +471,129 @@ describe('repository integration (real Postgres)', () => {
 
       const reloaded = await clients.findByClientId(realm.id, 'capped-agent-client');
       expect(reloaded?.maxAgentMode).toBe('admin');
+    });
+  });
+
+  // --- per-agent action audit (ADR-007 §2, #186) ---------------------------
+
+  describe('audit_logs — per-agent action audit (ADR-007 §2, #186)', () => {
+    it('round-trips agent attribution columns (actor, subject, act chain, mode)', async () => {
+      const realm = await seedRealm('agent-audit-realm');
+      const subject = await seedUser(realm.id, 'subject@example.com');
+      const agentClient = await seedClient(realm.id, 'agent-actor');
+      const audit = createAuditLogsRepository(db().database.db);
+
+      const row = await audit.create({
+        userId: subject.id,
+        oauthClientId: agentClient.id,
+        actorClientId: 'agent-actor',
+        delegationChain: ['agent-actor', 'prior-agent'],
+        scopeMode: 'exec',
+        event: 'oauth.token.exchange.success',
+        eventType: 'token',
+        success: true,
+        ipAddress: '127.0.0.1',
+        userAgent: 'vitest',
+        metadata: { grantType: 'token-exchange', delegationDepth: 2 },
+      });
+
+      expect(row.actorClientId).toBe('agent-actor');
+      expect(row.delegationChain).toEqual(['agent-actor', 'prior-agent']);
+      expect(row.scopeMode).toBe('exec');
+      // The subject of the on-behalf-of action is the end-user.
+      expect(row.userId).toBe(subject.id);
+    });
+
+    it('accepts the new "agent" event_type enum value', async () => {
+      const realm = await seedRealm('agent-event-type-realm');
+      const subject = await seedUser(realm.id, 'agent-evt@example.com');
+      const agentClient = await seedClient(realm.id, 'agent-evt-actor');
+      const audit = createAuditLogsRepository(db().database.db);
+
+      const row = await audit.create({
+        userId: subject.id,
+        oauthClientId: agentClient.id,
+        actorClientId: 'agent-evt-actor',
+        event: 'agent.action',
+        eventType: 'agent',
+        success: true,
+      });
+      expect(row.eventType).toBe('agent');
+    });
+
+    it('leaves agent columns null for ordinary (non-agent) entries — backward compatible', async () => {
+      const realm = await seedRealm('plain-audit-realm');
+      const user = await seedUser(realm.id, 'plain@example.com');
+      const audit = createAuditLogsRepository(db().database.db);
+
+      // An entry written exactly as pre-#186 callers do (no agent fields).
+      const row = await audit.create({
+        userId: user.id,
+        event: 'auth.login.success',
+        eventType: 'auth',
+        success: true,
+      });
+
+      expect(row.actorClientId).toBeNull();
+      expect(row.delegationChain).toBeNull();
+      expect(row.scopeMode).toBeNull();
+    });
+
+    it('findByActorClientId returns only an agent’s actions, newest first', async () => {
+      const realm = await seedRealm('agent-activity-realm');
+      const subject = await seedUser(realm.id, 'activity@example.com');
+      const agentA = await seedClient(realm.id, 'agent-a');
+      const agentB = await seedClient(realm.id, 'agent-b');
+      const audit = createAuditLogsRepository(db().database.db);
+
+      // Two actions by agent-a (different scope modes) and one by agent-b.
+      await audit.create({
+        userId: subject.id,
+        oauthClientId: agentA.id,
+        actorClientId: 'agent-a',
+        delegationChain: ['agent-a'],
+        scopeMode: 'readonly',
+        event: 'oauth.token.exchange.success',
+        eventType: 'token',
+        success: true,
+        createdAt: 1_000,
+      });
+      await audit.create({
+        userId: subject.id,
+        oauthClientId: agentA.id,
+        actorClientId: 'agent-a',
+        delegationChain: ['agent-a'],
+        scopeMode: 'exec',
+        event: 'oauth.stepup.elevation',
+        eventType: 'auth',
+        success: true,
+        createdAt: 2_000,
+      });
+      await audit.create({
+        userId: subject.id,
+        oauthClientId: agentB.id,
+        actorClientId: 'agent-b',
+        delegationChain: ['agent-b'],
+        scopeMode: 'readonly',
+        event: 'oauth.token.exchange.success',
+        eventType: 'token',
+        success: true,
+        createdAt: 1_500,
+      });
+
+      const activity = await audit.findByActorClientId('agent-a');
+      expect(activity).toHaveLength(2);
+      // Newest first (created_at desc).
+      expect(activity[0].event).toBe('oauth.stepup.elevation');
+      expect(activity[0].scopeMode).toBe('exec');
+      expect(activity[1].scopeMode).toBe('readonly');
+      // Strictly scoped to agent-a — agent-b's action is not returned.
+      expect(activity.every((r) => r.actorClientId === 'agent-a')).toBe(true);
+
+      // eventType filter narrows within the agent's activity.
+      const tokenOnly = await audit.findByActorClientId('agent-a', { eventType: 'token' });
+      expect(tokenOnly).toHaveLength(1);
+      expect(tokenOnly[0].event).toBe('oauth.token.exchange.success');
     });
   });
 });

--- a/libs/infra/db/src/lib/schema/audit.ts
+++ b/libs/infra/db/src/lib/schema/audit.ts
@@ -2,7 +2,7 @@ import { relations, sql } from 'drizzle-orm';
 import { bigint, boolean, index, jsonb, pgTable, text, uuid, varchar } from 'drizzle-orm/pg-core';
 
 import { oauthClients, users } from './core';
-import { auditEventTypeEnum } from './enums';
+import { agentModeEnum, auditEventTypeEnum } from './enums';
 import { EPOCH_MS_NOW } from './sql-helpers';
 
 export const auditLogs = pgTable(
@@ -11,6 +11,11 @@ export const auditLogs = pgTable(
     id: uuid('id')
       .primaryKey()
       .default(sql`uuidv7()`),
+    /**
+     * The subject of the action. For agent-attributable entries (ADR-007 §2
+     * #186) this is the end-user the agent acted *on behalf of*. Nullable +
+     * `set null` so a deleted user does not orphan the historical record.
+     */
     userId: uuid('user_id').references(() => users.id, { onDelete: 'set null' }),
     oauthClientId: uuid('oauth_client_id').references(() => oauthClients.id, {
       onDelete: 'set null',
@@ -20,6 +25,29 @@ export const auditLogs = pgTable(
     success: boolean('success').notNull().default(true),
     ipAddress: varchar('ip_address', { length: 45 }),
     userAgent: text('user_agent'),
+    /**
+     * Per-agent action audit (ADR-007 §2, #186). Denormalized `client_id`
+     * STRING of the agent that performed the action on behalf of `userId`.
+     * Stored as a string (not the `oauth_clients.id` FK) so the attribution
+     * survives deletion of the client row (the FK `oauthClientId` is
+     * `set null` on delete). Null for ordinary, non-delegated entries.
+     * NEVER a token or secret — only the public client identifier.
+     */
+    actorClientId: varchar('actor_client_id', { length: 255 }),
+    /**
+     * The RFC 8693 `act` delegation chain flattened to the ordered list of
+     * actor `client_id`s — index 0 is the most recent (outermost) actor, each
+     * following entry a prior actor. Turns the in-token chain into an
+     * accountable, queryable record. Contains ONLY public client identifiers;
+     * never any token, secret, or subject material. Null when not delegated.
+     */
+    delegationChain: jsonb('delegation_chain').$type<string[] | null>(),
+    /**
+     * The agent scope mode (`readonly` | `admin` | `exec`) granted for this
+     * action, when the operation was gated by an agent scope mode (#184).
+     * Null when the action carries no agent-mode scope.
+     */
+    scopeMode: agentModeEnum('scope_mode'),
     metadata: jsonb('metadata').$type<Record<string, unknown> | null>(),
     createdAt: bigint('created_at', { mode: 'number' }).notNull().default(EPOCH_MS_NOW),
   },
@@ -34,6 +62,11 @@ export const auditLogs = pgTable(
       .on(t.event, t.createdAt)
       .where(sql`${t.success} = false`),
     index('idx_audit_logs_ip_address').on(t.ipAddress),
+    // "Agent activity" queries: which actions did this agent take, newest
+    // first. Partial — only agent-attributed rows carry an actorClientId.
+    index('idx_audit_logs_actor_client_id')
+      .on(t.actorClientId, t.createdAt)
+      .where(sql`${t.actorClientId} IS NOT NULL`),
   ]
 );
 

--- a/libs/infra/db/src/lib/schema/audit.ts
+++ b/libs/infra/db/src/lib/schema/audit.ts
@@ -1,5 +1,15 @@
 import { relations, sql } from 'drizzle-orm';
-import { bigint, boolean, index, jsonb, pgTable, text, uuid, varchar } from 'drizzle-orm/pg-core';
+import {
+  bigint,
+  boolean,
+  check,
+  index,
+  jsonb,
+  pgTable,
+  text,
+  uuid,
+  varchar,
+} from 'drizzle-orm/pg-core';
 
 import { oauthClients, users } from './core';
 import { agentModeEnum, auditEventTypeEnum } from './enums';
@@ -67,6 +77,14 @@ export const auditLogs = pgTable(
     index('idx_audit_logs_actor_client_id')
       .on(t.actorClientId, t.createdAt)
       .where(sql`${t.actorClientId} IS NOT NULL`),
+    // Defensive: the delegation chain is a JSON array of client_id strings.
+    // Mirrors the `oauth_clients_audience_is_array` check so a malformed
+    // (non-array) value cannot be persisted even if a future caller bypasses
+    // the typed `$type<string[]>()` helper.
+    check(
+      'audit_logs_delegation_chain_is_array',
+      sql`${t.delegationChain} IS NULL OR jsonb_typeof(${t.delegationChain}) = 'array'`
+    ),
   ]
 );
 

--- a/libs/infra/db/src/lib/schema/enums.ts
+++ b/libs/infra/db/src/lib/schema/enums.ts
@@ -102,4 +102,5 @@ export const auditEventTypeEnum = pgEnum('audit_event_type', [
   'security', // Security events (failed login, suspicious activity)
   'user', // User management events
   'realm', // Realm management events
+  'agent', // Agent-attributable actions (delegated/on-behalf-of, ADR-007 §2 #186)
 ]);

--- a/libs/infra/db/src/lib/schema/enums.ts
+++ b/libs/infra/db/src/lib/schema/enums.ts
@@ -102,5 +102,12 @@ export const auditEventTypeEnum = pgEnum('audit_event_type', [
   'security', // Security events (failed login, suspicious activity)
   'user', // User management events
   'realm', // Realm management events
-  'agent', // Agent-attributable actions (delegated/on-behalf-of, ADR-007 §2 #186)
+  // Reserved (ADR-007 §2, #186) for a future DEDICATED agent-action event type.
+  // The current agent-native emit sites (token-exchange, step-up elevation,
+  // client_credentials) keep their existing `token`/`auth` category and carry
+  // agent attribution via the `actor_client_id` / `delegation_chain` /
+  // `scope_mode` COLUMNS — not by changing `event_type` — so existing queries
+  // filtering on those categories stay unaffected. This value lets a
+  // purpose-built agent event be added later without a second enum migration.
+  'agent',
 ]);


### PR DESCRIPTION
## Summary

Final sub-issue of the ADR-007 §2 agent-native epic (#181). Extends `audit_logs` so every action an agent takes on behalf of a user is **attributable**: which agent, on behalf of whom, under what delegation (`act`) chain and scope mode. Turns the RFC 8693 delegation chain into an accountable, queryable record — the data foundation for a future developer-portal "agent activity" view (UI not built here).

## Schema (additive, backward-compatible)

`0006_lame_peter_parker.sql` — existing rows are unaffected (all new columns nullable):

- `actor_client_id` (varchar) — denormalized agent `client_id` **string**, so attribution survives deletion of the client row (the FK `oauth_client_id` is set-null on delete).
- `delegation_chain` (jsonb) — the flattened `act` chain as ordered actor client_ids (outermost / most-recent first). **Public identifiers only.**
- `scope_mode` (`agent_mode` enum) — the effective agent scope mode granted.
- New `audit_event_type` enum value `agent` for genuinely agent-only events.
- Partial index `idx_audit_logs_actor_client_id` on `(actor_client_id, created_at) WHERE actor_client_id IS NOT NULL` for the agent-activity query.

## Emission (reuses the existing `repositories.auditLogs.create` sink)

- **Token exchange** (`token.ts` `handleTokenExchange`) success → agent + subject user + flattened `act` chain + highest agent scope mode.
- **Step-up elevation** (`consent.ts` `oauth.stepup.elevation`) → agent attribution when the elevating client is a verified agent; non-agent clients record no agent fields (existing behavior unchanged).
- **client_credentials** success → agent + scope mode for agent clients (no subject / no delegation chain); non-agent clients unaffected.

## Security

Only **public client identifiers** are persisted — no access / refresh / subject / actor tokens, no client secrets, no scope secrets. A dedicated test asserts no token/secret material reaches the audit fields. Agent attribution reuses the fail-closed `isAgentClient` accessor (epic #181 default-deny: `is_agent` is self-asserted and never sufficient alone).

New repository query `findByActorClientId` returns an agent's actions newest-first for the future activity view.

## Tests / CI

- Unit: token-exchange, step-up, and client_credentials produce audit rows attributing agent + subject + delegation + mode; non-agent paths leave the agent columns null; `flattenActChain` / `highestAgentModeInScopes` helpers.
- Integration (testcontainers PG18): the migration applies cleanly; new columns + `findByActorClientId` round-trip; the `agent` event type is accepted.
- `pnpm nx run-many -t lint typecheck test build -p auth-server infra-db` is green; the Docker-backed `infra-db:test-integration` suite passes (22/22).

Closes #186

https://claude.ai/code/session_01Re2rxPkdcgzJe7LSddhxv6