### PR TITLE
feat(auth): security headers + XSS/CSRF/cookie hardening for the browser /ui flow (T3)

### DIFF
--- a/apps/auth-server/package.json
+++ b/apps/auth-server/package.json
@@ -8,6 +8,7 @@
     "@fastify/autoload": "catalog:",
     "@fastify/cors": "catalog:",
     "@fastify/formbody": "catalog:",
+    "@fastify/helmet": "catalog:",
     "@fastify/rate-limit": "catalog:",
     "@fastify/swagger": "catalog:",
     "@fastify/swagger-ui": "catalog:",

--- a/apps/auth-server/src/app/app.ts
+++ b/apps/auth-server/src/app/app.ts
@@ -14,6 +14,7 @@ import type { FastifyInstance } from 'fastify';
 import { env } from '../config/env';
 import errorHandler from './plugins/error-handler';
 import { rateLimitPlugin } from './plugins/rate-limit';
+import { securityHeadersPlugin } from './plugins/security-headers';
 
 export async function app(fastify: FastifyInstance, opts: object) {
   await fastify.register(databasePlugin, {
@@ -108,6 +109,11 @@ export async function app(fastify: FastifyInstance, opts: object) {
 
   await fastify.register(rateLimitPlugin);
 
+  // Security headers (issue #113): register before routes so every response —
+  // including the server-rendered login/consent pages and error responses —
+  // carries the CSP, HSTS, frame-options and related hardening headers.
+  await fastify.register(securityHeadersPlugin);
+
   await fastify.register(cors, {
     origin: env.CORS_ORIGIN || '*',
   });
@@ -122,7 +128,7 @@ export async function app(fastify: FastifyInstance, opts: object) {
   fastify.register(AutoLoad, {
     dir: path.join(__dirname, 'plugins'),
     options: { ...opts },
-    ignorePattern: /(error-handler|rate-limit)\.(ts|js)$|\.(test|spec)\.(ts|js)$/,
+    ignorePattern: /(error-handler|rate-limit|security-headers)\.(ts|js)$|\.(test|spec)\.(ts|js)$/,
   });
 
   fastify.register(AutoLoad, {

--- a/apps/auth-server/src/app/helpers/html.test.ts
+++ b/apps/auth-server/src/app/helpers/html.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { esc, html, render, safe } from './html';
+import { esc, html, render, safe, safeUrl } from './html';
 
 describe('html helpers', () => {
   it('esc escapes HTML-special characters', () => {
@@ -26,5 +26,41 @@ describe('html helpers', () => {
     const items = ['<a>', '<b>'];
     const out = render(html`${items}`);
     expect(out).toBe('&lt;a&gt;&lt;b&gt;');
+  });
+
+  it('esc neutralises single quotes (attribute breakout defence)', () => {
+    expect(esc(`' onmouseover='alert(1)`)).toBe('&#39; onmouseover=&#39;alert(1)');
+  });
+});
+
+describe('safeUrl (#112)', () => {
+  it('accepts http(s) and mailto URLs unchanged', () => {
+    expect(safeUrl('https://example.com/app')).toBe('https://example.com/app');
+    expect(safeUrl('http://example.com')).toBe('http://example.com');
+    expect(safeUrl('mailto:ops@example.com')).toBe('mailto:ops@example.com');
+  });
+
+  it('rejects javascript:/data:/vbscript: URLs (XSS vectors)', () => {
+    expect(safeUrl('javascript:alert(1)')).toBeUndefined();
+    expect(safeUrl('JavaScript:alert(1)')).toBeUndefined();
+    expect(safeUrl('data:text/html,<script>alert(1)</script>')).toBeUndefined();
+    expect(safeUrl('vbscript:msgbox(1)')).toBeUndefined();
+  });
+
+  it('rejects relative URLs and non-string/empty input', () => {
+    expect(safeUrl('/relative/path')).toBeUndefined();
+    expect(safeUrl('not a url')).toBeUndefined();
+    expect(safeUrl('')).toBeUndefined();
+    expect(safeUrl(undefined)).toBeUndefined();
+    expect(safeUrl(null)).toBeUndefined();
+    expect(safeUrl(42)).toBeUndefined();
+  });
+
+  it('a rejected href is not rendered as a clickable link in a page fragment', () => {
+    const evil = 'javascript:alert(document.cookie)';
+    const href = safeUrl(evil);
+    const out = render(href ? html`<a href="${href}">link</a>` : html`<span>no link</span>`);
+    expect(out).not.toContain('javascript:');
+    expect(out).toBe('<span>no link</span>');
   });
 });

--- a/apps/auth-server/src/app/helpers/html.ts
+++ b/apps/auth-server/src/app/helpers/html.ts
@@ -69,3 +69,34 @@ export function html(strings: TemplateStringsArray, ...values: unknown[]): SafeH
 export function render(fragment: SafeHtml): string {
   return fragment.value;
 }
+
+/**
+ * Schemes permitted in a user-facing hyperlink. `javascript:`, `data:`,
+ * `vbscript:` and friends are deliberately excluded: HTML-escaping protects an
+ * attribute *value* against breaking out of its quotes, but it does NOT stop a
+ * `javascript:alert(1)` URL (which contains no quotes) from executing when the
+ * link is clicked. Any href/src built from client-supplied data MUST pass
+ * through `safeUrl()` first (issue #112).
+ */
+const SAFE_URL_SCHEMES = new Set(['http:', 'https:', 'mailto:']);
+
+/**
+ * Return `value` if it parses as an absolute URL with an allowlisted scheme,
+ * otherwise `undefined`. Use for any href/src interpolated from
+ * client-controlled metadata (e.g. an OAuth client's `homepage_uri`) so a
+ * `javascript:`/`data:` URL cannot be rendered as a clickable link.
+ *
+ * Note: a relative URL is rejected (returns undefined) because it has no
+ * parseable scheme — callers that need same-origin relative links should build
+ * those from trusted server-side values, not from user input.
+ */
+export function safeUrl(value: unknown): string | undefined {
+  if (typeof value !== 'string' || value.length === 0) return undefined;
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    return undefined;
+  }
+  return SAFE_URL_SCHEMES.has(parsed.protocol) ? value : undefined;
+}

--- a/apps/auth-server/src/app/helpers/session-cookie-secure.test.ts
+++ b/apps/auth-server/src/app/helpers/session-cookie-secure.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Companion to session-cookie.test.ts (#109). That file mocks
+ * SESSION_COOKIE_SECURE=false to exercise the local-dev path; this file mocks
+ * it true (the production default) and asserts the Secure attribute is emitted
+ * on both set and clear. Kept in a separate module so the env mock does not
+ * collide with the false-path tests.
+ */
+vi.mock('../../config/env', () => ({
+  env: {
+    SESSION_COOKIE_SECRET: 'test-secret-at-least-32-characters-long-padding',
+    SESSION_COOKIE_TTL: 3600,
+    SESSION_COOKIE_SECURE: true,
+  },
+}));
+
+function captureCookie(fn: (reply: never) => void): string {
+  const headers: Record<string, string> = {};
+  const reply = {
+    header: (k: string, v: string) => {
+      headers[k] = v;
+      return reply;
+    },
+  } as never;
+  fn(reply);
+  return headers['Set-Cookie'];
+}
+
+afterEach(() => {
+  vi.resetModules();
+});
+
+describe('session cookie Secure attribute (#109, production default)', () => {
+  it('setSessionCookie emits Secure when SESSION_COOKIE_SECURE is true', async () => {
+    const { setSessionCookie } = await import('./session-cookie');
+    const cookie = captureCookie((reply) => setSessionCookie(reply, 'sid'));
+    expect(cookie).toContain('Secure');
+    expect(cookie).toContain('HttpOnly');
+    expect(cookie).toContain('SameSite=Lax');
+    expect(cookie).toContain('Path=/');
+  });
+
+  it('clearSessionCookie also emits Secure so the clear matches the set', async () => {
+    const { clearSessionCookie } = await import('./session-cookie');
+    const cookie = captureCookie((reply) => clearSessionCookie(reply));
+    expect(cookie).toContain('Secure');
+    expect(cookie).toContain('Max-Age=0');
+  });
+});

--- a/apps/auth-server/src/app/helpers/session-cookie.test.ts
+++ b/apps/auth-server/src/app/helpers/session-cookie.test.ts
@@ -62,6 +62,25 @@ describe('session cookie helpers', () => {
     expect(cookie).toContain('Path=/');
     expect(cookie).toContain('HttpOnly');
     expect(cookie).toContain('SameSite=Lax');
+    // __Host- prefix is the only safe cookie-name prefix and implies the
+    // browser-enforced Secure + Path=/ + no-Domain contract (#109).
+    expect(SESSION_COOKIE_NAME.startsWith('__Host-')).toBe(true);
+    expect(cookie).not.toContain('Domain=');
+  });
+
+  it('omits Secure only when SESSION_COOKIE_SECURE is false (local-dev override)', () => {
+    // The module-level env mock sets SESSION_COOKIE_SECURE: false. The default
+    // in the schema is true (#109) — this asserts the dev override path works
+    // and that Secure is gated solely by that flag.
+    const headers: Record<string, string> = {};
+    const reply = {
+      header: (k: string, v: string) => {
+        headers[k] = v;
+        return reply;
+      },
+    } as never;
+    setSessionCookie(reply, 'sid');
+    expect(headers['Set-Cookie']).not.toContain('Secure');
   });
 
   it('clearSessionCookie emits Max-Age=0', () => {

--- a/apps/auth-server/src/app/plugins/security-headers.test.ts
+++ b/apps/auth-server/src/app/plugins/security-headers.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Integration test for the security-headers plugin (issue #113).
+ *
+ * Verifies the strict, nonce-based Content-Security-Policy plus HSTS,
+ * X-Frame-Options, X-Content-Type-Options and Referrer-Policy are applied to
+ * every response, the per-request style nonce is fresh, and the /docs (Swagger
+ * UI) prefix receives the relaxed CSP instead.
+ */
+import Fastify, { type FastifyInstance } from 'fastify';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../config/env', () => ({
+  env: {
+    SECURITY_HSTS_ENABLED: true,
+    SECURITY_HSTS_MAX_AGE: 31536000,
+  },
+}));
+
+import { securityHeadersPlugin } from './security-headers';
+
+async function buildApp(): Promise<FastifyInstance> {
+  const app = Fastify();
+  await app.register(securityHeadersPlugin);
+  app.get('/page', async (_req, reply) => {
+    reply.header('content-type', 'text/html');
+    return `<style nonce="${reply.cspNonce.style}">body{}</style>`;
+  });
+  // Stand-in for Swagger UI's served HTML at the /docs prefix.
+  app.get('/docs', async (_req, reply) => {
+    reply.header('content-type', 'text/html');
+    return '<html>swagger</html>';
+  });
+  app.get('/docs/static/index.js', async () => 'console.log(1)');
+  await app.ready();
+  return app;
+}
+
+describe('security-headers plugin (#113)', () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    app = await buildApp();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('sets a strict, nonce-based CSP on normal routes', async () => {
+    const res = await app.inject({ method: 'GET', url: '/page' });
+    const csp = res.headers['content-security-policy'] as string;
+    expect(csp).toBeTruthy();
+    expect(csp).toContain("default-src 'self'");
+    expect(csp).toContain("object-src 'none'");
+    expect(csp).toContain("frame-ancestors 'none'");
+    expect(csp).toContain("base-uri 'self'");
+    expect(csp).toContain("form-action 'self'");
+    // No inline-script escape hatch.
+    expect(csp).not.toContain("'unsafe-inline'");
+    // style-src and script-src carry a generated nonce.
+    expect(csp).toMatch(/style-src [^;]*'nonce-/);
+    expect(csp).toMatch(/script-src [^;]*'nonce-/);
+  });
+
+  it('emits a fresh CSP nonce per request and the page embeds it', async () => {
+    const res1 = await app.inject({ method: 'GET', url: '/page' });
+    const res2 = await app.inject({ method: 'GET', url: '/page' });
+
+    const nonce1 = /style-src [^;]*'nonce-([^']+)'/.exec(
+      res1.headers['content-security-policy'] as string
+    )?.[1];
+    const nonce2 = /style-src [^;]*'nonce-([^']+)'/.exec(
+      res2.headers['content-security-policy'] as string
+    )?.[1];
+
+    expect(nonce1).toBeTruthy();
+    expect(nonce2).toBeTruthy();
+    expect(nonce1).not.toBe(nonce2);
+    // The rendered <style nonce> matches the header nonce for this same request.
+    expect(res1.body).toContain(`nonce="${nonce1}"`);
+  });
+
+  it('sets HSTS with one-year max-age, includeSubDomains and preload', async () => {
+    const res = await app.inject({ method: 'GET', url: '/page' });
+    const hsts = res.headers['strict-transport-security'] as string;
+    expect(hsts).toContain('max-age=31536000');
+    expect(hsts).toContain('includeSubDomains');
+    expect(hsts).toContain('preload');
+  });
+
+  it('sets X-Frame-Options, X-Content-Type-Options and Referrer-Policy', async () => {
+    const res = await app.inject({ method: 'GET', url: '/page' });
+    expect(res.headers['x-frame-options']).toBe('DENY');
+    expect(res.headers['x-content-type-options']).toBe('nosniff');
+    expect(res.headers['referrer-policy']).toBe('no-referrer');
+  });
+
+  it('serves a relaxed CSP on the /docs (Swagger UI) prefix', async () => {
+    const root = await app.inject({ method: 'GET', url: '/docs' });
+    const asset = await app.inject({ method: 'GET', url: '/docs/static/index.js' });
+
+    for (const res of [root, asset]) {
+      const csp = res.headers['content-security-policy'] as string;
+      // Swagger UI needs its own inline scripts/styles.
+      expect(csp).toContain("script-src 'self' 'unsafe-inline'");
+      expect(csp).toContain("style-src 'self' 'unsafe-inline'");
+      // The strict per-request nonce policy must NOT leak onto /docs.
+      expect(csp).not.toContain("'nonce-");
+    }
+
+    // Non-/docs routes keep the strict policy (no unsafe-inline).
+    const page = await app.inject({ method: 'GET', url: '/page' });
+    expect(page.headers['content-security-policy']).not.toContain("'unsafe-inline'");
+  });
+});
+
+describe('security-headers plugin — HSTS disabled (#113 dev override)', () => {
+  it('omits HSTS when SECURITY_HSTS_ENABLED is false', async () => {
+    vi.resetModules();
+    vi.doMock('../../config/env', () => ({
+      env: { SECURITY_HSTS_ENABLED: false, SECURITY_HSTS_MAX_AGE: 31536000 },
+    }));
+    const { securityHeadersPlugin: plugin } = await import('./security-headers');
+    const app = Fastify();
+    await app.register(plugin);
+    app.get('/page', async () => 'ok');
+    await app.ready();
+
+    const res = await app.inject({ method: 'GET', url: '/page' });
+    expect(res.headers['strict-transport-security']).toBeUndefined();
+
+    await app.close();
+    vi.doUnmock('../../config/env');
+  });
+});

--- a/apps/auth-server/src/app/plugins/security-headers.ts
+++ b/apps/auth-server/src/app/plugins/security-headers.ts
@@ -1,0 +1,136 @@
+import helmet from '@fastify/helmet';
+import type { FastifyInstance, FastifyPluginOptions, FastifyReply, FastifyRequest } from 'fastify';
+import fp from 'fastify-plugin';
+
+import { env } from '../../config/env';
+
+/**
+ * Security headers & browser hardening (issue #113).
+ *
+ * Registers `@fastify/helmet` with a strict, nonce-based Content-Security-Policy
+ * plus HSTS, X-Frame-Options, X-Content-Type-Options and Referrer-Policy.
+ *
+ * ## CSP design
+ *
+ * The server-rendered login/consent pages (issues #150, #112) ship inline
+ * `<style>` blocks. Rather than weaken the policy with `'unsafe-inline'`,
+ * `@fastify/helmet`'s `enableCSPNonces` generates a fresh per-request nonce
+ * exposed on `reply.cspNonce.style`; the page renderers stamp it onto each
+ * `<style nonce>` tag. `script-src` stays `'self'` (plus its own unused nonce)
+ * — the pages contain no JavaScript, so any injected `<script>` (reflected or
+ * stored XSS) is refused by the browser.
+ *
+ * `'unsafe-inline'` is intentionally NOT listed for scripts. It IS effectively
+ * neutralised for styles too: when a nonce is present, browsers ignore an
+ * accompanying `'unsafe-inline'` style fallback, so only the nonced styles run.
+ *
+ * ## Swagger UI exception
+ *
+ * Swagger UI at `/docs` bundles its own inline scripts and styles and cannot
+ * use our nonce, so the strict CSP would break it. The `/docs` prefix is
+ * excluded from the global CSP and served a relaxed policy instead. The
+ * exception is scoped to that prefix only; every other route keeps the strict
+ * policy.
+ *
+ * ## Environment-aware posture (ADR-008, kept compatible)
+ *
+ * Strict-by-default. HSTS can be turned off for local plain-HTTP dev via
+ * `SECURITY_HSTS_ENABLED=false` (mirrors the existing `SESSION_COOKIE_SECURE`
+ * gate); production MUST keep it on.
+ */
+
+/** Prefix served by Swagger UI; excluded from the strict CSP. */
+const SWAGGER_PREFIX = '/docs';
+
+/** Relaxed CSP for Swagger UI, which needs its own inline scripts/styles. */
+const SWAGGER_CSP =
+  "default-src 'self'; " +
+  "base-uri 'self'; " +
+  "script-src 'self' 'unsafe-inline'; " +
+  "style-src 'self' 'unsafe-inline'; " +
+  "img-src 'self' data: https:; " +
+  "font-src 'self' data:; " +
+  "connect-src 'self'; " +
+  "object-src 'none'; " +
+  "frame-ancestors 'self'";
+
+function isSwaggerRequest(request: FastifyRequest): boolean {
+  // url includes the query string; compare against the path prefix only.
+  const path = request.url.split('?', 1)[0];
+  return path === SWAGGER_PREFIX || path.startsWith(`${SWAGGER_PREFIX}/`);
+}
+
+/**
+ * Register security headers. Wrapped with `fastify-plugin` so the `cspNonce`
+ * reply decorator and the global helmet hooks apply to every route registered
+ * by the parent app, not just this plugin's encapsulated context.
+ */
+export const securityHeadersPlugin = fp<FastifyPluginOptions>(
+  async (fastify: FastifyInstance) => {
+    await fastify.register(helmet, {
+      global: true,
+      // Generates a fresh per-request nonce on `reply.cspNonce.{script,style}`
+      // and appends `'nonce-<value>'` to the script-src/style-src directives.
+      enableCSPNonces: true,
+      contentSecurityPolicy: {
+        useDefaults: false,
+        directives: {
+          'default-src': ["'self'"],
+          'base-uri': ["'self'"],
+          // No inline scripts: the rendered pages contain none, so an injected
+          // <script> is refused outright (defence-in-depth behind html.ts escaping).
+          // enableCSPNonces still appends a script nonce; we never emit it, so
+          // inline scripts remain effectively blocked.
+          'script-src': ["'self'"],
+          // Inline <style> is allowed ONLY when carrying the per-request nonce
+          // (appended by enableCSPNonces).
+          'style-src': ["'self'"],
+          'img-src': ["'self'", 'data:'],
+          'font-src': ["'self'", 'data:'],
+          'connect-src': ["'self'"],
+          'form-action': ["'self'"],
+          'object-src': ["'none'"],
+          'frame-ancestors': ["'none'"],
+        },
+      },
+      // HSTS: one-year max-age, subdomains, preload (issue #113). Gated so local
+      // plain-HTTP dev does not pin the host to HTTPS. Browsers ignore HSTS over
+      // plain HTTP, so this is also harmless when accidentally left on in dev.
+      strictTransportSecurity: env.SECURITY_HSTS_ENABLED
+        ? {
+            maxAge: env.SECURITY_HSTS_MAX_AGE,
+            includeSubDomains: true,
+            preload: true,
+          }
+        : false,
+      // Clickjacking + MIME-sniffing protection.
+      frameguard: { action: 'deny' },
+      xContentTypeOptions: true,
+      referrerPolicy: { policy: 'no-referrer' },
+      // We are an API/auth server, not a cross-origin resource provider for
+      // browser apps; keep COEP off so it never interferes with redirects, and
+      // let CORS (registered separately) govern cross-origin reads.
+      crossOriginEmbedderPolicy: false,
+    });
+
+    // Swagger UI exception: replace the strict CSP with the relaxed policy on
+    // the /docs prefix only. Runs after helmet's own onSend has set the strict
+    // header, so we overwrite rather than append.
+    fastify.addHook(
+      'onSend',
+      async (request: FastifyRequest, reply: FastifyReply, payload: unknown) => {
+        if (isSwaggerRequest(request)) {
+          reply.header('Content-Security-Policy', SWAGGER_CSP);
+        }
+        return payload;
+      }
+    );
+
+    fastify.log.info('Security headers plugin registered');
+  },
+  {
+    name: '@qauth-labs/security-headers',
+  }
+);
+
+export default securityHeadersPlugin;

--- a/apps/auth-server/src/app/routes/ui/consent.test.ts
+++ b/apps/auth-server/src/app/routes/ui/consent.test.ts
@@ -28,6 +28,9 @@ function createReply() {
     body?: unknown;
   } = { headers: {} };
   const reply: any = {
+    // Mirrors @fastify/helmet's enableCSPNonces decorator (issue #113): the
+    // consent/login renderers read reply.cspNonce.style for the inline <style>.
+    cspNonce: { script: 'test-script-nonce', style: 'test-style-nonce' },
     code(n: number) {
       state.statusCode = n;
       return reply;
@@ -165,7 +168,10 @@ describe('UI /ui/consent GET — rendering', () => {
     expect(html).toContain('Test App wants to access your account');
     expect(html).toContain('csrf_token');
     expect(state.headers['Content-Type']).toContain('text/html');
-    expect(state.headers['X-Frame-Options']).toBe('DENY');
+    // Clickjacking/MIME/Referrer/CSP hardening moved to the global
+    // security-headers plugin (#113) — covered in security-headers.test.ts.
+    // The page stamps the per-request CSP nonce onto its inline <style>.
+    expect(html).toContain('nonce="test-style-nonce"');
     expect(fastify.sessionUtils.setSession).toHaveBeenCalledOnce();
   });
 });

--- a/apps/auth-server/src/app/routes/ui/consent.ts
+++ b/apps/auth-server/src/app/routes/ui/consent.ts
@@ -18,7 +18,7 @@ import {
   isLoopbackRedirect,
   redirectHost,
 } from '../../helpers/consent';
-import { html, render, safe } from '../../helpers/html';
+import { html, render, safe, safeUrl } from '../../helpers/html';
 import { buildRedirectUrl } from '../../helpers/oauth-redirect';
 import { getOrCreateDefaultRealm } from '../../helpers/realm';
 import { highestAgentModeInScopes } from '../../helpers/scope-modes';
@@ -112,6 +112,8 @@ function consentPage(opts: {
   scopes: string[];
   badgeDynamic: boolean;
   csrfToken: string;
+  /** Per-request CSP nonce (issue #113) stamped onto the inline <style> tag. */
+  cspNonce: string;
   authorizeParams: Record<string, string | undefined>;
   /** RFC 8707 resource indicators — emitted as one hidden input per URI. */
   resources: string[];
@@ -159,11 +161,15 @@ function consentPage(opts: {
       </div>`
     : safe('');
 
-  const homepage = opts.clientHomepage
+  // #112: an OAuth client's homepage_uri is attacker-controlled (especially for
+  // CIMD/dynamically registered clients). HTML-escaping alone does not stop a
+  // `javascript:` URL from executing on click, so the href is gated through
+  // safeUrl(): only http(s)/mailto links are rendered clickable. The visible
+  // text is still escaped by the `html` tag so a rejected URL shows harmlessly.
+  const safeHomepage = safeUrl(opts.clientHomepage);
+  const homepage = safeHomepage
     ? html`<p class="homepage">
-        <a href="${opts.clientHomepage}" rel="noopener noreferrer" target="_blank"
-          >${opts.clientHomepage}</a
-        >
+        <a href="${safeHomepage}" rel="noopener noreferrer" target="_blank">${safeHomepage}</a>
       </p>`
     : safe('');
 
@@ -175,7 +181,7 @@ function consentPage(opts: {
           <meta name="viewport" content="width=device-width,initial-scale=1" />
           <meta name="robots" content="noindex" />
           <title>Authorize ${opts.clientName}</title>
-          <style>
+          <style nonce="${opts.cspNonce}">
             body {
               font-family:
                 system-ui,
@@ -381,10 +387,9 @@ export default async function (fastify: FastifyInstance) {
 
       reply.header('Content-Type', 'text/html; charset=utf-8');
       reply.header('Cache-Control', 'no-store');
-      // OWASP: tighten rendering context against clickjacking / MIME sniffing.
-      reply.header('X-Frame-Options', 'DENY');
-      reply.header('X-Content-Type-Options', 'nosniff');
-      reply.header('Referrer-Policy', 'no-referrer');
+      // Clickjacking / MIME-sniffing / referrer hardening are now applied
+      // globally by the security-headers plugin (issue #113), including the
+      // strict nonce-based CSP that this page's inline <style> relies on.
 
       return reply.send(
         consentPage({
@@ -396,6 +401,7 @@ export default async function (fastify: FastifyInstance) {
           scopes,
           badgeDynamic: isDynamicClientWithinBadgeWindow(client),
           csrfToken,
+          cspNonce: reply.cspNonce.style,
           authorizeParams: {
             client_id: query.client_id,
             redirect_uri: query.redirect_uri,

--- a/apps/auth-server/src/app/routes/ui/login.ts
+++ b/apps/auth-server/src/app/routes/ui/login.ts
@@ -35,8 +35,14 @@ function isSafeReturnTo(value: unknown): value is string {
   return true;
 }
 
-function loginPage(opts: { returnTo: string; error?: string; email?: string }): string {
-  const { returnTo, error, email } = opts;
+function loginPage(opts: {
+  returnTo: string;
+  /** Per-request CSP nonce (issue #113) stamped onto the inline <style> tag. */
+  cspNonce: string;
+  error?: string;
+  email?: string;
+}): string {
+  const { returnTo, cspNonce, error, email } = opts;
   return render(
     html`<!doctype html>
       <html lang="en">
@@ -45,7 +51,7 @@ function loginPage(opts: { returnTo: string; error?: string; email?: string }): 
           <meta name="viewport" content="width=device-width,initial-scale=1" />
           <meta name="robots" content="noindex" />
           <title>Sign in — QAuth</title>
-          <style>
+          <style nonce="${cspNonce}">
             body {
               font-family:
                 system-ui,
@@ -165,7 +171,7 @@ export default async function (fastify: FastifyInstance) {
       const returnTo = isSafeReturnTo(q.return_to) ? q.return_to : '/';
       reply.header('Content-Type', 'text/html; charset=utf-8');
       reply.header('Cache-Control', 'no-store');
-      return reply.send(loginPage({ returnTo, error: q.error }));
+      return reply.send(loginPage({ returnTo, cspNonce: reply.cspNonce.style, error: q.error }));
     }
   );
 
@@ -220,6 +226,7 @@ export default async function (fastify: FastifyInstance) {
         return reply.send(
           loginPage({
             returnTo,
+            cspNonce: reply.cspNonce.style,
             error: 'Invalid email or password.',
             email: body.email,
           })

--- a/docs/browser-security.md
+++ b/docs/browser-security.md
@@ -1,0 +1,93 @@
+# Browser security model (`/ui/*` flow)
+
+QAuth's interactive sign-in and consent screens live under `/ui/*` and are
+protected by a session cookie, a CSRF token, and a strict set of response
+headers. This document describes the contract for anyone integrating with or
+operating those endpoints. The machine-to-machine OAuth/OIDC endpoints under
+`/oauth/*` and `/auth/*` are JSON/bearer APIs and are **not** affected by the
+cookie/CSRF mechanics below.
+
+## Session cookie
+
+| Attribute  | Value                                           |
+| ---------- | ----------------------------------------------- |
+| Name       | `__Host-qauth_session`                          |
+| `HttpOnly` | always                                          |
+| `SameSite` | `Lax`                                           |
+| `Secure`   | on by default; gated by `SESSION_COOKIE_SECURE` |
+| `Path`     | `/`                                             |
+| `Domain`   | none (forbidden by the `__Host-` prefix)        |
+
+- The cookie carries only a signed session id (`<sessionId>.<HMAC-SHA256>`).
+  The authenticated user is bound to the id server-side in Redis, so logout /
+  revocation is a single key delete.
+- The `__Host-` prefix is browser-enforced: the cookie is rejected unless it is
+  `Secure`, `Path=/`, and has no `Domain`. This isolates it from sibling
+  subdomains.
+- `Secure` is **on by default**. Set `SESSION_COOKIE_SECURE=false` **only** for
+  local plain-HTTP development. In production it must stay on (the `__Host-`
+  prefix requires it).
+
+## CSRF protection (consent form)
+
+`POST /ui/consent` is the only cookie-authenticated, state-changing browser
+endpoint, so it is CSRF-protected with a session-bound double-submit token:
+
+1. `GET /ui/consent` renders a hidden `<input name="csrf_token">`. The same
+   value is stored in the server-side session.
+2. `POST /ui/consent` must submit that `csrf_token`. The server compares the
+   submitted value against the session copy with a timing-safe comparison
+   (`csrfTokensEqual`). A mismatch → `400 invalid_csrf_token` and an audit log
+   entry (`oauth.consent.csrf_failure`).
+3. The token is **burned** on a successful POST and re-minted on the next
+   `GET /ui/consent`, so a captured form cannot be replayed. The token is **not**
+   rotated on every GET, so opening the consent page in multiple tabs does not
+   invalidate earlier tabs.
+
+Clients embedding the consent flow must round-trip the `csrf_token` field
+verbatim from the rendered form; do not generate it client-side.
+
+### Why other endpoints do not carry a CSRF token
+
+- `POST /ui/login` submits credentials and runs **before** any authenticated
+  session exists. Classic CSRF rides an existing ambient session, which is
+  absent here; `SameSite=Lax` plus the fresh-session-on-success behaviour
+  (session-fixation defence) cover the relevant cases.
+- `/auth/login`, `/auth/logout`, `/auth/register`, `/auth/refresh`,
+  `/auth/resend-verification`, and all `/oauth/*` endpoints authenticate with a
+  **bearer token or client credentials**, not the browser session cookie. They
+  carry no ambient-authority cookie, so CSRF does not apply.
+
+## Response security headers (issue #113)
+
+`@fastify/helmet` applies the following to every response:
+
+- **Content-Security-Policy** (strict, nonce-based):
+  `default-src 'self'`, `script-src 'self'`, `style-src 'self' 'nonce-…'`,
+  `img-src 'self' data:`, `font-src 'self' data:`, `connect-src 'self'`,
+  `form-action 'self'`, `object-src 'none'`, `frame-ancestors 'none'`,
+  `base-uri 'self'`. A fresh per-request nonce authorises the inline `<style>`
+  on the login/consent pages; there is **no** `'unsafe-inline'` for scripts, so
+  an injected `<script>` is refused by the browser.
+- **Strict-Transport-Security**: `max-age=31536000; includeSubDomains; preload`
+  (one year, preload-eligible). Gated by `SECURITY_HSTS_ENABLED` /
+  `SECURITY_HSTS_MAX_AGE`; keep enabled in production behind TLS.
+- **X-Frame-Options**: `DENY` — clickjacking protection.
+- **X-Content-Type-Options**: `nosniff`.
+- **Referrer-Policy**: `no-referrer`.
+
+### Swagger UI exception
+
+The strict CSP would break Swagger UI (it bundles inline scripts/styles), so the
+`/docs` prefix is served a relaxed CSP that permits `'unsafe-inline'` for its
+own scripts and styles. The relaxation is scoped to `/docs` only; every other
+route keeps the strict policy.
+
+## Related configuration
+
+| Env var                 | Default    | Purpose                              |
+| ----------------------- | ---------- | ------------------------------------ |
+| `SESSION_COOKIE_SECURE` | `true`     | `Secure` flag on the session cookie. |
+| `SESSION_COOKIE_TTL`    | `86400`    | Session lifetime (seconds).          |
+| `SECURITY_HSTS_ENABLED` | `true`     | Emit the HSTS header.                |
+| `SECURITY_HSTS_MAX_AGE` | `31536000` | HSTS `max-age` (seconds).            |

--- a/libs/server/config/src/lib/schemas/auth.ts
+++ b/libs/server/config/src/lib/schemas/auth.ts
@@ -168,6 +168,29 @@ export const authEnvSchema = z.object({
     .transform((v) => v === 'true'),
 
   /**
+   * Whether to emit the `Strict-Transport-Security` (HSTS) response header
+   * (issue #113). Defaults true (strict-by-default, mirroring the
+   * `SESSION_COOKIE_SECURE` pattern); local dev over plain HTTP can set false
+   * so a browser does not pin the dev host to HTTPS for a year. Production
+   * MUST keep this true. HSTS is only honoured by browsers over HTTPS, so
+   * leaving it on is harmless behind a TLS-terminating reverse proxy.
+   */
+  SECURITY_HSTS_ENABLED: z
+    .enum(['true', 'false'])
+    .default('true')
+    .transform((v) => v === 'true'),
+
+  /**
+   * `max-age` (seconds) for the HSTS header (issue #113). Defaults to one
+   * year (31536000), the value required for HSTS preload-list inclusion.
+   */
+  SECURITY_HSTS_MAX_AGE: z.coerce
+    .number()
+    .int()
+    .min(0)
+    .default(365 * 24 * 60 * 60),
+
+  /**
    * Window (in days) after dynamic registration during which the consent
    * screen shows the "Newly registered" phishing-defense badge. Zero
    * disables the badge.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,9 @@ catalogs:
     '@fastify/formbody':
       specifier: ^8.0.2
       version: 8.0.2
+    '@fastify/helmet':
+      specifier: ^13.0.2
+      version: 13.0.2
     '@fastify/rate-limit':
       specifier: ^10.3.0
       version: 10.3.0
@@ -384,6 +387,9 @@ importers:
       '@fastify/formbody':
         specifier: 'catalog:'
         version: 8.0.2
+      '@fastify/helmet':
+        specifier: 'catalog:'
+        version: 13.0.2
       '@fastify/rate-limit':
         specifier: 'catalog:'
         version: 10.3.0
@@ -1948,6 +1954,9 @@ packages:
 
   '@fastify/forwarded@3.0.1':
     resolution: {integrity: sha512-JqDochHFqXs3C3Ml3gOY58zM7OqO9ENqPo0UqAjAjH8L01fRZqwX9iLeX34//kiJubF7r2ZQHtBRU36vONbLlw==}
+
+  '@fastify/helmet@13.0.2':
+    resolution: {integrity: sha512-tO1QMkOfNeCt9l4sG/FiWErH4QMm+RjHzbMTrgew1DYOQ2vb/6M1G2iNABBrD7Xq6dUk+HLzWW8u+rmmhQHifA==}
 
   '@fastify/merge-json-schemas@0.2.1':
     resolution: {integrity: sha512-OA3KGBCy6KtIvLf8DINC5880o5iBlDX4SxzLQS8HorJAbqluzLRn80UXU0bxZn7UOFhFgpRJDasfwn9nG4FG4A==}
@@ -5545,6 +5554,10 @@ packages:
   he@1.2.0:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
     hasBin: true
+
+  helmet@8.2.0:
+    resolution: {integrity: sha512-DRgTIUgnWcJ62KyarxxziuqYxKGnR6Rgg19BlbucN/dpmJbl1XOit6qvoOX0ZT+HhWe5OUVhU/a1zpGyc1xA0Q==}
+    engines: {node: '>=18.0.0'}
 
   hermes-estree@0.25.1:
     resolution: {integrity: sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==}
@@ -9382,6 +9395,11 @@ snapshots:
       fastify-plugin: 5.1.0
 
   '@fastify/forwarded@3.0.1': {}
+
+  '@fastify/helmet@13.0.2':
+    dependencies:
+      fastify-plugin: 5.1.0
+      helmet: 8.2.0
 
   '@fastify/merge-json-schemas@0.2.1':
     dependencies:
@@ -13373,6 +13391,8 @@ snapshots:
       function-bind: 1.1.2
 
   he@1.2.0: {}
+
+  helmet@8.2.0: {}
 
   hermes-estree@0.25.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -80,6 +80,7 @@ catalog:
   '@fastify/autoload': '^6.3.1'
   '@fastify/cors': '^11.2.0'
   '@fastify/formbody': '^8.0.2'
+  '@fastify/helmet': '^13.0.2'
   '@fastify/rate-limit': '^10.3.0'
   '@fastify/swagger': '^9.7.0'
   '@fastify/swagger-ui': '^5.2.5'


### PR DESCRIPTION
## What

Implements the T3 §3.1 browser-hardening track for the auth-server.

### #113 — Security headers (helmet)
- New `security-headers` plugin registers `@fastify/helmet` before routes.
- Strict **nonce-based CSP**: `default-src 'self'`, `script-src 'self'`, `style-src 'self' 'nonce-…'`, `object-src 'none'`, `frame-ancestors 'none'`, `base-uri 'self'`, `form-action 'self'`. No `'unsafe-inline'` for scripts.
- **HSTS** (`max-age=31536000; includeSubDomains; preload`), **X-Frame-Options: DENY**, **X-Content-Type-Options: nosniff**, **Referrer-Policy: no-referrer**.
- Login/consent inline `<style>` tags carry a fresh per-request nonce.
- **Swagger UI** at `/docs` gets a scoped relaxed CSP so it keeps working.

### #112 — XSS
- Added `safeUrl()` (allowlists http/https/mailto) and gated the consent page's attacker-controlled client `homepage_uri` href through it — HTML-escaping alone does not stop a `javascript:` URL from executing on click.
- Confirmed all other interpolated values already pass through `html.ts` escaping.

### #108 — CSRF
- Audited every cookie-authenticated state-changing browser endpoint. `POST /ui/consent` is the only one and is already protected by the session-bound double-submit token. `/auth/*` and `/oauth/*` are bearer/credential APIs with no ambient cookie auth.
- Documented the token contract in `docs/browser-security.md`.

### #109 — Secure cookies
- Audited all `Set-Cookie` usage: only `__Host-qauth_session`, already HttpOnly + SameSite=Lax + Secure (default-on) + Path=/ + no Domain.
- Added tests covering the Secure-on (production default) and Secure-off (dev override) paths.

Strict-by-default with documented local-dev relaxations (`SESSION_COOKIE_SECURE`, `SECURITY_HSTS_ENABLED`), consistent with ADR-008.

## Dependency
Adds `@fastify/helmet@^13.0.2` via the pnpm catalog. `pnpm audit` — no known vulnerabilities.

## Tests
- `pnpm nx test auth-server` — 410 passed / 28 files
- `pnpm nx lint auth-server` — 0 errors
- `pnpm nx build auth-server` — success

## Notes
- CSP uses helmet's native `enableCSPNonces` (`reply.cspNonce.style`).
- `/docs` is the only CSP relaxation; every other route stays strict.

Closes #108
Closes #109
Closes #112
Closes #113

https://claude.ai/code/session_01SGm2UmswGGEXHyvuw57ubh
