### PR TITLE
feat(db): environment-aware authorization foundation (ADR-008)

### DIFF
--- a/apps/auth-server/src/app/helpers/cimd.ts
+++ b/apps/auth-server/src/app/helpers/cimd.ts
@@ -117,6 +117,13 @@ export interface CimdClientInsert {
   // default) — deny-by-default — so it can hold no `agent:*` scope until an
   // operator provisions a cap out of band. This is the epic #181 requirement:
   // never trust the client's own document for an escalation control.
+  //
+  // NOTE (ADR-008 §4, #196): likewise NO `environment` here, by design. The
+  // environment policy profile is OPERATOR-SET and MUST NOT be self-asserted via
+  // a CIMD document. `cimdDocumentSchema` defines no `environment` field (and
+  // strips unknowns per RFC 7591 §3.2), so a document cannot declare itself
+  // `development`. A CIMD client therefore takes the DB column's `production`
+  // default — the strictest profile — until an operator widens it out of band.
   metadata: Record<string, unknown>;
 }
 

--- a/apps/auth-server/src/app/helpers/environment-policy.test.ts
+++ b/apps/auth-server/src/app/helpers/environment-policy.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  type Environment,
+  ENVIRONMENT_PROFILES,
+  ENVIRONMENTS,
+  parseEnvironment,
+  resolveEnvironmentPolicy,
+  stricterEnvironment,
+} from './environment-policy';
+
+describe('environment-policy — parseEnvironment (fail-safe)', () => {
+  it('returns the value for each known environment', () => {
+    for (const env of ENVIRONMENTS) {
+      expect(parseEnvironment(env)).toBe(env);
+    }
+  });
+
+  it('fails safe to production for unknown / empty / null / undefined', () => {
+    expect(parseEnvironment('prod')).toBe('production');
+    expect(parseEnvironment('PRODUCTION')).toBe('production');
+    expect(parseEnvironment('')).toBe('production');
+    expect(parseEnvironment(null)).toBe('production');
+    expect(parseEnvironment(undefined)).toBe('production');
+    // never silently downgrades to a laxer profile
+    expect(parseEnvironment('dev')).toBe('production');
+  });
+});
+
+describe('environment-policy — stricterEnvironment (ceiling ordering)', () => {
+  it('production beats staging beats development', () => {
+    expect(stricterEnvironment('development', 'production')).toBe('production');
+    expect(stricterEnvironment('production', 'development')).toBe('production');
+    expect(stricterEnvironment('development', 'staging')).toBe('staging');
+    expect(stricterEnvironment('staging', 'production')).toBe('production');
+  });
+
+  it('is idempotent for equal inputs', () => {
+    for (const env of ENVIRONMENTS) {
+      expect(stricterEnvironment(env, env)).toBe(env);
+    }
+  });
+});
+
+describe('environment-policy — ENVIRONMENT_PROFILES table (ADR-008 §5)', () => {
+  it('development relaxes the security-relevant knobs', () => {
+    const dev = ENVIRONMENT_PROFILES.development;
+    expect(dev).toMatchObject({
+      environment: 'development',
+      staticApiKeysAllowed: true,
+      localhostRedirectAllowed: true,
+      pkceRequired: false,
+      accessTokenLifespanTier: 'long',
+      refreshRotationRequired: false,
+      rateLimitTier: 'lenient',
+      openDynamicRegistration: true,
+      agentStepUpEnforced: false,
+      t3SecurityEnforced: false,
+    });
+  });
+
+  it('staging keeps production-grade security, relaxing only operational knobs', () => {
+    const staging = ENVIRONMENT_PROFILES.staging;
+    const prod = ENVIRONMENT_PROFILES.production;
+    // Security knobs match production exactly.
+    expect(staging.staticApiKeysAllowed).toBe(false);
+    expect(staging.localhostRedirectAllowed).toBe(false);
+    expect(staging.pkceRequired).toBe(true);
+    expect(staging.refreshRotationRequired).toBe(true);
+    expect(staging.openDynamicRegistration).toBe(false);
+    expect(staging.agentStepUpEnforced).toBe(true);
+    expect(staging.t3SecurityEnforced).toBe(true);
+    // The ONLY relaxations vs production are operational conveniences.
+    expect(staging.rateLimitTier).toBe('lenient');
+    expect(prod.rateLimitTier).toBe('strict');
+  });
+
+  it('production is the strict baseline (every security knob hardened)', () => {
+    expect(ENVIRONMENT_PROFILES.production).toMatchObject({
+      environment: 'production',
+      staticApiKeysAllowed: false,
+      localhostRedirectAllowed: false,
+      pkceRequired: true,
+      accessTokenLifespanTier: 'short',
+      refreshRotationRequired: true,
+      rateLimitTier: 'strict',
+      openDynamicRegistration: false,
+      agentStepUpEnforced: true,
+      t3SecurityEnforced: true,
+    });
+  });
+
+  it('is frozen against mutation', () => {
+    expect(Object.isFrozen(ENVIRONMENT_PROFILES)).toBe(true);
+    expect(Object.isFrozen(ENVIRONMENT_PROFILES.development)).toBe(true);
+  });
+});
+
+describe('environment-policy — resolveEnvironmentPolicy (effective profile)', () => {
+  it('unset client + unset realm → production (default-deny / fail-safe)', () => {
+    expect(resolveEnvironmentPolicy({}, {}).environment).toBe('production');
+    expect(resolveEnvironmentPolicy(null, null).environment).toBe('production');
+    expect(resolveEnvironmentPolicy(undefined, undefined).environment).toBe('production');
+  });
+
+  it('realm ceiling caps a laxer client: realm=production forces client=development to production', () => {
+    const policy = resolveEnvironmentPolicy(
+      { environment: 'development' },
+      { maxEnvironmentLaxity: 'production' }
+    );
+    expect(policy).toBe(ENVIRONMENT_PROFILES.production);
+    expect(policy.environment).toBe('production');
+    expect(policy.staticApiKeysAllowed).toBe(false);
+  });
+
+  it('a development client under a development realm gets the development profile', () => {
+    const policy = resolveEnvironmentPolicy(
+      { environment: 'development' },
+      { maxEnvironmentLaxity: 'development' }
+    );
+    expect(policy).toBe(ENVIRONMENT_PROFILES.development);
+    expect(policy.staticApiKeysAllowed).toBe(true);
+  });
+
+  it('staging effective keeps strict security (client=staging, realm=staging)', () => {
+    const policy = resolveEnvironmentPolicy(
+      { environment: 'staging' },
+      { maxEnvironmentLaxity: 'staging' }
+    );
+    expect(policy.environment).toBe('staging');
+    expect(policy.pkceRequired).toBe(true);
+    expect(policy.t3SecurityEnforced).toBe(true);
+    expect(policy.staticApiKeysAllowed).toBe(false);
+  });
+
+  it('a staging realm caps a development client at staging (still strict security)', () => {
+    const policy = resolveEnvironmentPolicy(
+      { environment: 'development' },
+      { maxEnvironmentLaxity: 'staging' }
+    );
+    expect(policy.environment).toBe('staging');
+    expect(policy.staticApiKeysAllowed).toBe(false);
+    expect(policy.pkceRequired).toBe(true);
+  });
+
+  it('a stricter client is honoured even under a laxer realm ceiling', () => {
+    // Client self-declaring production while realm permits development:
+    // the STRICTER (production) wins — narrowing one's own privilege is safe.
+    const policy = resolveEnvironmentPolicy(
+      { environment: 'production' },
+      { maxEnvironmentLaxity: 'development' }
+    );
+    expect(policy.environment).toBe('production');
+  });
+
+  it('unknown / null values on either side fail safe to production', () => {
+    expect(
+      resolveEnvironmentPolicy({ environment: 'bogus' }, { maxEnvironmentLaxity: 'development' })
+        .environment
+    ).toBe('production');
+    expect(
+      resolveEnvironmentPolicy({ environment: 'development' }, { maxEnvironmentLaxity: 'nonsense' })
+        .environment
+    ).toBe('production');
+    expect(
+      resolveEnvironmentPolicy({ environment: null }, { maxEnvironmentLaxity: null }).environment
+    ).toBe('production');
+  });
+
+  it('returns a profile for every (client, realm) environment pairing', () => {
+    for (const clientEnv of ENVIRONMENTS) {
+      for (const realmEnv of ENVIRONMENTS) {
+        const policy = resolveEnvironmentPolicy(
+          { environment: clientEnv },
+          { maxEnvironmentLaxity: realmEnv }
+        );
+        const expected: Environment = stricterEnvironment(clientEnv, realmEnv);
+        expect(policy).toBe(ENVIRONMENT_PROFILES[expected]);
+      }
+    }
+  });
+});

