### PR TITLE
chore(portal): add developer-portal production Docker image and compose service (T3)

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -161,3 +161,15 @@ REFRESH_RATE_WINDOW=60
 # Logout endpoint rate limits
 LOGOUT_RATE_LIMIT=20
 LOGOUT_RATE_WINDOW=60
+
+# =============================================================================
+# Developer Portal (apps/developer-portal)
+# =============================================================================
+# Required: 32+ char random secret used to sign the portal session cookie
+# (__Host-qauth_portal_session). Generate with: openssl rand -hex 32
+PORTAL_SESSION_SECRET=change-me-to-a-random-hex-string-at-least-32-chars
+# Session cookie lifetime in seconds (default: 900 = 15 minutes)
+PORTAL_SESSION_TTL=900
+# Base URL the portal uses to reach the auth-server. Inside Docker Compose the
+# default resolves over the service network; override only for split setups.
+PORTAL_AUTH_SERVER_URL=http://auth-server:3000

--- a/apps/developer-portal/Dockerfile
+++ b/apps/developer-portal/Dockerfile
@@ -1,0 +1,80 @@
+# Developer Portal Dockerfile — production image.
+#
+# The portal is a TanStack Start app. Its Vite build emits a
+# framework-agnostic fetch handler (`server/server.js`, default export
+# `{ fetch }`) plus static client assets (`client/`) — it does NOT ship a
+# self-listening server. We therefore:
+#   1. build the app with Nx (`vite build`), and
+#   2. run it behind a tiny Node adapter (`server.mjs`) that pipes
+#      `node:http` requests into the fetch handler and serves the client
+#      assets.
+#
+# Dependency strategy mirrors the auth-server prod image: `pnpm deploy`
+# produces a self-contained tree whose node_modules contains real copies of
+# the workspace + external prod deps, so the build output's bare imports
+# (react, @tanstack/*) resolve at runtime without a custom resolver.
+#
+# Requires BuildKit (default on Docker 23+) for the `--mount=type=cache`
+# pnpm-store mount. A sibling `Dockerfile.dockerignore` lifts the root
+# `.dockerignore`'s exclusion of `apps/developer-portal` for this build only.
+#
+# syntax=docker/dockerfile:1.7
+
+# Stage 1: Workspace install + Nx build + pnpm deploy.
+FROM node:24-alpine AS builder
+WORKDIR /app
+RUN corepack enable
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY nx.json tsconfig.base.json ./
+COPY vitest.config.ts ./
+COPY libs ./libs
+COPY apps ./apps
+
+# Install with a cache mount for pnpm's package store.
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
+    pnpm install --frozen-lockfile --store-dir /pnpm/store
+
+# Build the TanStack Start app -> dist/apps/developer-portal/{server,client}.
+RUN pnpm nx build developer-portal
+
+# Produce a self-contained deploy bundle at /deploy containing the portal's
+# prod node_modules (real copies, not symlinks across the store).
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
+    pnpm --filter @qauth-labs/developer-portal deploy --prod --legacy \
+    --store-dir /pnpm/store /deploy
+
+# Stage 2: Runner.
+FROM node:24-alpine AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+
+# Non-root user, created before COPY --chown so layers land owned correctly.
+RUN addgroup -g 1001 -S nodejs && \
+    adduser -S nodejs -u 1001
+
+# Self-contained prod node_modules from the deploy bundle.
+COPY --from=builder --chown=nodejs:nodejs /deploy/node_modules ./node_modules
+
+# Built app output: SSR fetch handler + static client assets.
+COPY --from=builder --chown=nodejs:nodejs /app/dist/apps/developer-portal/server ./server
+COPY --from=builder --chown=nodejs:nodejs /app/dist/apps/developer-portal/client ./client
+
+# Node adapter (container entrypoint) + entrypoint script.
+COPY --chown=nodejs:nodejs apps/developer-portal/server.mjs ./server.mjs
+COPY --chown=nodejs:nodejs apps/developer-portal/docker-entrypoint.sh ./docker-entrypoint.sh
+# BusyBox `sed -i` rewrites + re-owns to root; re-chown the single file so
+# USER nodejs can exec it. (Per-file chown, not -R — cheap.)
+RUN sed -i 's/\r$//' ./docker-entrypoint.sh && \
+    chmod +x ./docker-entrypoint.sh && \
+    chown nodejs:nodejs ./docker-entrypoint.sh
+
+USER nodejs
+
+ENV PORT=3001
+ENV HOST=0.0.0.0
+EXPOSE 3001
+
+HEALTHCHECK --interval=30s --timeout=10s --start-period=20s --retries=3 \
+  CMD node -e "require('http').get('http://localhost:3001/healthz', (r) => {process.exit(r.statusCode === 200 ? 0 : 1)}).on('error', () => process.exit(1))"
+
+ENTRYPOINT ["/bin/sh", "/app/docker-entrypoint.sh"]

