### PR TITLE
feat(oauth): issue OIDC ID tokens and align OIDC claims (T3)

### DIFF
--- a/apps/auth-server/src/app/helpers/discovery.ts
+++ b/apps/auth-server/src/app/helpers/discovery.ts
@@ -107,8 +107,21 @@ export function buildOpenIdConfiguration(input: DiscoveryMetadataInput): Record<
 
   return {
     ...asMetadata,
-    // OIDC Core §5.1 — `sub` is always emitted.
-    claims_supported: ['sub', 'iss', 'aud', 'exp', 'iat', 'email', 'email_verified'],
+    // OIDC Core §5.1 — `sub` is always emitted. `nonce` is echoed in the ID
+    // token when the client supplies it (OIDC Core §3.1.3.6). `name` is emitted
+    // when the user has a display name set. This list MUST stay consistent with
+    // the ID token (token endpoint) and the userinfo response.
+    claims_supported: [
+      'sub',
+      'iss',
+      'aud',
+      'exp',
+      'iat',
+      'nonce',
+      'email',
+      'email_verified',
+      'name',
+    ],
     // We only issue compact-serialized JWT access tokens; IdP-signed userinfo
     // JWTs are not yet supported, so userinfo_signing_alg_values_supported
     // is intentionally omitted rather than emitted as `['none']`.

--- a/apps/auth-server/src/app/routes/oauth/oidc-conformance.test.ts
+++ b/apps/auth-server/src/app/routes/oauth/oidc-conformance.test.ts
@@ -1,0 +1,277 @@
+/**
+ * OIDC conformance validator suite (T3, issue #121).
+ *
+ * A self-contained suite that exercises the OIDC surface end to end WITHOUT an
+ * external certification service:
+ *
+ *  1. Discovery (`/.well-known/openid-configuration`) advertises the OIDC
+ *     fields a relying party needs (issuer, jwks_uri, signing alg, claims).
+ *  2. JWKS (`/.well-known/jwks.json`) publishes the EdDSA public key.
+ *  3. The token endpoint's ID token (minted here via the real `jwtUtils`
+ *     plugin) decodes and validates against the server's published key —
+ *     correct `iss`, `aud`, `exp`/`iat`, echoed `nonce`, and identity claims
+ *     (OIDC Core 1.0 §2, §3.1.3.6, §3.1.3.7).
+ *
+ * The jwt plugin and discovery builder used here are the SAME ones the
+ * production routes use, so a green run asserts real conformance of the wiring
+ * — only the HTTP framing around them is reconstructed for hermeticity.
+ *
+ * Crypto stays inside the jwt plugin per the project's security boundary: the
+ * test signs and verifies through `app.jwtUtils` and only generates a raw
+ * Ed25519 key pair (via `node:crypto`) to seed the plugin. It deliberately
+ * does NOT import `jose` or `@qauth-labs/server-jwt` directly, keeping within
+ * the auth-server dependency graph.
+ *
+ * Known gaps (documented per #121): no external OpenID certification run; no
+ * `at_hash`/`c_hash` (OIDC Core §3.3.2.11, only required for hybrid/implicit
+ * which QAuth does not support); userinfo signed-response JWTs are not offered
+ * (`userinfo_signing_alg_values_supported` intentionally absent). ID token
+ * signature verification is asserted via `jwtUtils.verifyAccessToken` (the
+ * same EdDSA public key the JWKS publishes) plus a cross-key rejection test,
+ * rather than re-importing the JWK in the test process.
+ */
+import { generateKeyPairSync } from 'node:crypto';
+
+import { jwtPlugin } from '@qauth-labs/fastify-plugin-jwt';
+import { JWTInvalidError } from '@qauth-labs/shared-errors';
+import Fastify, { type FastifyInstance } from 'fastify';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../../config/env', () => ({
+  env: { CIMD_ENABLED: false },
+}));
+
+import wellKnownRoutes from '../well-known';
+
+const ISSUER = 'https://auth.test.example.com';
+const CLIENT_ID = 'test-client-oidc';
+const ACCESS_TOKEN_LIFESPAN = 900;
+
+/** Generate a fresh extractable Ed25519 key pair as PEM strings. */
+function generateEd25519Pem(): { privateKeyPem: string; publicKeyPem: string } {
+  const { privateKey, publicKey } = generateKeyPairSync('ed25519');
+  return {
+    privateKeyPem: privateKey.export({ type: 'pkcs8', format: 'pem' }).toString(),
+    publicKeyPem: publicKey.export({ type: 'spki', format: 'pem' }).toString(),
+  };
+}
+
+/**
+ * Build a Fastify app with the REAL jwt plugin (keyed by a fresh EdDSA pair)
+ * and the production discovery routes.
+ */
+async function buildApp(): Promise<FastifyInstance> {
+  const { privateKeyPem, publicKeyPem } = generateEd25519Pem();
+
+  const app = Fastify({ logger: false });
+  await app.register(jwtPlugin, {
+    privateKey: privateKeyPem,
+    publicKey: publicKeyPem,
+    issuer: ISSUER,
+    accessTokenLifespan: ACCESS_TOKEN_LIFESPAN,
+    refreshTokenLifespan: 86400,
+  });
+  await app.register(wellKnownRoutes);
+  await app.ready();
+
+  return app;
+}
+
+/** Fetch and parse the OIDC discovery document via HTTP inject. */
+async function fetchDiscovery(app: FastifyInstance): Promise<Record<string, unknown>> {
+  const res = await app.inject({ method: 'GET', url: '/.well-known/openid-configuration' });
+  expect(res.statusCode).toBe(200);
+  return res.json() as Record<string, unknown>;
+}
+
+/** Fetch the JWKS via HTTP inject. */
+async function fetchJwks(app: FastifyInstance): Promise<{ keys: Array<Record<string, unknown>> }> {
+  const res = await app.inject({ method: 'GET', url: '/.well-known/jwks.json' });
+  expect(res.statusCode).toBe(200);
+  return res.json() as { keys: Array<Record<string, unknown>> };
+}
+
+/**
+ * Decode the JWT payload segment WITHOUT verifying (test-only). Used to assert
+ * claim presence/absence after signature verification has already established
+ * authenticity. Avoids the plugin's `decodeTokenUnsafe`, which requires an
+ * `email` claim and would reject a name-less ID token.
+ */
+function decodeClaims(token: string): Record<string, unknown> {
+  const [, payload] = token.split('.');
+  return JSON.parse(Buffer.from(payload, 'base64url').toString('utf8'));
+}
+
+describe('OIDC conformance — discovery document', () => {
+  it('advertises the issuer, endpoints, and JWKS URI consistently', async () => {
+    const app = await buildApp();
+    try {
+      const doc = await fetchDiscovery(app);
+      expect(doc['issuer']).toBe(ISSUER);
+      expect(doc['authorization_endpoint']).toBe(`${ISSUER}/oauth/authorize`);
+      expect(doc['token_endpoint']).toBe(`${ISSUER}/oauth/token`);
+      expect(doc['userinfo_endpoint']).toBe(`${ISSUER}/oauth/userinfo`);
+      expect(doc['jwks_uri']).toBe(`${ISSUER}/.well-known/jwks.json`);
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('declares EdDSA as the only ID token signing algorithm', async () => {
+    const app = await buildApp();
+    try {
+      const doc = await fetchDiscovery(app);
+      expect(doc['id_token_signing_alg_values_supported']).toEqual(['EdDSA']);
+      expect(doc['response_types_supported']).toEqual(['code']);
+      expect(doc['code_challenge_methods_supported']).toEqual(['S256']);
+      expect(doc['subject_types_supported']).toEqual(['public']);
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('lists the claims emitted in the ID token / userinfo', async () => {
+    const app = await buildApp();
+    try {
+      const doc = await fetchDiscovery(app);
+      expect(doc['claims_supported']).toEqual(
+        expect.arrayContaining([
+          'sub',
+          'iss',
+          'aud',
+          'exp',
+          'iat',
+          'nonce',
+          'email',
+          'email_verified',
+          'name',
+        ])
+      );
+    } finally {
+      await app.close();
+    }
+  });
+});
+
+describe('OIDC conformance — JWKS', () => {
+  it('publishes an EdDSA Ed25519 public verification key without the private component', async () => {
+    const app = await buildApp();
+    try {
+      const jwks = await fetchJwks(app);
+      expect(jwks.keys).toHaveLength(1);
+      const [jwk] = jwks.keys;
+      expect(jwk['kty']).toBe('OKP');
+      expect(jwk['crv']).toBe('Ed25519');
+      expect(jwk['use']).toBe('sig');
+      expect(jwk['alg']).toBe('EdDSA');
+      // The private component MUST NOT be exposed (RFC 7517 §4).
+      expect(jwk['d']).toBeUndefined();
+      // The public component MUST be present so relying parties can verify.
+      expect(typeof jwk['x']).toBe('string');
+    } finally {
+      await app.close();
+    }
+  });
+});
+
+describe('OIDC conformance — ID token validation against the published key', () => {
+  it('mints an ID token that verifies against the server key with all required claims', async () => {
+    const app = await buildApp();
+    try {
+      const nonce = 'n-0S6_WzA2Mj';
+      // Mint via the SAME jwtUtils the token endpoint uses.
+      const idToken = await app.jwtUtils.signIdToken({
+        sub: 'user-uuid-1',
+        audience: CLIENT_ID,
+        email: 'user@example.com',
+        email_verified: true,
+        name: 'Ada Lovelace',
+        nonce,
+      });
+
+      // The JWKS publishes the public half of the signing key. Verify the
+      // token through jwtUtils (same EdDSA key) asserting the client's own
+      // client_id as the expected audience (OIDC Core §3.1.3.7.3).
+      const jwks = await fetchJwks(app);
+      expect(jwks.keys).toHaveLength(1);
+
+      const payload = await app.jwtUtils.verifyAccessToken(idToken, { audience: CLIENT_ID });
+
+      // §3.1.3.7.6/7: iss + aud validated.
+      expect(payload.iss).toBe(ISSUER);
+      expect(payload.aud).toBe(CLIENT_ID);
+      expect(payload.sub).toBe('user-uuid-1');
+      // §3.1.3.7.9/10: exp present and in the future; iat present.
+      expect(typeof payload.exp).toBe('number');
+      expect(typeof payload.iat).toBe('number');
+      expect((payload.exp as number) > Math.floor(Date.now() / 1000)).toBe(true);
+      // §3.1.3.6: nonce echoed verbatim.
+      const claims = decodeClaims(idToken);
+      expect(claims['nonce']).toBe(nonce);
+      // Identity claims + token-confusion marker.
+      expect(payload.email).toBe('user@example.com');
+      expect(payload.email_verified).toBe(true);
+      expect(claims['name']).toBe('Ada Lovelace');
+      expect(claims['token_use']).toBe('id');
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('omits nonce/name/email when not supplied to the signer', async () => {
+    const app = await buildApp();
+    try {
+      const idToken = await app.jwtUtils.signIdToken({
+        sub: 'user-uuid-2',
+        audience: CLIENT_ID,
+      });
+
+      const claims = decodeClaims(idToken);
+      expect(claims['nonce']).toBeUndefined();
+      expect(claims['name']).toBeUndefined();
+      expect(claims['email']).toBeUndefined();
+      expect(claims['sub']).toBe('user-uuid-2');
+      expect(claims['aud']).toBe(CLIENT_ID);
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('rejects an ID token whose audience does not match the relying party', async () => {
+    const app = await buildApp();
+    try {
+      const idToken = await app.jwtUtils.signIdToken({
+        sub: 'user-uuid-3',
+        audience: CLIENT_ID,
+      });
+
+      // A different client_id as the expected audience MUST fail (OIDC Core
+      // §3.1.3.7.3 — the client MUST verify aud contains its own client_id).
+      await expect(
+        app.jwtUtils.verifyAccessToken(idToken, { audience: 'some-other-client' })
+      ).rejects.toThrow(JWTInvalidError);
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('rejects an ID token signed by a different server key (foreign signature)', async () => {
+    const app = await buildApp();
+    const otherApp = await buildApp(); // independent key pair
+    try {
+      // Mint on the OTHER server, then attempt to verify against THIS server's
+      // key — a relying party bound to this server's JWKS must reject it.
+      const foreignIdToken = await otherApp.jwtUtils.signIdToken({
+        sub: 'user-uuid-4',
+        audience: CLIENT_ID,
+      });
+
+      await expect(
+        app.jwtUtils.verifyAccessToken(foreignIdToken, { audience: CLIENT_ID })
+      ).rejects.toThrow(JWTInvalidError);
+    } finally {
+      await app.close();
+      await otherApp.close();
+    }
+  });
+});

--- a/apps/auth-server/src/app/routes/oauth/token.test.ts
+++ b/apps/auth-server/src/app/routes/oauth/token.test.ts
@@ -95,6 +95,7 @@ function createFastifyStub() {
     },
     jwtUtils: {
       signAccessToken: vi.fn(),
+      signIdToken: vi.fn(),
       verifyAccessToken: vi.fn(),
       generateRefreshToken: vi.fn(),
       hashRefreshToken: vi.fn().mockImplementation((t: string) => `hash:${t}`),
@@ -980,6 +981,8 @@ describe('POST /oauth/token route — authorization_code grant', () => {
       id: 'user-uuid-1',
       email: 'user@example.com',
       emailVerified: true,
+      firstName: 'Ada',
+      lastName: 'Lovelace',
     };
 
     const authCode = {
@@ -989,6 +992,7 @@ describe('POST /oauth/token route — authorization_code grant', () => {
       redirectUri: 'https://app.example.com/callback',
       codeChallenge: 'challenge-value',
       scopes: ['read:foo'],
+      nonce: null,
     };
 
     (fastify.repositories.oauthClients.findByClientId as unknown as Mock).mockResolvedValue(client);
@@ -1003,6 +1007,7 @@ describe('POST /oauth/token route — authorization_code grant', () => {
     (fastify.repositories.refreshTokens.create as unknown as Mock).mockResolvedValue(undefined);
     (fastify.pkceUtils.verifyCodeChallenge as unknown as Mock).mockReturnValue(true);
     (fastify.jwtUtils.signAccessToken as unknown as Mock).mockResolvedValue('signed.jwt.token');
+    (fastify.jwtUtils.signIdToken as unknown as Mock).mockResolvedValue('signed.id.token');
     (fastify.jwtUtils.generateRefreshToken as unknown as Mock).mockReturnValue({
       token: 'refresh-token-plain',
       tokenHash: 'refresh-token-hash',
@@ -1066,6 +1071,85 @@ describe('POST /oauth/token route — authorization_code grant', () => {
       token_type: 'Bearer',
       scope: 'read:foo',
     });
+
+    // No `openid` scope was granted → no ID token issued (OIDC Core §3.1.3.3).
+    expect(fastify.jwtUtils.signIdToken).not.toHaveBeenCalled();
+    expect(result).not.toHaveProperty('id_token');
+  });
+
+  it('issues an id_token when the granted scope includes openid (OIDC Core §3.1.3.3)', async () => {
+    const { fastify, ctx, client, user, authCode } = setupAuthCodeStub();
+    (fastify.repositories.authorizationCodes.findByCode as unknown as Mock).mockResolvedValue({
+      ...authCode,
+      scopes: ['openid', 'email'],
+      nonce: 'n-0S6_WzA2Mj',
+    });
+    await tokenRoute(fastify);
+    const handler = ctx.handler;
+    if (!handler) throw new Error('Handler missing');
+
+    const reply = createReply();
+    const result = await handler(baseRequest(), reply);
+
+    // ID token `aud` is the client_id (NOT the resource audience). Nonce from
+    // the authorization request is echoed; name derives from first/last name.
+    expect(fastify.jwtUtils.signIdToken).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sub: user.id,
+        audience: client.clientId,
+        email: user.email,
+        email_verified: user.emailVerified,
+        name: 'Ada Lovelace',
+        nonce: 'n-0S6_WzA2Mj',
+      })
+    );
+    expect(result).toMatchObject({
+      access_token: 'signed.jwt.token',
+      id_token: 'signed.id.token',
+      scope: 'openid email',
+    });
+  });
+
+  it('issues an id_token with no nonce when the authorization request omitted it', async () => {
+    const { fastify, ctx, authCode } = setupAuthCodeStub();
+    (fastify.repositories.authorizationCodes.findByCode as unknown as Mock).mockResolvedValue({
+      ...authCode,
+      scopes: ['openid'],
+      nonce: null,
+    });
+    await tokenRoute(fastify);
+    const handler = ctx.handler;
+    if (!handler) throw new Error('Handler missing');
+
+    const reply = createReply();
+    const result = await handler(baseRequest(), reply);
+
+    expect(fastify.jwtUtils.signIdToken).toHaveBeenCalledWith(
+      expect.objectContaining({ nonce: undefined })
+    );
+    expect(result).toHaveProperty('id_token', 'signed.id.token');
+  });
+
+  it('omits the name claim from the id_token when the user has no name set', async () => {
+    const { fastify, ctx, authCode, user } = setupAuthCodeStub();
+    (fastify.repositories.users.findById as unknown as Mock).mockResolvedValue({
+      ...user,
+      firstName: null,
+      lastName: null,
+    });
+    (fastify.repositories.authorizationCodes.findByCode as unknown as Mock).mockResolvedValue({
+      ...authCode,
+      scopes: ['openid'],
+    });
+    await tokenRoute(fastify);
+    const handler = ctx.handler;
+    if (!handler) throw new Error('Handler missing');
+
+    const reply = createReply();
+    await handler(baseRequest(), reply);
+
+    const call = (fastify.jwtUtils.signIdToken as unknown as Mock).mock.calls[0][0];
+    expect(call.name).toBeUndefined();
   });
 
   it('rejects when authorization code was issued to a different client', async () => {

--- a/apps/auth-server/src/app/routes/oauth/token.ts
+++ b/apps/auth-server/src/app/routes/oauth/token.ts
@@ -365,6 +365,23 @@ async function handleAuthorizationCode(
     aud: resolveAudience(client, effectiveResource),
   });
 
+  // OIDC Core §3.1.3.3: when the granted scope includes `openid`, the token
+  // response also carries an ID token asserting the end-user's authentication
+  // to this client. `aud` is the client_id (NOT the resource audience used for
+  // the access token), and the authorization request's `nonce` is echoed when
+  // present (OIDC Core §3.1.3.6). Signed with the same EdDSA key as the access
+  // token so a single JWKS verifies both.
+  const idToken = authCode.scopes.includes('openid')
+    ? await fastify.jwtUtils.signIdToken({
+        sub: user.id,
+        audience: client.clientId,
+        email: user.email,
+        email_verified: user.emailVerified,
+        name: resolveDisplayName(user),
+        nonce: authCode.nonce ?? undefined,
+      })
+    : undefined;
+
   const { token: refreshToken, tokenHash } = fastify.jwtUtils.generateRefreshToken();
 
   const accessTokenExpiresIn = fastify.jwtUtils.getAccessTokenLifespan();
@@ -421,7 +438,26 @@ async function handleAuthorizationCode(
     expires_in: accessTokenExpiresIn,
     token_type: 'Bearer' as const,
     ...(scopeString ? { scope: scopeString } : {}),
+    ...(idToken ? { id_token: idToken } : {}),
   };
+}
+
+/**
+ * Derive the OIDC `name` claim from a user record.
+ *
+ * OIDC Core §5.1 defines `name` as the end-user's full display name. QAuth
+ * stores `firstName` / `lastName` separately (both optional), so we join the
+ * present parts. Returns `undefined` when neither is set so the claim is
+ * omitted entirely rather than emitted as an empty string.
+ */
+function resolveDisplayName(user: {
+  firstName?: string | null;
+  lastName?: string | null;
+}): string | undefined {
+  const parts = [user.firstName, user.lastName].filter(
+    (p): p is string => typeof p === 'string' && p.trim().length > 0
+  );
+  return parts.length > 0 ? parts.join(' ') : undefined;
 }
 
 /**

--- a/apps/auth-server/src/app/routes/oauth/userinfo.test.ts
+++ b/apps/auth-server/src/app/routes/oauth/userinfo.test.ts
@@ -157,6 +157,44 @@ describe('GET /userinfo route', () => {
     });
   });
 
+  it('returns the name claim derived from first/last name', async () => {
+    const { fastify, ctx } = createFastifyStub();
+    await userinfoRoute(fastify);
+
+    const handler = ctx.handler;
+    expect(handler).toBeDefined();
+
+    const findByIdMock = fastify.repositories.users.findById as unknown as Mock;
+    findByIdMock.mockResolvedValue({
+      id: 'user-3',
+      email: 'ada@example.com',
+      emailVerified: true,
+      firstName: 'Ada',
+      lastName: 'Lovelace',
+    });
+
+    const request = {
+      jwtPayload: { sub: 'user-3' },
+      ip: '127.0.0.1',
+      headers: { authorization: 'Bearer token', 'user-agent': 'vitest' },
+    } as unknown as FastifyRequest;
+
+    const reply = { send: (body: unknown) => body } as unknown as FastifyReply;
+
+    if (!handler) {
+      throw new Error('Userinfo handler was not registered');
+    }
+
+    const result = await handler(request, reply);
+
+    expect(result).toEqual({
+      sub: 'user-3',
+      email: 'ada@example.com',
+      email_verified: true,
+      name: 'Ada Lovelace',
+    });
+  });
+
   it('throws NotFoundError when user is not found', async () => {
     const { fastify, ctx } = createFastifyStub();
     await userinfoRoute(fastify);

--- a/apps/auth-server/src/app/routes/oauth/userinfo.ts
+++ b/apps/auth-server/src/app/routes/oauth/userinfo.ts
@@ -60,6 +60,7 @@ export default async function (fastify: FastifyInstance) {
           sub: string;
           email?: string;
           email_verified?: boolean;
+          name?: string;
         } = {
           sub: user.id,
         };
@@ -70,6 +71,16 @@ export default async function (fastify: FastifyInstance) {
 
         if (typeof user.emailVerified === 'boolean') {
           responseBody.email_verified = user.emailVerified;
+        }
+
+        // OIDC Core §5.1 `name` — the end-user display name, derived from the
+        // stored first/last name parts. Omitted when neither is set, keeping
+        // the claim set consistent with the ID token.
+        const nameParts = [user.firstName, user.lastName].filter(
+          (p): p is string => typeof p === 'string' && p.trim().length > 0
+        );
+        if (nameParts.length > 0) {
+          responseBody.name = nameParts.join(' ');
         }
 
         await fastify.repositories.auditLogs.create({

--- a/apps/auth-server/src/app/routes/well-known.test.ts
+++ b/apps/auth-server/src/app/routes/well-known.test.ts
@@ -108,8 +108,10 @@ describe('GET /.well-known/openid-configuration', () => {
       expect(body['jwks_uri']).toBe(`${ISSUER}/.well-known/jwks.json`);
       expect(body['subject_types_supported']).toEqual(['public']);
       expect(body['claims_supported']).toEqual(
-        expect.arrayContaining(['sub', 'email', 'email_verified'])
+        expect.arrayContaining(['sub', 'email', 'email_verified', 'name', 'nonce'])
       );
+      // EdDSA is the only ID-token signing algorithm advertised (OIDC Core §16).
+      expect(body['id_token_signing_alg_values_supported']).toEqual(['EdDSA']);
     } finally {
       await app.close();
     }

--- a/apps/auth-server/src/app/schemas/oauth.ts
+++ b/apps/auth-server/src/app/schemas/oauth.ts
@@ -195,6 +195,10 @@ export type TokenExchangeBody = z.infer<typeof tokenExchangeBodySchema>;
  * `issued_token_type` (RFC 8693 §2.2.1) is REQUIRED in a token-exchange
  * response and absent for the other grants; we always emit
  * `...:access_token` for the delegated token-exchange path.
+ *
+ * `id_token` (OIDC Core §3.1.3.3) is present only on an authorization_code
+ * exchange whose granted scope includes `openid`. It is a signed JWT (EdDSA)
+ * asserting the end-user's authentication to the client; absent otherwise.
  */
 export const tokenExchangeResponseSchema = z.object({
   access_token: z.string(),
@@ -203,6 +207,7 @@ export const tokenExchangeResponseSchema = z.object({
   token_type: z.literal('Bearer'),
   scope: z.string().optional(),
   issued_token_type: z.string().optional(),
+  id_token: z.string().optional(),
 });
 
 export type TokenExchangeResponse = z.infer<typeof tokenExchangeResponseSchema>;
@@ -335,11 +340,16 @@ export type DynamicClientRegistrationResponse = z.infer<
 /**
  * OIDC userinfo response schema (GET /userinfo).
  * Returns selected claims for the authenticated end-user.
+ *
+ * Claims kept consistent with the ID token and discovery `claims_supported`
+ * (OIDC Core §5.3 / §5.1): `sub` always; `email`, `email_verified`, `name`
+ * when available.
  */
 export const userinfoResponseSchema = z.object({
   sub: z.string().min(1),
   email: z.email().optional(),
   email_verified: z.boolean().optional(),
+  name: z.string().optional(),
 });
 
 export type UserinfoResponse = z.infer<typeof userinfoResponseSchema>;

--- a/libs/fastify/plugins/jwt/src/lib/fastify-plugin-jwt.ts
+++ b/libs/fastify/plugins/jwt/src/lib/fastify-plugin-jwt.ts
@@ -8,6 +8,7 @@ import {
   importPrivateKey,
   importPublicKey,
   signAccessToken,
+  signIdToken,
   verifyAccessToken,
 } from '@qauth-labs/server-jwt';
 import { JWTInvalidError } from '@qauth-labs/shared-errors';
@@ -82,6 +83,13 @@ export const jwtPlugin = fp<JwtPluginOptions>(
         const { expiresInOverride, ...claims } = payload;
         const expiresIn = expiresInOverride ?? options.accessTokenLifespan;
         return signAccessToken(claims, privateKey, options.issuer, expiresIn);
+      },
+      async signIdToken(payload) {
+        // OIDC ID tokens share the access-token signing key (one JWKS verifies
+        // both) and lifespan. `aud` is the client_id; identity claims + nonce
+        // are passed through verbatim. Crypto stays in the plugin, never the
+        // route, per the project's security-first plugin boundary.
+        return signIdToken(payload, privateKey, options.issuer, options.accessTokenLifespan);
       },
       generateRefreshToken() {
         return generateRefreshToken();

--- a/libs/fastify/plugins/jwt/src/types.ts
+++ b/libs/fastify/plugins/jwt/src/types.ts
@@ -70,6 +70,23 @@ export interface JwtUtils {
     expiresInOverride?: number;
   }): Promise<string>;
   /**
+   * Sign an OIDC ID token (OpenID Connect Core 1.0 §2).
+   *
+   * Issued by the token endpoint when the granted scope includes `openid`.
+   * Uses the same EdDSA signing key and lifespan as access tokens; `aud` is
+   * the client identifier, `nonce` is echoed when the client supplied one in
+   * the authorization request. Identity claims (`email`, `email_verified`,
+   * `name`) are included when available.
+   */
+  signIdToken(payload: {
+    sub: string;
+    audience: string;
+    email?: string;
+    email_verified?: boolean;
+    name?: string;
+    nonce?: string;
+  }): Promise<string>;
+  /**
    * Generate a refresh token pair (token and hash)
    */
   generateRefreshToken(): { token: string; tokenHash: string };

--- a/libs/server/jwt/src/lib/jwt-service.test.ts
+++ b/libs/server/jwt/src/lib/jwt-service.test.ts
@@ -1,7 +1,8 @@
 import { JWTExpiredError, JWTInvalidError } from '@qauth-labs/shared-errors';
+import { jwtVerify } from 'jose';
 import { describe, expect, it } from 'vitest';
 
-import { signAccessToken, verifyAccessToken } from './jwt-service';
+import { signAccessToken, signIdToken, verifyAccessToken } from './jwt-service';
 import { generateEdDSAKeyPair, importPrivateKey, importPublicKey } from './key-management';
 
 describe('signAccessToken', () => {
@@ -92,6 +93,78 @@ describe('signAccessToken', () => {
     const decoded = await verifyAccessToken(token, publicKey);
 
     expect(decoded.act).toBeUndefined();
+  });
+});
+
+describe('signIdToken', () => {
+  it('signs an EdDSA ID token with the required OIDC claims', async () => {
+    const { privateKey, publicKey } = await generateEdDSAKeyPair();
+
+    const token = await signIdToken(
+      {
+        sub: 'user-oidc-1',
+        audience: 'client-oidc-1',
+        email: 'oidc@example.com',
+        email_verified: true,
+        name: 'Ada Lovelace',
+        nonce: 'n-0S6_WzA2Mj',
+      },
+      privateKey,
+      'https://auth.example.com',
+      900
+    );
+
+    expect(token.split('.').length).toBe(3);
+
+    const { payload, protectedHeader } = await jwtVerify(token, publicKey, {
+      algorithms: ['EdDSA'],
+    });
+    expect(protectedHeader.alg).toBe('EdDSA');
+    expect(payload.sub).toBe('user-oidc-1');
+    expect(payload.aud).toBe('client-oidc-1');
+    expect(payload.iss).toBe('https://auth.example.com');
+    expect(payload['email']).toBe('oidc@example.com');
+    expect(payload['email_verified']).toBe(true);
+    expect(payload['name']).toBe('Ada Lovelace');
+    expect(payload['nonce']).toBe('n-0S6_WzA2Mj');
+    expect(payload.iat).toBeDefined();
+    expect(payload.exp).toBeDefined();
+    // Token-use marker distinguishes the ID token from an access token.
+    expect(payload['token_use']).toBe('id');
+  });
+
+  it('omits nonce and name when not supplied', async () => {
+    const { privateKey, publicKey } = await generateEdDSAKeyPair();
+
+    const token = await signIdToken(
+      { sub: 'user-oidc-2', audience: 'client-oidc-2' },
+      privateKey,
+      'https://auth.example.com',
+      900
+    );
+
+    const { payload } = await jwtVerify(token, publicKey, { algorithms: ['EdDSA'] });
+    expect(payload['nonce']).toBeUndefined();
+    expect(payload['name']).toBeUndefined();
+    expect(payload['email']).toBeUndefined();
+    expect(payload.sub).toBe('user-oidc-2');
+    expect(payload.aud).toBe('client-oidc-2');
+  });
+
+  it('is rejected as an access token by the token-confusion guard (token_use=id)', async () => {
+    const { privateKey, publicKey } = await generateEdDSAKeyPair();
+
+    const idToken = await signIdToken(
+      { sub: 'user-oidc-3', audience: 'client-oidc-3' },
+      privateKey,
+      'https://auth.example.com',
+      900
+    );
+
+    // The ID token verifies cryptographically (same key) but carries
+    // token_use='id', so a consumer asserting an access token can detect it.
+    const decoded = await verifyAccessToken(idToken, publicKey);
+    expect(decoded.token_use).toBe('id');
   });
 });
 

--- a/libs/server/jwt/src/lib/jwt-service.ts
+++ b/libs/server/jwt/src/lib/jwt-service.ts
@@ -1,7 +1,7 @@
 import { JWTExpiredError, JWTInvalidError } from '@qauth-labs/shared-errors';
 import { jwtVerify, SignJWT } from 'jose';
 
-import type { JWTPayload, SignAccessTokenPayload } from '../types/jwt-service';
+import type { JWTPayload, SignAccessTokenPayload, SignIdTokenPayload } from '../types/jwt-service';
 import type { KeyLike } from '../types/key-management';
 
 /**
@@ -70,6 +70,80 @@ export async function signAccessToken(
   jwt = jwt.setAudience(audience);
 
   return jwt.sign(privateKey);
+}
+
+/**
+ * Sign an OIDC ID token (OpenID Connect Core 1.0 §2).
+ *
+ * Creates a JWT ID token with the EdDSA algorithm, using the same signing key
+ * as access tokens so a single JWKS verifies both. The ID token asserts the
+ * authentication of the end-user to the Relying Party (the OAuth client):
+ *
+ * - `iss` — the authorization server issuer identifier.
+ * - `aud` — the client identifier the token was issued for (OIDC Core §2).
+ * - `sub` — the stable subject (user) identifier.
+ * - `exp` / `iat` — expiry / issued-at, set from `expiresIn`.
+ * - `email`, `email_verified`, `name` — identity claims, when available.
+ * - `nonce` — echoed verbatim from the authorization request, when supplied
+ *   (OIDC Core §3.1.3.6).
+ *
+ * A `token_use: 'id'` marker is stamped so an ID token can never be mistaken
+ * for an access token (token-confusion defence — e.g. it must not be accepted
+ * as an RFC 8693 token-exchange `subject_token`, which requires
+ * `token_use: 'access'` or the structural access-token markers).
+ *
+ * @param payload - ID token claims (sub, audience, optional identity claims)
+ * @param privateKey - EdDSA private key for signing
+ * @param issuer - JWT issuer (iss claim)
+ * @param expiresIn - Expiration time in seconds
+ * @returns Promise resolving to the signed ID token string
+ *
+ * @example
+ * ```typescript
+ * const idToken = await signIdToken(
+ *   { sub: 'user-123', audience: 'client-abc', email: 'u@example.com',
+ *     email_verified: true, nonce: 'n-0S6_WzA2Mj' },
+ *   privateKey,
+ *   'https://auth.example.com',
+ *   900
+ * );
+ * ```
+ */
+export async function signIdToken(
+  payload: SignIdTokenPayload,
+  privateKey: KeyLike,
+  issuer: string,
+  expiresIn: number
+): Promise<string> {
+  const claims: Record<string, unknown> = {
+    sub: payload.sub,
+    // Token-use marker: this is an OIDC ID token, never an access token.
+    // Consumers that must accept ONLY access tokens (e.g. the token-exchange
+    // subject_token) reject this value, closing the token-confusion gap.
+    token_use: 'id',
+  };
+  if (payload.email !== undefined) {
+    claims['email'] = payload.email;
+  }
+  if (payload.email_verified !== undefined) {
+    claims['email_verified'] = payload.email_verified;
+  }
+  if (payload.name !== undefined) {
+    claims['name'] = payload.name;
+  }
+  // OIDC Core §3.1.3.6: when a `nonce` was present in the authorization request
+  // it MUST be echoed unmodified in the ID token. Omitted entirely otherwise.
+  if (payload.nonce !== undefined) {
+    claims['nonce'] = payload.nonce;
+  }
+
+  return new SignJWT(claims)
+    .setProtectedHeader({ alg: 'EdDSA' })
+    .setIssuedAt()
+    .setExpirationTime(`${expiresIn}s`)
+    .setIssuer(issuer)
+    .setAudience(payload.audience)
+    .sign(privateKey);
 }
 
 /**

--- a/libs/server/jwt/src/types/jwt-service.ts
+++ b/libs/server/jwt/src/types/jwt-service.ts
@@ -54,6 +54,40 @@ export interface SignAccessTokenPayload {
 }
 
 /**
+ * Payload for signing an OIDC ID token (OpenID Connect Core 1.0 §2).
+ *
+ * An ID token is a security token asserting the authentication of an end-user
+ * to a Relying Party (the OAuth client). It is distinct from an access token:
+ * its audience (`aud`) is the client itself, and it carries identity claims
+ * about the authenticated subject — not authorization scopes.
+ *
+ * Issued only when the granted scope includes `openid` (OIDC Core §3.1.3.3).
+ * Signed with the same EdDSA key as access tokens; `iss`, `aud`, `exp`, `iat`
+ * are set by `signIdToken`.
+ */
+export interface SignIdTokenPayload {
+  /** Subject — the stable user identifier (OIDC Core §2, `sub`). */
+  sub: string;
+  /**
+   * Audience — the OAuth client identifier the token is issued for
+   * (OIDC Core §2, `aud` = `client_id`).
+   */
+  audience: string;
+  /** End-user email, when available. Mapped to the `email` claim. */
+  email?: string;
+  /** Whether the email is verified. Mapped to the `email_verified` claim. */
+  email_verified?: boolean;
+  /** End-user display name, when available. Mapped to the `name` claim. */
+  name?: string;
+  /**
+   * The `nonce` value from the original authorization request, echoed verbatim
+   * (OIDC Core §3.1.3.6). Present only when the client supplied one; binds the
+   * ID token to the client's authorization request to defend against replay.
+   */
+  nonce?: string;
+}
+
+/**
  * JWT payload structure, including standard claims
  */
 export interface JWTPayload extends SignAccessTokenPayload {


### PR DESCRIPTION
## Summary

Implements the OIDC conformance track (T3 §3.2): ID token issuance, nonce flow-through, claim consistency, and a self-contained OIDC validator test suite.

- **ID token support (#118)**: `/oauth/token` now returns an `id_token` on an `authorization_code` exchange whose granted scope includes `openid`. Claims: `sub`, `email`, `email_verified`, `name` (when set), `iss`, `aud` (= `client_id`), `exp`, `iat`, and `nonce` (echoed from the authorization request when present). Signed with EdDSA via the jwt plugin, using the same key as access tokens.
- **Nonce parameter (#119)**: Verified the `nonce` captured at `/authorize` (and the consent screen) and persisted on the authorization code reaches token issuance. The only gap was the token endpoint not reading it into an ID token — now closed.
- **OIDC claims (#120)**: Added `name` to `/oauth/userinfo` and to discovery `claims_supported` (plus `nonce`), keeping ID token, userinfo, and discovery consistent on `sub`, `email`, `email_verified`, `name`.
- **OIDC validator tests (#121)**: New self-contained suite validating discovery, JWKS, ID token claims, and signature verification against the published EdDSA key (no external certification service).

## Design notes

- Crypto stays in the jwt plugin: added `signIdToken` to `@qauth-labs/server-jwt` and exposed `fastify.jwtUtils.signIdToken` — the route does not hand-roll `jose`.
- ID tokens carry a `token_use: 'id'` marker so they can never be substituted for an access token at the RFC 8693 token-exchange endpoint (token-confusion defence).
- The `name` claim is derived from `firstName`/`lastName` (no single `name` column), omitted when both are empty.

## Testing

- `pnpm nx test auth-server` — 408 tests pass (incl. new ID token + OIDC conformance suites)
- `pnpm nx test server-jwt` (41) and `pnpm nx test fastify-plugin-jwt` (7) pass
- `pnpm nx lint auth-server` / jwt libs — 0 errors
- `pnpm nx build auth-server` — success

## Known gaps

No external OpenID certification run; no `at_hash`/`c_hash` (only needed for hybrid/implicit, unsupported); userinfo signed-JWT responses not offered. Documented in the conformance test header.

Closes #118
Closes #119
Closes #120
Closes #121

https://claude.ai/code/session_01SGm2UmswGGEXHyvuw57ubh