--- a/apps/auth-server/src/app/helpers/environment-policy.ts
+++ b/apps/auth-server/src/app/helpers/environment-policy.ts
@@ -1,0 +1,244 @@
+/**
+ * Environment-aware authorization posture (ADR-008, issue #196).
+ *
+ * QAuth treats **environment** (`development` | `staging` | `production`) as a
+ * first-class, policy-profile dimension: one attribute that flips a coordinated
+ * bundle of security and operational defaults instead of N independent knobs.
+ *
+ * Two columns drive it:
+ *   - `oauth_clients.environment` — the client's DECLARED environment.
+ *   - `realms.max_environment_laxity` — a realm-level CEILING on how lax any
+ *     client in that realm may be.
+ *
+ * The **effective** environment is the STRICTER of the two (strictness order:
+ * `production` > `staging` > `development`). A realm pinned to `production`
+ * forces every client to the production profile regardless of its own field.
+ *
+ * FAIL-SAFE: both inputs default to `production`; an absent / unknown value on
+ * either side is treated as `production`. The relaxed posture is therefore
+ * opt-in and bounded, and misconfiguration fails closed.
+ *
+ * OPERATOR-SET: the relaxation direction is never self-asserted — it is set by
+ * an operator (seed/manifest, admin API, realm config), never by a client's own
+ * DCR request or CIMD metadata document. This mirrors the `max_agent_mode` /
+ * `dynamic_registration_allowed_scopes` precedent from ADR-007 §2.
+ *
+ * This module is the single resolver ADR-008 §7 calls for. Policy checkpoints —
+ * token issuance, the static-API-key gate, redirect-URI validation, DCR, agent
+ * step-up, T3 hardening (issues #197 / #97 / #98) — consult
+ * {@link resolveEnvironmentPolicy} rather than re-deriving rules, exactly as the
+ * `toAgentScopeContext` / `enforceAgentScopeCap` pattern centralises the agent
+ * scope-mode cap. It is intentionally PURE and depends on no DB row types: it
+ * accepts minimal structural inputs so it is trivial to import and unit-test.
+ */
+
+/** Canonical environments, ordered laxest → strictest. */
+export const ENVIRONMENTS = ['development', 'staging', 'production'] as const;
+
+export type Environment = (typeof ENVIRONMENTS)[number];
+
+/**
+ * Strictness rank: higher ⇒ stricter (more hardened). The effective
+ * environment is the MAX rank of the client value and the realm ceiling, so a
+ * realm at `production` always wins. Kept as an explicit map (not array index)
+ * so the ordering is intentional and survives reordering of {@link ENVIRONMENTS}.
+ */
+const ENVIRONMENT_STRICTNESS_RANK: Readonly<Record<Environment, number>> = {
+  development: 1,
+  staging: 2,
+  production: 3,
+} as const;
+
+/**
+ * Parse a value into a known {@link Environment}, or `production` for anything
+ * unrecognised. FAIL-SAFE: an unknown / empty / null / malformed value is NOT
+ * silently downgraded to a laxer profile — it resolves to the strictest
+ * (`production`), matching the NOT NULL `production` column defaults.
+ */
+export function parseEnvironment(value: string | null | undefined): Environment {
+  if (typeof value !== 'string') return 'production';
+  return (ENVIRONMENTS as readonly string[]).includes(value)
+    ? (value as Environment)
+    : 'production';
+}
+
+/**
+ * The STRICTER of two environments (ADR-008 §2). `production` beats `staging`
+ * beats `development`. Used to bound a client's declared environment by its
+ * realm's ceiling: `stricterEnvironment(clientEnv, realmCeiling)`.
+ *
+ * `stricterEnvironment('development', 'production')` → `'production'`
+ * `stricterEnvironment('development', 'staging')`    → `'staging'`
+ * `stricterEnvironment('development', 'development')`→ `'development'`
+ */
+export function stricterEnvironment(a: Environment, b: Environment): Environment {
+  return ENVIRONMENT_STRICTNESS_RANK[a] >= ENVIRONMENT_STRICTNESS_RANK[b] ? a : b;
+}
+
+/**
+ * Access-token lifespan tier (ADR-008 §5). Coarse, legible label rather than a
+ * concrete number of seconds — the token-issuance checkpoint (#197) maps a tier
+ * to its configured lifespan so the realm's `access_token_lifespan` and any
+ * per-environment override live in one place, not scattered across callers.
+ */
+export type AccessTokenLifespanTier = 'long' | 'short';
+
+/**
+ * Rate-limit tier (ADR-008 §5). `staging` keeps lenient limits for load
+ * testing, so it shares the `lenient` tier with `development`; `production` is
+ * `strict`. The rate-limit plugin maps a tier to concrete window/max values.
+ */
+export type RateLimitTier = 'lenient' | 'strict';
+
+/**
+ * The effective environment policy profile (ADR-008 §5). The resolved bundle of
+ * security and operational knobs a policy checkpoint consults. Every field is a
+ * resolved DEFAULT for the effective environment; an operator may later override
+ * an individual knob, but only WITHIN the realm ceiling and never below the hard
+ * security floors (client secrets are always hashed, audience binding always
+ * holds, etc.).
+ *
+ * Security-relevant relaxations apply to `development` ONLY. `staging` keeps
+ * production-grade security (`pkceRequired`, `refreshRotationRequired`,
+ * `agentStepUpEnforced`, `t3SecurityEnforced`, https-only redirects, no static
+ * keys) and relaxes only operational conveniences (rate limits, token lifespan).
+ */
+export interface EnvironmentPolicy {
+  /** The effective environment (stricter of client vs realm ceiling). */
+  readonly environment: Environment;
+  /**
+   * Static, long-lived developer API keys (#97/#98) may be issued/accepted.
+   * `development` only; `staging` and `production` use OAuth `client_credentials`.
+   */
+  readonly staticApiKeysAllowed: boolean;
+  /**
+   * `http://localhost` (loopback) redirect URIs are permitted. `development`
+   * only; `staging`/`production` are https-only. (Loopback exceptions for native
+   * apps per RFC 8252 are handled by redirect validation, not this flag.)
+   */
+  readonly localhostRedirectAllowed: boolean;
+  /**
+   * PKCE (`S256`) is REQUIRED. True for `staging`/`production`; in `development`
+   * it is recommended but not forced. Note QAuth's project-wide floor still sets
+   * `oauth_clients.require_pkce=true` by default — this only governs whether the
+   * environment profile additionally hard-requires it.
+   */
+  readonly pkceRequired: boolean;
+  /** Access-token lifespan tier: `long` in `development`, else `short`. */
+  readonly accessTokenLifespanTier: AccessTokenLifespanTier;
+  /** Refresh-token rotation is REQUIRED. True for `staging`/`production`. */
+  readonly refreshRotationRequired: boolean;
+  /** Rate-limit tier: `lenient` for `development`/`staging`, `strict` for `production`. */
+  readonly rateLimitTier: RateLimitTier;
+  /**
+   * Open dynamic client registration / CIMD. `development` is open; `staging`
+   * and `production` are gated. (This describes posture only — DCR security
+   * caps such as the realm scope allowlist always apply regardless.)
+   */
+  readonly openDynamicRegistration: boolean;
+  /** Agent step-up before dangerous ops is enforced. True for `staging`/`production`. */
+  readonly agentStepUpEnforced: boolean;
+  /**
+   * T3 hardening (security headers / CSRF / secure cookies, #108/#109/#113) is
+   * enforced. True for `staging`/`production`; relaxed in `development`.
+   */
+  readonly t3SecurityEnforced: boolean;
+}
+
+/**
+ * The static policy-profile table (ADR-008 §5), keyed by environment. Exported
+ * so downstream checkpoints (#197/#97/#98) can consume the per-environment
+ * defaults directly when they already know the effective environment, without
+ * re-running the resolver. Frozen to prevent accidental mutation of shared state.
+ *
+ * Security relaxations live in `development` ONLY; `staging` matches
+ * `production` on every security knob and differs only on operational
+ * conveniences (`rateLimitTier`, `accessTokenLifespanTier`).
+ */
+export const ENVIRONMENT_PROFILES: Readonly<Record<Environment, EnvironmentPolicy>> = Object.freeze(
+  {
+    development: Object.freeze({
+      environment: 'development',
+      staticApiKeysAllowed: true,
+      localhostRedirectAllowed: true,
+      pkceRequired: false,
+      accessTokenLifespanTier: 'long',
+      refreshRotationRequired: false,
+      rateLimitTier: 'lenient',
+      openDynamicRegistration: true,
+      agentStepUpEnforced: false,
+      t3SecurityEnforced: false,
+    }),
+    staging: Object.freeze({
+      environment: 'staging',
+      staticApiKeysAllowed: false,
+      localhostRedirectAllowed: false,
+      pkceRequired: true,
+      accessTokenLifespanTier: 'short',
+      refreshRotationRequired: true,
+      rateLimitTier: 'lenient',
+      openDynamicRegistration: false,
+      agentStepUpEnforced: true,
+      t3SecurityEnforced: true,
+    }),
+    production: Object.freeze({
+      environment: 'production',
+      staticApiKeysAllowed: false,
+      localhostRedirectAllowed: false,
+      pkceRequired: true,
+      accessTokenLifespanTier: 'short',
+      refreshRotationRequired: true,
+      rateLimitTier: 'strict',
+      openDynamicRegistration: false,
+      agentStepUpEnforced: true,
+      t3SecurityEnforced: true,
+    }),
+  } satisfies Record<Environment, EnvironmentPolicy>
+);
+
+/**
+ * Minimal structural view of a client for the resolver. Accepts a bare
+ * `{ environment }` rather than a full DB row so the resolver stays pure and
+ * easy to import/test. `environment` is optional and may arrive as a raw string
+ * from the DB column; {@link parseEnvironment} fails safe to `production` for
+ * any absent / unknown value.
+ */
+export interface EnvironmentClientLike {
+  environment?: Environment | string | null;
+}
+
+/**
+ * Minimal structural view of a realm for the resolver. `maxEnvironmentLaxity`
+ * is the realm-level ceiling; absent / unknown ⇒ `production` (fail-safe).
+ */
+export interface EnvironmentRealmLike {
+  maxEnvironmentLaxity?: Environment | string | null;
+}
+
+/**
+ * Resolve the effective {@link EnvironmentPolicy} for a client within its realm
+ * (ADR-008 §7). The single entry point every policy checkpoint should call.
+ *
+ * The effective environment is the STRICTER of the client's declared
+ * `environment` and the realm's `maxEnvironmentLaxity` ceiling, each parsed
+ * fail-safe to `production`. The returned profile is the corresponding frozen
+ * entry from {@link ENVIRONMENT_PROFILES}.
+ *
+ * Fail-safe behaviour:
+ *   - `resolveEnvironmentPolicy({}, {})` → production profile (both unset).
+ *   - `resolveEnvironmentPolicy({ environment: 'development' }, { maxEnvironmentLaxity: 'production' })`
+ *     → production profile (realm ceiling caps the laxer client).
+ *   - A `null`/unknown value on either side resolves to `production`.
+ *
+ * @param client A `{ environment }` view of the OAuth client (may be null/undefined).
+ * @param realm  A `{ maxEnvironmentLaxity }` view of the realm (may be null/undefined).
+ */
+export function resolveEnvironmentPolicy(
+  client: EnvironmentClientLike | null | undefined,
+  realm: EnvironmentRealmLike | null | undefined
+): EnvironmentPolicy {
+  const clientEnv = parseEnvironment(client?.environment ?? null);
+  const realmCeiling = parseEnvironment(realm?.maxEnvironmentLaxity ?? null);
+  const effective = stricterEnvironment(clientEnv, realmCeiling);
+  return ENVIRONMENT_PROFILES[effective];
+}