--- a/apps/developer-portal/Dockerfile.dev
+++ b/apps/developer-portal/Dockerfile.dev
@@ -1,0 +1,31 @@
+# Developer Portal – Development Dockerfile
+# Uses the Vite dev server via nx; pair with docker-compose.dev.yml +
+# Compose Watch (sync). Mirrors apps/auth-server/Dockerfile.dev.
+
+FROM node:24-alpine
+
+WORKDIR /app
+
+RUN corepack enable
+
+# Dependencies only (layer cache)
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY nx.json tsconfig.base.json ./
+COPY vitest.config.ts ./
+RUN pnpm install --frozen-lockfile
+
+# Workspace (Compose Watch will sync over these; writable for sync targets)
+COPY libs ./libs
+COPY apps ./apps
+
+RUN addgroup -g 1001 -S nodejs && adduser -S nodejs -u 1001 && \
+    chown -R nodejs:nodejs /app
+
+USER nodejs
+
+EXPOSE 3001
+
+# Vite dev server. The portal's vite.config sets server.port to 3000; override
+# to 3001 via --port so it does not collide with the auth-server dev server,
+# and bind 0.0.0.0 so it is reachable from the host.
+CMD ["pnpm", "nx", "dev", "developer-portal", "--", "--host", "0.0.0.0", "--port", "3001"]

--- a/apps/developer-portal/Dockerfile.dockerignore
+++ b/apps/developer-portal/Dockerfile.dockerignore
@@ -1,0 +1,64 @@
+# Build-context ignore for apps/developer-portal/Dockerfile.
+#
+# BuildKit prefers a `<dockerfile>.dockerignore` over the root `.dockerignore`
+# when one exists, so this file applies ONLY to the developer-portal image.
+# It deliberately does NOT exclude `apps/developer-portal` (the root
+# `.dockerignore` does, so the portal source reaches the auth-server image
+# graph) — the portal image needs its own source to build.
+
+# Dependencies
+node_modules
+.pnp
+.pnp.js
+
+# Build outputs (will be built inside Docker)
+dist
+.nx
+coverage
+
+# Testing
+*.test.ts
+*.test.tsx
+*.spec.ts
+*.spec.tsx
+.vitest
+
+# Git
+.git
+.gitignore
+.github
+
+# IDE
+.vscode
+.idea
+*.swp
+*.swo
+*~
+
+# Environment
+.env
+.env.local
+.env.*.local
+.env.test
+
+# Documentation (except READMEs in libs/apps)
+*.md
+!apps/**/README.md
+!libs/**/README.md
+local-docs
+
+# Logs
+*.log
+npm-debug.log*
+pnpm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Misc
+.cache
+.temp
+tmp

--- a/apps/developer-portal/docker-entrypoint.sh
+++ b/apps/developer-portal/docker-entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -e
+
+echo "Starting developer portal..."
+exec node server.mjs

--- a/apps/developer-portal/server.mjs
+++ b/apps/developer-portal/server.mjs
@@ -1,0 +1,154 @@
+/**
+ * Production Node.js server for the QAuth developer portal.
+ *
+ * TanStack Start's Vite build emits a framework-agnostic fetch handler at
+ * `server/server.js` (default export `{ fetch }`) plus static client assets
+ * under `client/`. It does not ship a self-listening server, so this thin
+ * adapter wires the fetch handler into `node:http` and serves the prebuilt
+ * client assets. It depends only on Node built-ins.
+ *
+ * Layout expected at runtime (see Dockerfile):
+ *   /app/server/server.js   <- TanStack Start fetch handler (default export)
+ *   /app/client/...         <- hashed client assets + index html shell
+ *   /app/server.mjs         <- this file (the container entrypoint)
+ *
+ * Env:
+ *   PORT  (default 3001) — port to listen on
+ *   HOST  (default 0.0.0.0) — interface to bind
+ */
+import { createReadStream } from 'node:fs';
+import { stat } from 'node:fs/promises';
+import { createServer } from 'node:http';
+import { extname, join, normalize } from 'node:path';
+import { Readable } from 'node:stream';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const CLIENT_DIR = join(__dirname, 'client');
+
+const PORT = Number(process.env.PORT ?? 3001);
+const HOST = process.env.HOST ?? '0.0.0.0';
+
+// The TanStack Start server entry resolves its dependencies (react, @tanstack/*)
+// from node_modules. Importing it lazily keeps any resolution error visible.
+const { default: handler } = await import('./server/server.js');
+
+const MIME = {
+  '.js': 'text/javascript; charset=utf-8',
+  '.mjs': 'text/javascript; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.html': 'text/html; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.svg': 'image/svg+xml',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.ico': 'image/x-icon',
+  '.webp': 'image/webp',
+  '.woff': 'font/woff',
+  '.woff2': 'font/woff2',
+  '.ttf': 'font/ttf',
+  '.map': 'application/json; charset=utf-8',
+  '.txt': 'text/plain; charset=utf-8',
+};
+
+/** Resolve a request path to a real file under CLIENT_DIR, or null. */
+async function resolveStaticFile(pathname) {
+  // Block path traversal: normalize and ensure the result stays in CLIENT_DIR.
+  const safe = normalize(decodeURIComponent(pathname)).replace(/^(\.\.[/\\])+/, '');
+  const filePath = join(CLIENT_DIR, safe);
+  if (!filePath.startsWith(CLIENT_DIR)) return null;
+  try {
+    const s = await stat(filePath);
+    if (s.isFile()) return filePath;
+  } catch {
+    /* not a static file */
+  }
+  return null;
+}
+
+/** Convert a Node IncomingMessage into a WHATWG Request. */
+function toWebRequest(req) {
+  const proto = (req.headers['x-forwarded-proto'] || 'http').toString().split(',')[0];
+  const host = req.headers.host ?? `${HOST}:${PORT}`;
+  const url = new URL(req.url ?? '/', `${proto}://${host}`);
+  const headers = new Headers();
+  for (const [key, value] of Object.entries(req.headers)) {
+    if (value === undefined) continue;
+    if (Array.isArray(value)) for (const v of value) headers.append(key, v);
+    else headers.set(key, value);
+  }
+  const hasBody = req.method !== 'GET' && req.method !== 'HEAD';
+  return new Request(url, {
+    method: req.method,
+    headers,
+    body: hasBody ? Readable.toWeb(req) : undefined,
+    duplex: hasBody ? 'half' : undefined,
+  });
+}
+
+/** Pipe a WHATWG Response back onto the Node ServerResponse. */
+async function writeWebResponse(webRes, res) {
+  res.statusCode = webRes.status;
+  webRes.headers.forEach((value, key) => res.setHeader(key, value));
+  if (!webRes.body) {
+    res.end();
+    return;
+  }
+  await new Promise((resolve, reject) => {
+    const nodeStream = Readable.fromWeb(webRes.body);
+    nodeStream.on('error', reject);
+    res.on('close', resolve);
+    nodeStream.pipe(res);
+  });
+}
+
+const server = createServer(async (req, res) => {
+  try {
+    // Liveness probe: answered by the adapter itself so a HEALTHCHECK never
+    // depends on the upstream auth-server being reachable. It only confirms
+    // the Node process is up and accepting connections.
+    if (req.url === '/healthz') {
+      res.statusCode = 200;
+      res.setHeader('Content-Type', 'text/plain; charset=utf-8');
+      res.end('ok');
+      return;
+    }
+
+    // Static assets first (cheap, avoids running the SSR handler for files).
+    if (req.method === 'GET' || req.method === 'HEAD') {
+      const filePath = await resolveStaticFile(new URL(req.url ?? '/', 'http://x').pathname);
+      if (filePath) {
+        res.statusCode = 200;
+        res.setHeader('Content-Type', MIME[extname(filePath)] ?? 'application/octet-stream');
+        // Hashed assets are immutable; the HTML shell is handled by the SSR path.
+        res.setHeader('Cache-Control', 'public, max-age=31536000, immutable');
+        if (req.method === 'HEAD') {
+          res.end();
+          return;
+        }
+        createReadStream(filePath).pipe(res);
+        return;
+      }
+    }
+
+    const webRes = await handler.fetch(toWebRequest(req));
+    await writeWebResponse(webRes, res);
+  } catch (err) {
+    console.error('Request failed:', err);
+    if (!res.headersSent) res.statusCode = 500;
+    res.end('Internal Server Error');
+  }
+});
+
+server.listen(PORT, HOST, () => {
+  console.log(`developer-portal listening on http://${HOST}:${PORT}`);
+});
+
+// Graceful shutdown for container orchestration.
+for (const signal of ['SIGINT', 'SIGTERM']) {
+  process.on(signal, () => {
+    server.close(() => process.exit(0));
+  });
+}

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -42,3 +42,42 @@ services:
         - action: sync
           path: ./tsconfig.base.json
           target: /app/tsconfig.base.json