--- a/apps/auth-server/src/app/routes/oauth/register.test.ts
+++ b/apps/auth-server/src/app/routes/oauth/register.test.ts
@@ -348,6 +348,34 @@ describe('POST /oauth/register — Dynamic Client Registration (RFC 7591)', () =
     expect(state.createdClients[0].isAgent).toBe(false);
   });
 
+  it('ignores a self-asserted environment in the DCR body (ADR-008 §4 — operator-set only)', async () => {
+    const { fastify, ctx, state } = createFastifyStub();
+    await registerRoute(fastify);
+
+    const { reply } = createReply();
+    const result = (await ctx.handler!(
+      {
+        body: {
+          client_name: 'Sneaky Client',
+          redirect_uris: ['https://app.example/cb'],
+          grant_types: ['authorization_code', 'refresh_token'],
+          response_types: ['code'],
+          // A client cannot relax itself by self-declaring development:
+          // the field is stripped by the schema AND the route forces
+          // production. The client must NOT escape production gates.
+          environment: 'development',
+        },
+        ip: '127.0.0.1',
+        headers: {},
+      },
+      reply
+    )) as Record<string, unknown>;
+
+    // Never echoed back, and never persisted as the self-asserted value.
+    expect('environment' in result).toBe(false);
+    expect(state.createdClients[0].environment).toBe('production');
+  });
+
   it('seeds the realm default allowlist on first use when empty', async () => {
     const { fastify, ctx, state } = createFastifyStub({
       dynamicRegistrationAllowedScopes: [],

--- a/apps/auth-server/src/app/routes/oauth/register.ts
+++ b/apps/auth-server/src/app/routes/oauth/register.ts
@@ -130,6 +130,16 @@ export default async function (fastify: FastifyInstance) {
         // ADR-007 §2: first-class agent classification. Defaults to false
         // (standard client); nothing is gated on it yet.
         isAgent: normalized.isAgent,
+        // ADR-008 §4 (#196): `environment` is OPERATOR-SET, never self-asserted.
+        // We deliberately do NOT pass it here, so a self-declared
+        // `environment: development` in the DCR body cannot relax the client —
+        // the column keeps its `production` default (the strictest profile),
+        // exactly as `maxAgentMode` is omitted from self-registration. The DCR
+        // request schema strips unknown fields, so an `environment` key never
+        // reaches this handler in the first place; omitting it from the insert
+        // is the defence-in-depth that keeps that guarantee true even if the
+        // schema changes.
+        environment: 'production',
         // Stamp the dyn-reg timestamp so the consent screen (issue #150)
         // can surface the "Newly registered" phishing-defense badge
         // within DYNAMIC_CLIENT_BADGE_DAYS of registration.

--- a/libs/infra/db/drizzle/0007_thankful_nova.sql
+++ b/libs/infra/db/drizzle/0007_thankful_nova.sql
@@ -1,0 +1,3 @@
+CREATE TYPE "public"."environment" AS ENUM('development', 'staging', 'production');--> statement-breakpoint
+ALTER TABLE "oauth_clients" ADD COLUMN "environment" "environment" DEFAULT 'production' NOT NULL;--> statement-breakpoint
+ALTER TABLE "realms" ADD COLUMN "max_environment_laxity" "environment" DEFAULT 'production' NOT NULL;

--- a/libs/infra/db/drizzle/meta/0007_snapshot.json
+++ b/libs/infra/db/drizzle/meta/0007_snapshot.json
@@ -1,0 +1,2207 @@
+{
+  "id": "52b5cc07-b2ca-412e-96f4-01b58d609800",
+  "prevId": "0b64f09c-13ff-480f-8c51-cb7a0aa33807",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_client_id": {
+          "name": "oauth_client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event": {
+          "name": "event",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "audit_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_client_id": {
+          "name": "actor_client_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delegation_chain": {
+          "name": "delegation_chain",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope_mode": {
+          "name": "scope_mode",
+          "type": "agent_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(EXTRACT(EPOCH FROM NOW())::bigint * 1000)"
+        }
+      },
+      "indexes": {
+        "idx_audit_logs_user_id": {
+          "name": "idx_audit_logs_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_logs_oauth_client_id": {
+          "name": "idx_audit_logs_oauth_client_id",
+          "columns": [
+            {
+              "expression": "oauth_client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_logs_event_type": {
+          "name": "idx_audit_logs_event_type",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_logs_event": {
+          "name": "idx_audit_logs_event",
+          "columns": [
+            {
+              "expression": "event",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_logs_created_at": {
+          "name": "idx_audit_logs_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_logs_user_event": {
+          "name": "idx_audit_logs_user_event",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_logs_failed": {
+          "name": "idx_audit_logs_failed",
+          "columns": [
+            {
+              "expression": "event",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"audit_logs\".\"success\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_logs_ip_address": {
+          "name": "idx_audit_logs_ip_address",
+          "columns": [
+            {
+              "expression": "ip_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_logs_actor_client_id": {
+          "name": "idx_audit_logs_actor_client_id",
+          "columns": [
+            {
+              "expression": "actor_client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"audit_logs\".\"actor_client_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_logs_user_id_users_id_fk": {
+          "name": "audit_logs_user_id_users_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "audit_logs_oauth_client_id_oauth_clients_id_fk": {
+          "name": "audit_logs_oauth_client_id_oauth_clients_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "oauth_clients",
+          "columnsFrom": ["oauth_client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "audit_logs_delegation_chain_is_array": {
+          "name": "audit_logs_delegation_chain_is_array",
+          "value": "\"audit_logs\".\"delegation_chain\" IS NULL OR jsonb_typeof(\"audit_logs\".\"delegation_chain\") = 'array'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.oauth_consents": {
+      "name": "oauth_consents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oauth_client_id": {
+          "name": "oauth_client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "realm_id": {
+          "name": "realm_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(EXTRACT(EPOCH FROM NOW())::bigint * 1000)"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_oauth_consents_user_client_active": {
+          "name": "idx_oauth_consents_user_client_active",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "oauth_client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"oauth_consents\".\"revoked_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_oauth_consents_user_id": {
+          "name": "idx_oauth_consents_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_oauth_consents_client_id": {
+          "name": "idx_oauth_consents_client_id",
+          "columns": [
+            {
+              "expression": "oauth_client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_oauth_consents_realm_id": {
+          "name": "idx_oauth_consents_realm_id",
+          "columns": [
+            {
+              "expression": "realm_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_consents_user_id_users_id_fk": {
+          "name": "oauth_consents_user_id_users_id_fk",
+          "tableFrom": "oauth_consents",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_consents_oauth_client_id_oauth_clients_id_fk": {
+          "name": "oauth_consents_oauth_client_id_oauth_clients_id_fk",
+          "tableFrom": "oauth_consents",
+          "tableTo": "oauth_clients",
+          "columnsFrom": ["oauth_client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_consents_realm_id_realms_id_fk": {
+          "name": "oauth_consents_realm_id_realms_id_fk",
+          "tableFrom": "oauth_consents",
+          "tableTo": "realms",
+          "columnsFrom": ["realm_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_clients": {
+      "name": "oauth_clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "realm_id": {
+          "name": "realm_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret_hash": {
+          "name": "client_secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "audience": {
+          "name": "audience",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "require_pkce": {
+          "name": "require_pkce",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "token_endpoint_auth_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'client_secret_post'"
+        },
+        "grant_types": {
+          "name": "grant_types",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[\"authorization_code\",\"refresh_token\"]'::jsonb"
+        },
+        "response_types": {
+          "name": "response_types",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[\"code\"]'::jsonb"
+        },
+        "developer_id": {
+          "name": "developer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_agent": {
+          "name": "is_agent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "max_agent_mode": {
+          "name": "max_agent_mode",
+          "type": "agent_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "environment",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'production'"
+        },
+        "dynamic_registered_at": {
+          "name": "dynamic_registered_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(EXTRACT(EPOCH FROM NOW())::bigint * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(EXTRACT(EPOCH FROM NOW())::bigint * 1000)"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_oauth_clients_realm_client_id_unique": {
+          "name": "idx_oauth_clients_realm_client_id_unique",
+          "columns": [
+            {
+              "expression": "realm_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_oauth_clients_client_id": {
+          "name": "idx_oauth_clients_client_id",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_oauth_clients_realm_id": {
+          "name": "idx_oauth_clients_realm_id",
+          "columns": [
+            {
+              "expression": "realm_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_oauth_clients_developer_id": {
+          "name": "idx_oauth_clients_developer_id",
+          "columns": [
+            {
+              "expression": "developer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_oauth_clients_enabled": {
+          "name": "idx_oauth_clients_enabled",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"oauth_clients\".\"enabled\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_oauth_clients_realm_client_id_enabled": {
+          "name": "idx_oauth_clients_realm_client_id_enabled",
+          "columns": [
+            {
+              "expression": "realm_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_clients_realm_id_realms_id_fk": {
+          "name": "oauth_clients_realm_id_realms_id_fk",
+          "tableFrom": "oauth_clients",
+          "tableTo": "realms",
+          "columnsFrom": ["realm_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_clients_developer_id_users_id_fk": {
+          "name": "oauth_clients_developer_id_users_id_fk",
+          "tableFrom": "oauth_clients",
+          "tableTo": "users",
+          "columnsFrom": ["developer_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "oauth_clients_audience_is_array": {
+          "name": "oauth_clients_audience_is_array",
+          "value": "\"oauth_clients\".\"audience\" IS NULL OR jsonb_typeof(\"oauth_clients\".\"audience\") = 'array'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.realms": {
+      "name": "realms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "access_token_lifespan": {
+          "name": "access_token_lifespan",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 900
+        },
+        "refresh_token_lifespan": {
+          "name": "refresh_token_lifespan",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 604800
+        },
+        "ssl_required": {
+          "name": "ssl_required",
+          "type": "ssl_required",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'external'"
+        },
+        "verify_email": {
+          "name": "verify_email",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "registration_allowed": {
+          "name": "registration_allowed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "login_with_email_allowed": {
+          "name": "login_with_email_allowed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "duplicate_emails_allowed": {
+          "name": "duplicate_emails_allowed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "password_policy": {
+          "name": "password_policy",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sso_idle_timeout": {
+          "name": "sso_idle_timeout",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sso_max_lifespan": {
+          "name": "sso_max_lifespan",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoke_refresh_token": {
+          "name": "revoke_refresh_token",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "refresh_token_max_reuse": {
+          "name": "refresh_token_max_reuse",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "default_locale": {
+          "name": "default_locale",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supported_locales": {
+          "name": "supported_locales",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "dynamic_registration_allowed_scopes": {
+          "name": "dynamic_registration_allowed_scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "max_environment_laxity": {
+          "name": "max_environment_laxity",
+          "type": "environment",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'production'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(EXTRACT(EPOCH FROM NOW())::bigint * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(EXTRACT(EPOCH FROM NOW())::bigint * 1000)"
+        }
+      },
+      "indexes": {
+        "idx_realms_enabled": {
+          "name": "idx_realms_enabled",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"realms\".\"enabled\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "realms_name_unique": {
+          "name": "realms_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "realm_id": {
+          "name": "realm_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_normalized": {
+          "name": "email_normalized",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(EXTRACT(EPOCH FROM NOW())::bigint * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(EXTRACT(EPOCH FROM NOW())::bigint * 1000)"
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_users_realm_email_normalized_unique": {
+          "name": "idx_users_realm_email_normalized_unique",
+          "columns": [
+            {
+              "expression": "realm_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email_normalized",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_email": {
+          "name": "idx_users_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_realm_id": {
+          "name": "idx_users_realm_id",
+          "columns": [
+            {
+              "expression": "realm_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_enabled": {
+          "name": "idx_users_enabled",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"users\".\"enabled\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_realm_email_enabled": {
+          "name": "idx_users_realm_email_enabled",
+          "columns": [
+            {
+              "expression": "realm_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email_normalized",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_realm_id_realms_id_fk": {
+          "name": "users_realm_id_realms_id_fk",
+          "tableFrom": "users",
+          "tableTo": "realms",
+          "columnsFrom": ["realm_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roles": {
+      "name": "roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "realm_id": {
+          "name": "realm_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_client_id": {
+          "name": "oauth_client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(EXTRACT(EPOCH FROM NOW())::bigint * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(EXTRACT(EPOCH FROM NOW())::bigint * 1000)"
+        }
+      },
+      "indexes": {
+        "idx_roles_realm_name_unique": {
+          "name": "idx_roles_realm_name_unique",
+          "columns": [
+            {
+              "expression": "realm_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "oauth_client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_roles_name": {
+          "name": "idx_roles_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_roles_realm_id": {
+          "name": "idx_roles_realm_id",
+          "columns": [
+            {
+              "expression": "realm_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_roles_oauth_client_id": {
+          "name": "idx_roles_oauth_client_id",
+          "columns": [
+            {
+              "expression": "oauth_client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "roles_realm_id_realms_id_fk": {
+          "name": "roles_realm_id_realms_id_fk",
+          "tableFrom": "roles",
+          "tableTo": "realms",
+          "columnsFrom": ["realm_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "roles_oauth_client_id_oauth_clients_id_fk": {
+          "name": "roles_oauth_client_id_oauth_clients_id_fk",
+          "tableFrom": "roles",
+          "tableTo": "oauth_clients",
+          "columnsFrom": ["oauth_client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_roles": {
+      "name": "user_roles",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigned_at": {
+          "name": "assigned_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(EXTRACT(EPOCH FROM NOW())::bigint * 1000)"
+        },
+        "assigned_by": {
+          "name": "assigned_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_user_roles_user_id": {
+          "name": "idx_user_roles_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_roles_role_id": {
+          "name": "idx_user_roles_role_id",
+          "columns": [
+            {
+              "expression": "role_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_roles_user_id_users_id_fk": {
+          "name": "user_roles_user_id_users_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_roles_role_id_roles_id_fk": {
+          "name": "user_roles_role_id_roles_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "roles",
+          "columnsFrom": ["role_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_roles_assigned_by_users_id_fk": {
+          "name": "user_roles_assigned_by_users_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "users",
+          "columnsFrom": ["assigned_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_roles_pk": {
+          "name": "user_roles_pk",
+          "columns": ["user_id", "role_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oauth_client_id": {
+          "name": "oauth_client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_hash": {
+          "name": "access_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_hash": {
+          "name": "refresh_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(EXTRACT(EPOCH FROM NOW())::bigint * 1000)"
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(EXTRACT(EPOCH FROM NOW())::bigint * 1000)"
+        }
+      },
+      "indexes": {
+        "idx_sessions_user_id": {
+          "name": "idx_sessions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sessions_active": {
+          "name": "idx_sessions_active",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"sessions\".\"revoked\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sessions_expires_at": {
+          "name": "idx_sessions_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sessions_access_token_hash": {
+          "name": "idx_sessions_access_token_hash",
+          "columns": [
+            {
+              "expression": "access_token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sessions_oauth_client_id": {
+          "name": "idx_sessions_oauth_client_id",
+          "columns": [
+            {
+              "expression": "oauth_client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sessions_oauth_client_id_oauth_clients_id_fk": {
+          "name": "sessions_oauth_client_id_oauth_clients_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "oauth_clients",
+          "columnsFrom": ["oauth_client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.authorization_codes": {
+      "name": "authorization_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oauth_client_id": {
+          "name": "oauth_client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge": {
+          "name": "code_challenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge_method": {
+          "name": "code_challenge_method",
+          "type": "code_challenge_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'S256'"
+        },
+        "nonce": {
+          "name": "nonce",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "resource": {
+          "name": "resource",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used": {
+          "name": "used",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(EXTRACT(EPOCH FROM NOW())::bigint * 1000)"
+        }
+      },
+      "indexes": {
+        "idx_authorization_codes_active": {
+          "name": "idx_authorization_codes_active",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"authorization_codes\".\"used\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_authorization_codes_expires_at": {
+          "name": "idx_authorization_codes_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_authorization_codes_user_id": {
+          "name": "idx_authorization_codes_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_authorization_codes_oauth_client_id": {
+          "name": "idx_authorization_codes_oauth_client_id",
+          "columns": [
+            {
+              "expression": "oauth_client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "authorization_codes_oauth_client_id_oauth_clients_id_fk": {
+          "name": "authorization_codes_oauth_client_id_oauth_clients_id_fk",
+          "tableFrom": "authorization_codes",
+          "tableTo": "oauth_clients",
+          "columnsFrom": ["oauth_client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "authorization_codes_user_id_users_id_fk": {
+          "name": "authorization_codes_user_id_users_id_fk",
+          "tableFrom": "authorization_codes",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "authorization_codes_code_unique": {
+          "name": "authorization_codes_code_unique",
+          "nullsNotDistinct": false,
+          "columns": ["code"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_verification_tokens": {
+      "name": "email_verification_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used": {
+          "name": "used",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(EXTRACT(EPOCH FROM NOW())::bigint * 1000)"
+        }
+      },
+      "indexes": {
+        "idx_email_verification_tokens_user_id": {
+          "name": "idx_email_verification_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_email_verification_tokens_active": {
+          "name": "idx_email_verification_tokens_active",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"email_verification_tokens\".\"used\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_email_verification_tokens_expires_at": {
+          "name": "idx_email_verification_tokens_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_verification_tokens_user_id_users_id_fk": {
+          "name": "email_verification_tokens_user_id_users_id_fk",
+          "tableFrom": "email_verification_tokens",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "email_verification_tokens_token_hash_unique": {
+          "name": "email_verification_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.refresh_tokens": {
+      "name": "refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oauth_client_id": {
+          "name": "oauth_client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "family_id": {
+          "name": "family_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "resource": {
+          "name": "resource",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_reason": {
+          "name": "revoked_reason",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_token_hash": {
+          "name": "previous_token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(EXTRACT(EPOCH FROM NOW())::bigint * 1000)"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_refresh_tokens_active": {
+          "name": "idx_refresh_tokens_active",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"refresh_tokens\".\"revoked\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_refresh_tokens_expires_at": {
+          "name": "idx_refresh_tokens_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_refresh_tokens_user_id": {
+          "name": "idx_refresh_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_refresh_tokens_oauth_client_id": {
+          "name": "idx_refresh_tokens_oauth_client_id",
+          "columns": [
+            {
+              "expression": "oauth_client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_refresh_tokens_user_active": {
+          "name": "idx_refresh_tokens_user_active",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"refresh_tokens\".\"revoked\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_refresh_tokens_family_id": {
+          "name": "idx_refresh_tokens_family_id",
+          "columns": [
+            {
+              "expression": "family_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "refresh_tokens_user_id_users_id_fk": {
+          "name": "refresh_tokens_user_id_users_id_fk",
+          "tableFrom": "refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "refresh_tokens_oauth_client_id_oauth_clients_id_fk": {
+          "name": "refresh_tokens_oauth_client_id_oauth_clients_id_fk",
+          "tableFrom": "refresh_tokens",
+          "tableTo": "oauth_clients",
+          "columnsFrom": ["oauth_client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "refresh_tokens_token_hash_unique": {
+          "name": "refresh_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.agent_mode": {
+      "name": "agent_mode",
+      "schema": "public",
+      "values": ["readonly", "admin", "exec"]
+    },
+    "public.audit_event_type": {
+      "name": "audit_event_type",
+      "schema": "public",
+      "values": ["auth", "token", "client", "security", "user", "realm", "agent"]
+    },
+    "public.code_challenge_method": {
+      "name": "code_challenge_method",
+      "schema": "public",
+      "values": ["S256"]
+    },
+    "public.environment": {
+      "name": "environment",
+      "schema": "public",
+      "values": ["development", "staging", "production"]
+    },
+    "public.grant_type": {
+      "name": "grant_type",
+      "schema": "public",
+      "values": ["authorization_code", "refresh_token", "client_credentials"]
+    },
+    "public.response_type": {
+      "name": "response_type",
+      "schema": "public",
+      "values": ["code"]
+    },
+    "public.ssl_required": {
+      "name": "ssl_required",
+      "schema": "public",
+      "values": ["none", "external", "all"]
+    },
+    "public.token_endpoint_auth_method": {
+      "name": "token_endpoint_auth_method",
+      "schema": "public",
+      "values": ["client_secret_post", "client_secret_basic", "private_key_jwt", "none"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/libs/infra/db/drizzle/meta/_journal.json
+++ b/libs/infra/db/drizzle/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1782388437344,
       "tag": "0006_open_wolfsbane",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1782449651385,
+      "tag": "0007_thankful_nova",
+      "breakpoints": true
     }
   ]
 }

--- a/libs/infra/db/src/lib/schema/core.ts
+++ b/libs/infra/db/src/lib/schema/core.ts
@@ -14,6 +14,7 @@ import {
 
 import {
   agentModeEnum,
+  environmentEnum,
   GrantType,
   ResponseType,
   sslRequiredEnum,
@@ -69,6 +70,27 @@ export const realms = pgTable(
       .notNull()
       .default(JSONB_EMPTY_ARRAY)
       .$type<string[]>(),
+    /**
+     * Realm-level CEILING on how lax any client in this realm may be
+     * (ADR-008 §2, issue #196). A client's effective environment is the
+     * STRICTER of its own `oauth_clients.environment` and this ceiling, so a
+     * realm set to `production` forces every client to the production profile
+     * regardless of the client's own field — the ceiling can never be exceeded.
+     * This mirrors `dynamic_registration_allowed_scopes` as a realm-level hard
+     * cap on what a client may obtain.
+     *
+     * FAIL-SAFE DEFAULT: `production`. A fresh realm caps everything at the
+     * strictest profile until an operator deliberately widens it, so an
+     * unconfigured deployment is hardened and misconfiguration fails closed.
+     *
+     * OPERATOR-SET ONLY: the relaxation direction is set via seed/manifest,
+     * admin API, or realm config — never self-asserted by a client. The single
+     * resolver `resolveEnvironmentPolicy(client, realm)` consumes this value;
+     * policy checkpoints (#197/#97/#98) consult the resolver, not this column
+     * directly. Defaulting NOT NULL keeps the migration backward-compatible:
+     * every existing realm becomes `production` (the prior, strict behaviour).
+     */
+    maxEnvironmentLaxity: environmentEnum('max_environment_laxity').notNull().default('production'),
     metadata: jsonb('metadata').$type<Record<string, unknown> | null>(),
     createdAt: bigint('created_at', { mode: 'number' }).notNull().default(EPOCH_MS_NOW),
     updatedAt: bigint('updated_at', { mode: 'number' }).notNull().default(EPOCH_MS_NOW),
@@ -183,6 +205,33 @@ export const oauthClients = pgTable(
      * cap because this column is not part of the registration request.
      */
     maxAgentMode: agentModeEnum('max_agent_mode'),
+    /**
+     * The client's declared deployment environment / policy profile
+     * (ADR-008 §2, issue #196). Selects a coordinated bundle of security and
+     * operational defaults (static API keys, localhost redirects, PKCE, token
+     * lifespans, refresh rotation, rate limits, open DCR, agent step-up, T3
+     * headers — see ADR-008 §5) instead of a dozen independent switches.
+     *
+     * This is only the client's REQUESTED laxity; the effective profile is the
+     * STRICTER of this value and the realm's `max_environment_laxity` ceiling,
+     * computed by `resolveEnvironmentPolicy(client, realm)`. A realm pinned to
+     * `production` overrides a client that asks for `development`.
+     *
+     * FAIL-SAFE DEFAULT: `production`. An unconfigured client gets the strictest
+     * profile, never the laxest — the relaxed posture is opt-in and bounded, the
+     * default everywhere is the hardened one. NOT NULL keeps the migration
+     * backward-compatible: every existing row becomes `production`.
+     *
+     * OPERATOR-SET, NOT SELF-ASSERTED. Unlike `is_agent` (self-asserted client
+     * input), the relaxation direction here is set ONLY by an operator —
+     * seed/manifest, admin API, or realm config. It is NOT accepted from
+     * `POST /oauth/register` (DCR) or a CIMD metadata document: a client cannot
+     * declare itself `development` to escape production gates, exactly as a
+     * client cannot self-grant `max_agent_mode`. New clients created via
+     * DCR/CIMD therefore always get this column's `production` default. Mirror
+     * this guarantee at every future write path that persists a client.
+     */
+    environment: environmentEnum('environment').notNull().default('production'),
     /**
      * Set when the client was created via dynamic client registration (RFC 7591).
      * Null for hand-provisioned / first-party clients. Consumed by the consent

--- a/libs/infra/db/src/lib/schema/enums.ts
+++ b/libs/infra/db/src/lib/schema/enums.ts
@@ -92,6 +92,39 @@ export const agentModeEnum = pgEnum('agent_mode', AGENT_MODES);
 export type AgentMode = (typeof AGENT_MODES)[number];
 
 /**
+ * Deployment environment / policy profile (ADR-008, issue #196).
+ *
+ * Selects an environment-aware **policy profile** — a coordinated bundle of
+ * security and operational defaults — rather than N independent knobs. Ordered
+ * here laxest → strictest (`development` < `staging` < `production`); the
+ * effective profile for a client is always the STRICTER of the client's own
+ * value and its realm ceiling (see `resolveEnvironmentPolicy`).
+ *
+ * - `development` — relaxes security-relevant conveniences (static API keys,
+ *   localhost redirects, long token lifespans, lenient rate limits, open DCR,
+ *   relaxed agent step-up / T3 headers). Local work only.
+ * - `staging` — keeps PRODUCTION-GRADE security; relaxes only operational
+ *   conveniences (e.g. lenient rate limits for load testing). Promoting
+ *   dev→staging surfaces security posture before production.
+ * - `production` — the strict baseline and the T3 hardening bundle. This is the
+ *   FAIL-SAFE default everywhere: an unset client or realm value resolves to
+ *   `production`, so misconfiguration fails closed.
+ *
+ * The relaxation direction is OPERATOR-SET only — never self-asserted via DCR
+ * (`POST /oauth/register`) or a CIMD metadata document — mirroring how
+ * `max_agent_mode` and `dynamic_registration_allowed_scopes` are handled.
+ */
+const ENVIRONMENTS = [
+  'development', // laxest — local convenience, security relaxations apply here only
+  'staging', // production-grade security; operational conveniences relaxed
+  'production', // strictest — fail-safe default; the T3 hardening bundle
+] as const;
+
+export const environmentEnum = pgEnum('environment', ENVIRONMENTS);
+
+export type Environment = (typeof ENVIRONMENTS)[number];
+
+/**
  * Audit Log Event Types
  * Categorizes audit events for filtering and analysis
  */


### PR DESCRIPTION
## Summary

Foundation for ADR-008 (environment-aware authorization posture). Introduces `environment` (`development` | `staging` | `production`) as a first-class **policy-profile** dimension — one attribute that flips a coordinated bundle of security/operational defaults instead of a dozen independent switches.

This is the **critical-path foundation** (#196) that #197 / #97 / #98 build on. It delivers the schema, the resolver, and the operator-only write-path guarantees **only** — no policy is wired into a checkpoint yet.

## What's included

- **Enum + schema + migration** (`0007_thankful_nova`): `oauth_clients.environment` (NOT NULL, default `production`) + `realms.max_environment_laxity` (realm-level laxity ceiling, NOT NULL, default `production`). Backward-compatible — existing rows backfill to `production`.
- **Resolver** — `helpers/environment-policy.ts` exposes `resolveEnvironmentPolicy(client, realm)`, the `EnvironmentPolicy` type, and the static `ENVIRONMENT_PROFILES` table (ADR-008 §5). Effective env = the **stricter** of client vs realm ceiling; both fail safe to `production`.
- **Operator-only writes** — DCR (`/oauth/register`) and CIMD never accept a self-asserted `environment`; new clients default to `production`. Mirrors `max_agent_mode`.

## Fail-safe / security properties

- Unset client **or** realm ⇒ `production` (default-deny; misconfiguration fails closed).
- A realm pinned to `production` forces every client to the production profile.
- Security relaxations apply to `development` **only**; `staging` keeps production-grade security.
- `environment` is operator-set, never self-asserted.

## Testing
- `nx test auth-server` — 456 tests (19 new resolver + DCR self-assertion-ignored test).
- `nx lint auth-server`, `nx build auth-server`, `nx lint/typecheck infra-db` — green.

Closes #196

https://claude.ai/code/session_01SGm2UmswGGEXHyvuw57ubh