+
+  developer-portal:
+    build:
+      context: .
+      dockerfile: apps/developer-portal/Dockerfile.dev
+    command: ['pnpm', 'nx', 'dev', 'developer-portal', '--', '--host', '0.0.0.0', '--port', '3001']
+    environment:
+      # Fix for NX finding config in monorepo structure inside container
+      NX_DAEMON: 'false'
+    develop:
+      watch:
+        # Sync source code changes immediately (Hot Reload)
+        - action: sync
+          path: ./apps/developer-portal
+          target: /app/apps/developer-portal
+          ignore:
+            - node_modules
+            - dist
+        - action: sync
+          path: ./libs
+          target: /app/libs
+          ignore:
+            - node_modules
+            - dist
+
+        # Sync config files but DO NOT trigger full rebuilds automatically.
+        # If dependencies change, run: docker compose down && docker compose up --build
+        - action: sync
+          path: ./package.json
+          target: /app/package.json
+        - action: sync
+          path: ./pnpm-lock.yaml
+          target: /app/pnpm-lock.yaml
+        - action: sync
+          path: ./nx.json
+          target: /app/nx.json
+        - action: sync
+          path: ./tsconfig.base.json
+          target: /app/tsconfig.base.json

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -163,6 +163,41 @@ services:
     networks:
       - qauth-network
 
+  developer-portal:
+    build:
+      context: .
+      dockerfile: apps/developer-portal/Dockerfile
+    container_name: qauth-developer-portal
+    environment:
+      # Server
+      NODE_ENV: ${NODE_ENV:-production}
+      PORT: 3001
+      HOST: 0.0.0.0
+      # Reach the auth-server over the Compose network (not the host).
+      AUTH_SERVER_URL: ${PORTAL_AUTH_SERVER_URL:-http://auth-server:3000}
+      # 32+ char secret used to sign the portal session cookie.
+      PORTAL_SESSION_SECRET: ${PORTAL_SESSION_SECRET}
+      PORTAL_SESSION_TTL: ${PORTAL_SESSION_TTL:-900}
+    ports:
+      - '3001:3001'
+    depends_on:
+      auth-server:
+        condition: service_healthy
+    healthcheck:
+      test:
+        [
+          'CMD',
+          'node',
+          '-e',
+          "require('http').get('http://localhost:3001/healthz', (r) => {process.exit(r.statusCode === 200 ? 0 : 1)}).on('error', () => process.exit(1))",
+        ]
+      interval: 30s
+      timeout: 10s
+      start_period: 20s
+      retries: 3
+    networks:
+      - qauth-network
+
 volumes:
   postgres_data:
   redis_data:

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -12,13 +12,17 @@ QAuth uses Docker Compose to orchestrate the following services:
 | **redis**            | `redis:7-alpine`     | Session cache and rate limiting                          |
 | **migration-runner** | Custom               | Runs database migrations via Nx                          |
 | **auth-server**      | Custom               | Main authentication API server                           |
+| **developer-portal** | Custom               | TanStack Start web UI for registration/login/consents    |
 
 ### Production vs development
 
-| Use case        | Compose file(s)                                 | Auth-server image                            | Watch                |
+| Use case        | Compose file(s)                                 | Service image                                | Watch                |
 | --------------- | ----------------------------------------------- | -------------------------------------------- | -------------------- |
 | **Production**  | `docker-compose.yml`                            | `Dockerfile` (multi-stage prod build)        | No                   |
-| **Development** | `docker-compose.yml` + `docker-compose.dev.yml` | `Dockerfile.dev` (deps + source, `nx serve`) | Yes (sync + rebuild) |
+| **Development** | `docker-compose.yml` + `docker-compose.dev.yml` | `Dockerfile.dev` (deps + source, dev server) | Yes (sync + rebuild) |
+
+Both `auth-server` and `developer-portal` follow this convention: a multi-stage
+`Dockerfile` for production and a `Dockerfile.dev` for the watch-based dev flow.
 
 ## Prerequisites
 
@@ -93,8 +97,12 @@ docker compose -f docker-compose.yml -f docker-compose.dev.yml up --watch
 # Check all services are healthy
 docker-compose ps
 
-# Test health endpoint
+# Test the auth-server health endpoint
 curl http://localhost:3000/health
+
+# Test the developer-portal liveness probe, then open it in a browser
+curl http://localhost:3001/healthz   # -> ok
+# http://localhost:3001
 ```
 
 Expected response:
@@ -129,6 +137,14 @@ Expected response:
 │  │                      :3000                              │  │
 │  │  Waits for: postgres (healthy), redis (healthy),       │  │
 │  │             migration-runner (completed)                │  │
+│  └───────────────────────────┬────────────────────────────┘  │
+│                              │ health check dependency        │
+│                              ▼                                 │
+│  ┌────────────────────────────────────────────────────────┐  │
+│  │                 developer-portal                        │  │
+│  │                      :3001                              │  │
+│  │  Waits for: auth-server (healthy). Calls it server-     │  │
+│  │  side at http://auth-server:3000 over the network.      │  │
 │  └────────────────────────────────────────────────────────┘  │
 └─────────────────────────────────────────────────────────────┘
 ```
@@ -183,6 +199,38 @@ The main authentication API server.
 - **Production**: `Dockerfile` → `docker-entrypoint.sh` runs `node main.js`.
 - **Development**: `Dockerfile.dev` → `pnpm nx serve auth-server --watch`; use with `docker-compose.dev.yml` and `--watch`.
 
+### Developer Portal
+
+The TanStack Start web UI for user registration, email verification, login, and
+OAuth consent management. It renders server-side and calls the auth-server only
+from its server functions — tokens never reach the browser.
+
+- **Port**: 3001 (mapped to host)
+- **Health Check**: `GET /healthz` (a lightweight liveness probe served by the
+  Node adapter; it does **not** depend on the auth-server being reachable)
+- **Production**: `Dockerfile` → `docker-entrypoint.sh` runs `node server.mjs`.
+- **Development**: `Dockerfile.dev` → `pnpm nx dev developer-portal` (Vite dev
+  server); use with `docker-compose.dev.yml` and `--watch`.
+- **Depends on**: `auth-server` (healthy).
+
+TanStack Start's Vite build emits a framework-agnostic fetch handler
+(`server/server.js`) plus static client assets (`client/`) rather than a
+self-listening server, so the production image runs a tiny Node adapter
+(`apps/developer-portal/server.mjs`) that pipes `node:http` requests into the
+fetch handler and serves the client assets. The image is built with the same
+`pnpm deploy --prod` strategy as the auth-server so the build output's bare
+imports resolve at runtime.
+
+> **Build context note:** the portal source is excluded from the auth-server /
+> migration-runner build contexts by the root `.dockerignore` (see the build
+> note below). The portal image lifts that exclusion for its own build via a
+> sibling `apps/developer-portal/Dockerfile.dockerignore`, which BuildKit
+> prefers over the root file when present. No action is needed — this is wired
+> up already.
+
+Open the portal at `http://localhost:3001` once the stack is up. Set a
+`PORTAL_SESSION_SECRET` in `.env` first (see Environment Variables).
+
 ## Common Operations
 
 ### Rebuild Images
@@ -191,8 +239,15 @@ The main authentication API server.
 
 ```bash
 docker compose up -d --build
-# Or rebuild only auth-server
+# Or rebuild a single service
 docker compose build auth-server && docker compose up -d auth-server
+docker compose build developer-portal && docker compose up -d developer-portal
+```
+
+Build the portal image directly (from the repo root, BuildKit on):
+
+```bash
+DOCKER_BUILDKIT=1 docker build -f apps/developer-portal/Dockerfile -t qauth-developer-portal .
 ```
 
 **Development:** use `docker compose -f docker-compose.yml -f docker-compose.dev.yml up --watch`; sync/rebuild is automatic. For dependency or config changes, the dev setup will rebuild the auth-server image when those files change.
@@ -258,22 +313,33 @@ See `.env.docker.example` for all available variables. Key variables:
 | `NODE_ENV`        | No       | `production` (default) or `development` for dev    |
 | `LOG_LEVEL`       | No       | `info` (default); use `debug` for development      |
 
+#### Developer Portal
+
+| Variable                 | Required | Default                   | Description                                                 |
+| ------------------------ | -------- | ------------------------- | ----------------------------------------------------------- |
+| `PORTAL_SESSION_SECRET`  | Yes      | —                         | 32+ char secret signing the portal session cookie           |
+| `PORTAL_SESSION_TTL`     | No       | `900`                     | Session cookie lifetime in seconds                          |
+| `PORTAL_AUTH_SERVER_URL` | No       | `http://auth-server:3000` | Base URL the portal uses (server-side) to reach auth-server |
+
+Generate a secret with `openssl rand -hex 32`. The portal will not start without
+`PORTAL_SESSION_SECRET`.
+
 For **development** with `docker-compose.dev.yml`, set `NODE_ENV=development` and `LOG_LEVEL=debug` in `.env`.
 
 ### Client ID Metadata Documents (CIMD)
 
 CIMD is the recommended MCP client-registration mechanism (see [ADR-007](./adr/007-mcp-first-positioning.md)). When a `client_id` is an HTTPS URL, the auth-server fetches and validates the client's metadata document on demand instead of persisting a registration record. All settings have safe defaults — none are required to run.
 
-| Variable                       | Required | Default              | Description                                                                                                   |
-| ------------------------------ | -------- | -------------------- | ------------------------------------------------------------------------------------------------------------- |
-| `CIMD_ENABLED`                 | No       | `true`               | Master switch. When `false`, URL-formatted `client_id`s are rejected with `invalid_client`.                   |
-| `CIMD_TRUST_POLICY`            | No       | `accept-any-https`   | `accept-any-https` (any validating HTTPS document) or `allowlist` (only hosts in `CIMD_TRUSTED_DOMAINS`).     |
-| `CIMD_TRUSTED_DOMAINS`         | No       | _(empty)_            | Comma/space-separated host allowlist for `allowlist` policy. A leading `*.` permits subdomains.               |
-| `CIMD_CACHE_DEFAULT_TTL`       | No       | `300`                | Cache TTL (seconds) when the document carries no usable `Cache-Control`/`Expires`.                            |
-| `CIMD_CACHE_MAX_TTL`           | No       | `3600`               | Hard upper bound (seconds) on any cached document, regardless of upstream `max-age`.                          |
-| `CIMD_MAX_DOCUMENT_BYTES`      | No       | `65536`              | Maximum document size in bytes.                                                                               |
-| `CIMD_FETCH_TIMEOUT_MS`        | No       | `5000`               | Per-fetch timeout in milliseconds.                                                                            |
-| `CIMD_ALLOW_PRIVATE_ADDRESSES` | No       | `false`              | Allow fetches to non-public IPs (loopback/private/link-local). **Keep `false` in production** — it disables the SSRF guard; for dev/integration harnesses only. |
+| Variable                       | Required | Default            | Description                                                                                                                                                     |
+| ------------------------------ | -------- | ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `CIMD_ENABLED`                 | No       | `true`             | Master switch. When `false`, URL-formatted `client_id`s are rejected with `invalid_client`.                                                                     |
+| `CIMD_TRUST_POLICY`            | No       | `accept-any-https` | `accept-any-https` (any validating HTTPS document) or `allowlist` (only hosts in `CIMD_TRUSTED_DOMAINS`).                                                       |
+| `CIMD_TRUSTED_DOMAINS`         | No       | _(empty)_          | Comma/space-separated host allowlist for `allowlist` policy. A leading `*.` permits subdomains.                                                                 |
+| `CIMD_CACHE_DEFAULT_TTL`       | No       | `300`              | Cache TTL (seconds) when the document carries no usable `Cache-Control`/`Expires`.                                                                              |
+| `CIMD_CACHE_MAX_TTL`           | No       | `3600`             | Hard upper bound (seconds) on any cached document, regardless of upstream `max-age`.                                                                            |
+| `CIMD_MAX_DOCUMENT_BYTES`      | No       | `65536`            | Maximum document size in bytes.                                                                                                                                 |
+| `CIMD_FETCH_TIMEOUT_MS`        | No       | `5000`             | Per-fetch timeout in milliseconds.                                                                                                                              |
+| `CIMD_ALLOW_PRIVATE_ADDRESSES` | No       | `false`            | Allow fetches to non-public IPs (loopback/private/link-local). **Keep `false` in production** — it disables the SSRF guard; for dev/integration harnesses only. |
 
 > **Note:** `.env.docker.example` does not yet list the `CIMD_*` variables. They are optional and default-safe, so the stack runs without them; add them to `.env` only to override the defaults above.
 
@@ -323,7 +389,9 @@ docker builder prune
 docker-compose build --no-cache
 ```
 
-If the build fails on `Cannot find module '@tailwindcss/vite'` or a similar dev-portal-scoped import: `apps/developer-portal` is intentionally excluded from the auth-server and migration-runner build contexts via `.dockerignore`. The exclusion keeps Nx's project-graph processor from trying to parse configs for an app that has no Dockerfile of its own yet. Developer-portal will ship with its own image when Phase 2 is ready; until then the exclusion is load-bearing and should not be removed.
+If the build fails on `Cannot find module '@tailwindcss/vite'` or a similar dev-portal-scoped import while building **auth-server** or **migration-runner**: `apps/developer-portal` is intentionally excluded from those build contexts via the root `.dockerignore`. The exclusion keeps Nx's project-graph processor from trying to parse the portal's configs (which import portal-scoped dev deps) during an auth-server build. This exclusion is load-bearing and should not be removed.
+
+The **developer-portal** image needs its own source, so it ships a sibling `apps/developer-portal/Dockerfile.dockerignore`. BuildKit prefers a `<dockerfile>.dockerignore` over the root `.dockerignore`, so that file applies to the portal build only and deliberately does **not** exclude `apps/developer-portal`. Build the portal image with BuildKit enabled (default on Docker 23+) so this per-Dockerfile ignore is honored.
 
 ### Watch: "no space left on device"
 


### PR DESCRIPTION
## Summary
Adds a production Docker image, dev image, and Docker Compose wiring for the `developer-portal` (TanStack Start) app, with docs. Closes #129.

TanStack Start's Vite build emits a framework-agnostic **fetch handler** (`server/server.js`) plus static client assets — not a self-listening server. The production image therefore runs a tiny zero-dependency Node adapter (`server.mjs`) that serves the client assets and pipes `node:http` requests into the fetch handler. Dependency handling mirrors the auth-server prod image (`pnpm deploy --prod`), so the build output's externalized imports resolve at runtime.

## What's included
- **`apps/developer-portal/Dockerfile`** — multi-stage BuildKit prod build (`pnpm install` → `nx build` → `pnpm deploy --prod`), non-root user (uid 1001), `EXPOSE 3001`, HEALTHCHECK on `/healthz`.
- **`apps/developer-portal/server.mjs`** — Node HTTP adapter (built-ins only): `/healthz` liveness, static asset serving with traversal protection, fetch handler bridge, graceful shutdown.
- **`apps/developer-portal/Dockerfile.dev`** — Vite dev server for Compose Watch.
- **`apps/developer-portal/docker-entrypoint.sh`** — runs `node server.mjs`.
- **`apps/developer-portal/Dockerfile.dockerignore`** — per-image context override so the portal build sees its own source (the root `.dockerignore` excludes it to keep the auth-server build working; this is load-bearing and untouched).
- **`docker-compose.yml` / `docker-compose.dev.yml`** — `developer-portal` service on port 3001, `depends_on: auth-server (healthy)`, reaches auth-server at `http://auth-server:3000` over the Compose network.
- **`.env.docker.example`** — `PORTAL_SESSION_SECRET`, `PORTAL_SESSION_TTL`, `PORTAL_AUTH_SERVER_URL`.
- **`docs/docker.md`** — portal service details, env vars, build/run/verify steps.

## Port & start command
Port **3001** (auth-server keeps 3000). Started via `node server.mjs` — the required hosting approach for TanStack Start's fetch-handler output.

## Verification
- `DOCKER_BUILDKIT=1 docker build -f apps/developer-portal/Dockerfile -t qauth-developer-portal .` succeeds (363 MB).
- Container boots, `GET /healthz` → 200, static assets → 200, runs as uid 1001, HEALTHCHECK passes.
- auth-server image still builds (the per-Dockerfile ignore scopes the override correctly).
- `pnpm nx lint developer-portal` passes; both compose configs validate.

## Notes / follow-ups
- `/healthz` was added to the adapter so the healthcheck doesn't depend on the upstream auth-server being up.
- Pre-existing inconsistency (left as-is): root `.env.example` sets `AUTH_SERVER_URL=http://localhost:3001` while auth-server listens on 3000 — worth reconciling separately.

https://claude.ai/code/session_01SGm2UmswGGEXHyvuw57ubh
