### PR TITLE
feat(oauth): wire production environment profile as the T3 hardening bundle (ADR-008)

### DIFF
--- a/apps/auth-server/src/app/helpers/client-auth.ts
+++ b/apps/auth-server/src/app/helpers/client-auth.ts
@@ -48,6 +48,15 @@ export type OAuthClientLike = {
    * criterion that, together with `isAgent`, gates agent-mode scopes.
    */
   maxAgentMode?: AgentMode | null;
+  /**
+   * ADR-008 §2 (#196/#197) the client's declared environment / policy profile.
+   * Optional + may arrive as a raw string from the DB column; the policy
+   * resolver fails safe to `production` for any absent / unknown value, so an
+   * older caller that omits it is treated as production (the hardened default).
+   * Consumed via `resolveEnvironmentPolicy(client, realm)` at the token-issuance
+   * checkpoint — never re-derived inline. OPERATOR-SET, never self-asserted.
+   */
+  environment?: string | null;
 };
 
 /**

--- a/apps/auth-server/src/app/helpers/client-resolution.ts
+++ b/apps/auth-server/src/app/helpers/client-resolution.ts
@@ -59,6 +59,16 @@ export interface ResolvedClient {
    * bound the reserved `agent:*` scopes the client may request.
    */
   maxAgentMode: AgentMode | null;
+  /**
+   * ADR-008 §2 (#196/#197) the client's declared environment / policy profile.
+   * Surfaced here so the authorize / token / consent handlers that already
+   * consume the resolved client can resolve the effective environment policy
+   * via `resolveEnvironmentPolicy(client, realm)` without a second DB read.
+   * OPERATOR-SET, never self-asserted; the resolver fails safe to `production`
+   * for any absent / unknown value. Persisted rows and CIMD-materialised rows
+   * both carry the NOT NULL `production`-default column.
+   */
+  environment: string;
   metadata: Record<string, unknown> | null;
 }
 

--- a/apps/auth-server/src/app/helpers/environment-policy.test.ts
+++ b/apps/auth-server/src/app/helpers/environment-policy.test.ts
@@ -5,7 +5,9 @@ import {
   ENVIRONMENT_PROFILES,
   ENVIRONMENTS,
   parseEnvironment,
+  resolveAccessTokenLifespanSeconds,
   resolveEnvironmentPolicy,
+  resolveRateLimitMax,
   stricterEnvironment,
 } from './environment-policy';
 
@@ -178,5 +180,131 @@ describe('environment-policy — resolveEnvironmentPolicy (effective profile)', 
         expect(policy).toBe(ENVIRONMENT_PROFILES[expected]);
       }
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tier → concrete-value mappers (ADR-008 §5, #197). These are the single place
+// a tier label is turned into a number; checkpoints call them rather than
+// re-deriving `dev ? x : y`.
+// ---------------------------------------------------------------------------
+
+describe('environment-policy — resolveAccessTokenLifespanSeconds (#197)', () => {
+  const config = { shortSeconds: 900, longSeconds: 28800 };
+
+  it('maps the short tier (staging/production) to the baseline lifespan', () => {
+    expect(resolveAccessTokenLifespanSeconds('short', config)).toBe(900);
+  });
+
+  it('maps the long tier (development) to the dev-convenience lifespan', () => {
+    expect(resolveAccessTokenLifespanSeconds('long', config)).toBe(28800);
+  });
+
+  it('a production-effective policy always resolves the short baseline', () => {
+    const policy = resolveEnvironmentPolicy(
+      { environment: 'development' },
+      { maxEnvironmentLaxity: 'production' }
+    );
+    expect(resolveAccessTokenLifespanSeconds(policy.accessTokenLifespanTier, config)).toBe(900);
+  });
+
+  it('only a development-effective policy gets the longer lifespan', () => {
+    const dev = resolveEnvironmentPolicy(
+      { environment: 'development' },
+      { maxEnvironmentLaxity: 'development' }
+    );
+    const staging = resolveEnvironmentPolicy(
+      { environment: 'staging' },
+      { maxEnvironmentLaxity: 'staging' }
+    );
+    expect(resolveAccessTokenLifespanSeconds(dev.accessTokenLifespanTier, config)).toBe(28800);
+    expect(resolveAccessTokenLifespanSeconds(staging.accessTokenLifespanTier, config)).toBe(900);
+  });
+});
+
+describe('environment-policy — resolveRateLimitMax (#197)', () => {
+  const config = { lenientMax: 600, strictMax: 60 };
+
+  it('maps the strict tier (production) to the tight cap', () => {
+    expect(resolveRateLimitMax('strict', config)).toBe(60);
+  });
+
+  it('maps the lenient tier (development/staging) to the relaxed cap', () => {
+    expect(resolveRateLimitMax('lenient', config)).toBe(600);
+  });
+
+  it('a production realm forces the strict cap even for a development client', () => {
+    const policy = resolveEnvironmentPolicy(
+      { environment: 'development' },
+      { maxEnvironmentLaxity: 'production' }
+    );
+    expect(resolveRateLimitMax(policy.rateLimitTier, config)).toBe(60);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// HARD FLOORS (ADR-008 §5, #197): the resolver must NEVER relax these, in any
+// environment. The profile carries no field that could turn them off; this test
+// pins that contract so a future profile-table edit cannot smuggle one in.
+// ---------------------------------------------------------------------------
+
+describe('environment-policy — hard floors never relax (#197)', () => {
+  it('development relaxes ONLY the ADR-sanctioned knobs; no security floor is exposed', () => {
+    const dev = ENVIRONMENT_PROFILES.development;
+
+    // The exhaustive set of fields the profile is ALLOWED to carry. If a new
+    // field is added it must be listed here deliberately — a floor (hashed
+    // secrets, audience binding, signature/issuer validation, confidential-only
+    // grants) must NEVER become a profile knob, so it must never appear.
+    expect(Object.keys(dev).sort()).toEqual(
+      [
+        'accessTokenLifespanTier',
+        'agentStepUpEnforced',
+        'environment',
+        'localhostRedirectAllowed',
+        'openDynamicRegistration',
+        'pkceRequired',
+        'rateLimitTier',
+        'refreshRotationRequired',
+        'staticApiKeysAllowed',
+        't3SecurityEnforced',
+      ].sort()
+    );
+
+    // No floor-shaped key exists on ANY profile (a resolver can't disable them).
+    for (const env of ENVIRONMENTS) {
+      const keys = Object.keys(ENVIRONMENT_PROFILES[env]);
+      for (const forbidden of [
+        'hashClientSecret',
+        'audienceBindingEnforced',
+        'verifyTokenSignature',
+        'verifyIssuer',
+        'allowPublicConfidentialGrants',
+      ]) {
+        expect(keys).not.toContain(forbidden);
+      }
+    }
+  });
+
+  it('the difference between development and production is EXACTLY the sanctioned knobs', () => {
+    const dev = ENVIRONMENT_PROFILES.development;
+    const prod = ENVIRONMENT_PROFILES.production;
+    const differing = (Object.keys(prod) as (keyof typeof prod)[]).filter(
+      (k) => k !== 'environment' && dev[k] !== prod[k]
+    );
+    // Every relaxation development makes is one of these eight ADR-008 §5 rows.
+    expect(differing.sort()).toEqual(
+      [
+        'accessTokenLifespanTier',
+        'agentStepUpEnforced',
+        'localhostRedirectAllowed',
+        'openDynamicRegistration',
+        'pkceRequired',
+        'rateLimitTier',
+        'refreshRotationRequired',
+        'staticApiKeysAllowed',
+        't3SecurityEnforced',
+      ].sort()
+    );
   });
 });

--- a/apps/auth-server/src/app/helpers/environment-policy.ts
+++ b/apps/auth-server/src/app/helpers/environment-policy.ts
@@ -242,3 +242,66 @@ export function resolveEnvironmentPolicy(
   const effective = stricterEnvironment(clientEnv, realmCeiling);
   return ENVIRONMENT_PROFILES[effective];
 }
+
+// ---------------------------------------------------------------------------
+// Tier → concrete-value mappers (ADR-008 §5, issue #197).
+//
+// The profile table above is deliberately COARSE: it carries legible tier
+// labels (`accessTokenLifespanTier`, `rateLimitTier`), not magic numbers. The
+// concrete seconds / request caps stay in realm/env config so an operator
+// tunes one place. These two pure mappers are the SINGLE point where a tier is
+// turned into a number — every policy checkpoint (#197) calls them instead of
+// re-deriving its own `dev ? x : y` arithmetic, mirroring how
+// `enforceAgentScopeCap` centralises the agent cap decision.
+// ---------------------------------------------------------------------------
+
+/**
+ * Concrete access-token lifespans (seconds) the two tiers map to. Both numbers
+ * come from configuration — the resolver only SELECTS between them by tier:
+ *   - `short` — the production/staging baseline (`ACCESS_TOKEN_LIFESPAN`).
+ *   - `long`  — the `development` convenience (`DEV_ACCESS_TOKEN_LIFESPAN`).
+ */
+export interface AccessTokenLifespanConfig {
+  /** The `short` tier value in seconds (production/staging baseline). */
+  readonly shortSeconds: number;
+  /** The `long` tier value in seconds (development convenience). */
+  readonly longSeconds: number;
+}
+
+/**
+ * Map an {@link AccessTokenLifespanTier} to a concrete number of seconds using
+ * the supplied config (ADR-008 §5). `short` (production/staging) returns the
+ * baseline lifespan; `long` (development) returns the dev-convenience lifespan.
+ *
+ * FAIL-SAFE: the `long` value is clamped to be at LEAST the `short` baseline is
+ * NOT applied here on purpose — `long` is a development relaxation and a
+ * misconfigured `longSeconds < shortSeconds` simply yields a shorter dev token,
+ * which is the safe direction. The strict tiers always get exactly the baseline.
+ */
+export function resolveAccessTokenLifespanSeconds(
+  tier: AccessTokenLifespanTier,
+  config: AccessTokenLifespanConfig
+): number {
+  return tier === 'long' ? config.longSeconds : config.shortSeconds;
+}
+
+/**
+ * Concrete per-window request caps the two rate-limit tiers map to. Both come
+ * from configuration; the resolver only SELECTS by tier.
+ */
+export interface RateLimitTierConfig {
+  /** The `lenient` tier cap (development / staging, e.g. load testing). */
+  readonly lenientMax: number;
+  /** The `strict` tier cap (production). */
+  readonly strictMax: number;
+}
+
+/**
+ * Map a {@link RateLimitTier} to a concrete per-window request cap (ADR-008
+ * §5). `strict` (production) returns the tight cap; `lenient`
+ * (development/staging) returns the relaxed cap. The window itself is unchanged
+ * by environment — only the cap moves, matching the profile table.
+ */
+export function resolveRateLimitMax(tier: RateLimitTier, config: RateLimitTierConfig): number {
+  return tier === 'strict' ? config.strictMax : config.lenientMax;
+}

--- a/apps/auth-server/src/app/helpers/oauth-redirect.test.ts
+++ b/apps/auth-server/src/app/helpers/oauth-redirect.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+
+import { ENVIRONMENT_PROFILES } from './environment-policy';
+import {
+  buildRedirectUrl,
+  isHttpLocalhostRedirect,
+  isRedirectUriAllowedForPolicy,
+} from './oauth-redirect';
+
+describe('oauth-redirect — isHttpLocalhostRedirect (ADR-008 §5, #197)', () => {
+  it('is true for http loopback hosts (localhost, 127.0.0.0/8, ::1)', () => {
+    expect(isHttpLocalhostRedirect('http://localhost/cb')).toBe(true);
+    expect(isHttpLocalhostRedirect('http://localhost:3000/cb')).toBe(true);
+    expect(isHttpLocalhostRedirect('http://127.0.0.1/cb')).toBe(true);
+    expect(isHttpLocalhostRedirect('http://127.1.2.3:8080/cb')).toBe(true);
+    expect(isHttpLocalhostRedirect('http://[::1]:9000/cb')).toBe(true);
+  });
+
+  it('is false for https loopback (https is fine everywhere)', () => {
+    expect(isHttpLocalhostRedirect('https://localhost/cb')).toBe(false);
+    expect(isHttpLocalhostRedirect('https://127.0.0.1/cb')).toBe(false);
+  });
+
+  it('is false for non-loopback http (handled by the policy gate as a reject, not a dev allowance)', () => {
+    expect(isHttpLocalhostRedirect('http://example.com/cb')).toBe(false);
+    expect(isHttpLocalhostRedirect('http://169.254.169.254/cb')).toBe(false);
+  });
+
+  it('is false for unparseable input (existing checks stay authoritative)', () => {
+    expect(isHttpLocalhostRedirect('not a url')).toBe(false);
+    expect(isHttpLocalhostRedirect('')).toBe(false);
+  });
+});
+
+describe('oauth-redirect — isRedirectUriAllowedForPolicy (ADR-008 §5, #197)', () => {
+  it('development permits http://localhost redirects', () => {
+    expect(
+      isRedirectUriAllowedForPolicy('http://localhost:3000/cb', ENVIRONMENT_PROFILES.development)
+    ).toBe(true);
+  });
+
+  it('staging and production reject http://localhost (https-only)', () => {
+    expect(
+      isRedirectUriAllowedForPolicy('http://localhost:3000/cb', ENVIRONMENT_PROFILES.staging)
+    ).toBe(false);
+    expect(
+      isRedirectUriAllowedForPolicy('http://127.0.0.1/cb', ENVIRONMENT_PROFILES.production)
+    ).toBe(false);
+  });
+
+  it('https redirects are permitted in every environment (the gate never widens)', () => {
+    for (const env of ['development', 'staging', 'production'] as const) {
+      expect(
+        isRedirectUriAllowedForPolicy('https://example.com/cb', ENVIRONMENT_PROFILES[env])
+      ).toBe(true);
+      expect(isRedirectUriAllowedForPolicy('https://localhost/cb', ENVIRONMENT_PROFILES[env])).toBe(
+        true
+      );
+    }
+  });
+
+  it('a custom-scheme native redirect is unaffected by the gate', () => {
+    expect(
+      isRedirectUriAllowedForPolicy(
+        'com.example.app:/oauth2redirect',
+        ENVIRONMENT_PROFILES.production
+      )
+    ).toBe(true);
+  });
+});
+
+describe('oauth-redirect — buildRedirectUrl (unchanged behaviour)', () => {
+  it('appends params and strips the fragment', () => {
+    const url = buildRedirectUrl('https://example.com/cb#frag', { code: 'abc', state: 'xyz' });
+    expect(url).toBe('https://example.com/cb?code=abc&state=xyz');
+  });
+});

--- a/apps/auth-server/src/app/helpers/oauth-redirect.ts
+++ b/apps/auth-server/src/app/helpers/oauth-redirect.ts
@@ -1,3 +1,71 @@
+import type { EnvironmentPolicy } from './environment-policy';
+
+/**
+ * Host literals treated as loopback/localhost for the plain-HTTP redirect gate
+ * (ADR-008 §5, #197). IPv6 `::1` is matched after stripping URL brackets; the
+ * full IPv4 `127.0.0.0/8` block is matched by {@link isIpv4LoopbackHost}.
+ */
+const LOOPBACK_HOSTS = new Set(['localhost', '::1']);
+
+/** True when `host` is anywhere in the IPv4 loopback block `127.0.0.0/8`. */
+function isIpv4LoopbackHost(host: string): boolean {
+  const octets = host.split('.');
+  if (octets.length !== 4) return false;
+  for (const o of octets) {
+    if (!/^\d{1,3}$/.test(o)) return false;
+    const n = Number(o);
+    if (n < 0 || n > 255) return false;
+  }
+  return Number(octets[0]) === 127;
+}
+
+/**
+ * True when `redirectUri` is an `http://` (NOT https) loopback/localhost URI —
+ * the exact shape ADR-008 §5 permits only for `development`. An https URI (even
+ * to localhost) is fine in every environment and returns false; a non-loopback
+ * `http://` URI also returns false here (it is rejected outright by the policy
+ * gate, never "allowed in development"). Unparseable input returns false so the
+ * caller's existing exact-match / scheme checks remain authoritative.
+ */
+export function isHttpLocalhostRedirect(redirectUri: string): boolean {
+  let url: URL;
+  try {
+    url = new URL(redirectUri);
+  } catch {
+    return false;
+  }
+  if (url.protocol !== 'http:') return false;
+  const host = url.hostname.toLowerCase().replace(/^\[|\]$/g, '');
+  return LOOPBACK_HOSTS.has(host) || isIpv4LoopbackHost(host);
+}
+
+/**
+ * Whether a (already registered, exact-matched) `redirect_uri` is permitted
+ * under the effective environment policy (ADR-008 §5, #197).
+ *
+ * The ONLY environment-gated case is an `http://localhost` (loopback) redirect:
+ * permitted for a `development` client (`localhostRedirectAllowed`), rejected as
+ * https-only for `staging`/`production`. Everything else — any https URI, any
+ * custom-scheme native redirect — is unaffected and returns true; this gate
+ * never widens what is allowed, it only withholds the plain-HTTP-loopback
+ * convenience outside development.
+ *
+ * FAIL-SAFE: an unset client/realm resolves to the `production` profile, whose
+ * `localhostRedirectAllowed` is false, so a misconfigured deployment rejects
+ * plain-HTTP loopback redirects (the hardened direction).
+ *
+ * NB: this is a SECOND gate, layered after the existing exact-match check
+ * (`client.redirectUris.includes(redirect_uri)`) — it does not replace it. A
+ * URI must be both registered AND allowed by the environment.
+ */
+export function isRedirectUriAllowedForPolicy(
+  redirectUri: string,
+  policy: EnvironmentPolicy
+): boolean {
+  if (!isHttpLocalhostRedirect(redirectUri)) return true;
+  return policy.localhostRedirectAllowed;
+}
+
 /**
  * Build redirect URL for authorize success or error (RFC 6749 4.1.2, 4.1.2.1).
  * redirect_uri is exact; we append ?key=value&...

--- a/apps/auth-server/src/app/helpers/session-cookie.ts
+++ b/apps/auth-server/src/app/helpers/session-cookie.ts
@@ -88,11 +88,41 @@ export function readCookie(request: FastifyRequest, name: string): string | unde
 }
 
 /**
+ * Resolve whether the session cookie's `Secure` attribute is set.
+ *
+ * ADR-008 §5 (#197) T3 relaxation seam, CLIENT-SCOPED. Secure cookies are a T3
+ * control. The session cookie is GLOBAL — it is minted at `/ui/login`, which
+ * carries NO `client_id` (only a `return_to`) — so there is no client whose
+ * environment could safely relax it there. We therefore DEFAULT TO STRICT:
+ * `env.SESSION_COOKIE_SECURE` (true in production) governs the attribute, and a
+ * caller may relax it ONLY by passing an explicit `secureOverride === false`
+ * derived from a resolved `development`-profile policy on a surface that
+ * unambiguously has a client in scope. No such caller exists today, so the
+ * cookie stays strict everywhere — the deliberate fail-safe for a global
+ * control. (Local plain-HTTP dev already relaxes it via `SESSION_COOKIE_SECURE`.)
+ *
+ * @param secureOverride When `false`, force-disable `Secure` (a deliberate
+ *   client-scoped development relaxation). When omitted/`true`, the strict
+ *   `env.SESSION_COOKIE_SECURE` default applies.
+ */
+function resolveCookieSecure(secureOverride?: boolean): boolean {
+  if (secureOverride === false) return false;
+  return env.SESSION_COOKIE_SECURE;
+}
+
+/**
  * Emit a Set-Cookie header for the signed session. Attributes match the
  * issue #150 spec: __Host-, Secure (configurable for local dev),
  * HttpOnly, SameSite=Lax, Path=/.
+ *
+ * @param secureOverride see {@link resolveCookieSecure} — a client-scoped
+ *   development relaxation of the `Secure` attribute (defaults to strict).
  */
-export function setSessionCookie(reply: FastifyReply, sessionId: string): void {
+export function setSessionCookie(
+  reply: FastifyReply,
+  sessionId: string,
+  secureOverride?: boolean
+): void {
   const attrs = [
     `${SESSION_COOKIE_NAME}=${signSessionId(sessionId)}`,
     'Path=/',
@@ -102,7 +132,7 @@ export function setSessionCookie(reply: FastifyReply, sessionId: string): void {
   ];
   // __Host- prefix requires Secure. Tests may turn this off for in-process
   // assertions but production must have it set.
-  if (env.SESSION_COOKIE_SECURE) attrs.push('Secure');
+  if (resolveCookieSecure(secureOverride)) attrs.push('Secure');
   reply.header('Set-Cookie', attrs.join('; '));
 }
 

--- a/apps/auth-server/src/app/helpers/step-up.test.ts
+++ b/apps/auth-server/src/app/helpers/step-up.test.ts
@@ -196,6 +196,55 @@ describe('evaluateStepUp', () => {
     const within = evaluateStepUp({ ...base, maxAgeSeconds: 60, authTimeMs: NOW - 30 * 1000 });
     expect(within.requiresFreshLogin).toBe(false);
   });
+
+  // ADR-008 §5 (#197): `enforceDangerousStepUp` gates ONLY the automatic
+  // dangerous-scope fresh-login. Explicit client requests (prompt/max_age) are
+  // always honoured. Defaults to true (strict) when omitted.
+  describe('enforceDangerousStepUp (environment-gated automatic step-up)', () => {
+    const staleDangerous: StepUpInput = {
+      ...base,
+      requestedScopes: ['agent:exec'],
+      priorConsentScopes: [],
+      authTimeMs: NOW - 10 * 60 * 1000, // stale, outside the freshness window
+    };
+
+    it('defaults to enforced (omitted ⇒ dangerous scope forces fresh login)', () => {
+      const d = evaluateStepUp(staleDangerous);
+      expect(d.dangerous).toEqual(['agent:exec']);
+      expect(d.requiresFreshLogin).toBe(true);
+    });
+
+    it('enforced (staging/production): dangerous scope forces fresh login', () => {
+      const d = evaluateStepUp({ ...staleDangerous, enforceDangerousStepUp: true });
+      expect(d.requiresFreshLogin).toBe(true);
+    });
+
+    it('relaxed (development): the AUTOMATIC dangerous-scope step-up is not forced', () => {
+      const d = evaluateStepUp({ ...staleDangerous, enforceDangerousStepUp: false });
+      // The scope is still classified dangerous (for audit), but the server no
+      // longer forces a fresh login off that classification in development.
+      expect(d.dangerous).toEqual(['agent:exec']);
+      expect(d.requiresFreshLogin).toBe(false);
+    });
+
+    it('relaxed development STILL honours an explicit prompt=login (client opt-in always wins)', () => {
+      const d = evaluateStepUp({
+        ...staleDangerous,
+        enforceDangerousStepUp: false,
+        prompt: 'login',
+      });
+      expect(d.requiresFreshLogin).toBe(true);
+    });
+
+    it('relaxed development STILL honours an explicit max_age (client opt-in always wins)', () => {
+      const d = evaluateStepUp({
+        ...staleDangerous,
+        enforceDangerousStepUp: false,
+        maxAgeSeconds: 0, // demand a brand-new authentication
+      });
+      expect(d.requiresFreshLogin).toBe(true);
+    });
+  });
 });
 
 describe('stepUpErrorForPromptNone', () => {

--- a/apps/auth-server/src/app/helpers/step-up.ts
+++ b/apps/auth-server/src/app/helpers/step-up.ts
@@ -118,6 +118,20 @@ export interface StepUpInput {
    * separately and exactly — it is NOT widened by this window.
    */
   freshAuthWindowMs: number;
+  /**
+   * Whether the AUTOMATIC dangerous-scope step-up is enforced (ADR-008 §5,
+   * #197 — the `agentStepUpEnforced` profile knob). True for `staging` /
+   * `production` (and the safe default when omitted); false ONLY for a
+   * `development`-profile client, where the server-driven "dangerous scope ⇒
+   * fresh login" rule is relaxed for local convenience.
+   *
+   * This relaxes ONLY the server's own dangerous-scope inference. The EXPLICIT
+   * client step-up requests — `prompt=login` and `max_age` — are honoured in
+   * EVERY environment (a relying party that asks for fresh auth always gets the
+   * gate), so an MCP resource server can still force step-up in development.
+   * Defaults to `true` so existing two-call sites keep the strict behaviour.
+   */
+  enforceDangerousStepUp?: boolean;
 }
 
 /** The step-up decision. */
@@ -189,11 +203,19 @@ export function evaluateStepUp(input: StepUpInput): StepUpDecision {
 
   const authAgeMs = input.nowMs - input.authTimeMs;
 
+  // ADR-008 §5 (#197): the AUTOMATIC dangerous-scope step-up is gated by the
+  // environment profile (`agentStepUpEnforced`). It is enforced for staging /
+  // production and when the flag is omitted (strict default); a `development`
+  // client relaxes ONLY this server-inferred rule. The EXPLICIT client requests
+  // (`prompt=login`, `max_age`) are always honoured regardless of environment.
+  const enforceDangerousStepUp = input.enforceDangerousStepUp ?? true;
+  const dangerousForcesLogin = enforceDangerousStepUp && dangerous.length > 0;
+
   // `prompt=login` and dangerous scopes demand a *fresh* authentication, but
   // one performed within the freshness window counts — otherwise the post-login
   // return trip would re-trigger the same requirement and loop.
   const authIsFresh = authAgeMs <= input.freshAuthWindowMs;
-  const loginRequirement = (dangerous.length > 0 || input.prompt === 'login') && !authIsFresh;
+  const loginRequirement = (dangerousForcesLogin || input.prompt === 'login') && !authIsFresh;
 
   // `max_age` is enforced exactly against the request value (not widened by the
   // freshness window) BUT at OIDC second-granularity: floor the age to whole

--- a/apps/auth-server/src/app/plugins/security-headers.test.ts
+++ b/apps/auth-server/src/app/plugins/security-headers.test.ts
@@ -16,7 +16,7 @@ vi.mock('../../config/env', () => ({
   },
 }));
 
-import { securityHeadersPlugin } from './security-headers';
+import { markRelaxedCsp, securityHeadersPlugin } from './security-headers';
 
 async function buildApp(): Promise<FastifyInstance> {
   const app = Fastify();
@@ -24,6 +24,13 @@ async function buildApp(): Promise<FastifyInstance> {
   app.get('/page', async (_req, reply) => {
     reply.header('content-type', 'text/html');
     return `<style nonce="${reply.cspNonce.style}">body{}</style>`;
+  });
+  // ADR-008 §5 (#197): stand-in for a development-profile consent screen that
+  // requests the relaxed CSP via markRelaxedCsp.
+  app.get('/dev-consent', async (_req, reply) => {
+    markRelaxedCsp(reply);
+    reply.header('content-type', 'text/html');
+    return '<style>body{}</style>';
   });
   // Stand-in for Swagger UI's served HTML at the /docs prefix.
   app.get('/docs', async (_req, reply) => {
@@ -111,6 +118,24 @@ describe('security-headers plugin (#113)', () => {
     // Non-/docs routes keep the strict policy (no unsafe-inline).
     const page = await app.inject({ method: 'GET', url: '/page' });
     expect(page.headers['content-security-policy']).not.toContain("'unsafe-inline'");
+  });
+
+  it('serves the relaxed development CSP when a route marks the reply (ADR-008 §5, #197)', async () => {
+    const res = await app.inject({ method: 'GET', url: '/dev-consent' });
+    const csp = res.headers['content-security-policy'] as string;
+    // Inline styles permitted without a nonce for the development consent screen.
+    expect(csp).toContain("style-src 'self' 'unsafe-inline'");
+    // Scripts stay strict — the dev relaxation never loosens script-src.
+    expect(csp).toContain("script-src 'self'");
+    expect(csp).not.toMatch(/script-src [^;]*'unsafe-inline'/);
+    // No nonce policy leaks onto the relaxed response.
+    expect(csp).not.toContain("'nonce-");
+
+    // An UNMARKED route still gets the strict nonce-based policy — relaxation is
+    // opt-in per reply and never bleeds across requests (default-to-strict).
+    const strict = await app.inject({ method: 'GET', url: '/page' });
+    expect(strict.headers['content-security-policy']).not.toContain("'unsafe-inline'");
+    expect(strict.headers['content-security-policy']).toMatch(/style-src [^;]*'nonce-/);
   });
 });
 

--- a/apps/auth-server/src/app/plugins/security-headers.ts
+++ b/apps/auth-server/src/app/plugins/security-headers.ts
@@ -42,6 +42,46 @@ import { env } from '../../config/env';
 /** Prefix served by Swagger UI; excluded from the strict CSP. */
 const SWAGGER_PREFIX = '/docs';
 
+/**
+ * Reply marker (ADR-008 §5, #197) requesting the relaxed development CSP. T3
+ * security headers are a GLOBAL control with no client in scope, so they
+ * DEFAULT TO STRICT everywhere; the only sanctioned relaxation is on the
+ * consent screen — the rare browser surface that unambiguously carries a
+ * `client_id` — for a `development`-profile client. That route MARKS its reply
+ * via {@link markRelaxedCsp}; the swap itself happens HERE, in the one place
+ * that already overrides helmet's CSP (Swagger, below), so the override logic
+ * stays centralised and route handlers need no onSend of their own.
+ */
+const RELAX_CSP_MARKER = Symbol('qauth.security.relaxCsp');
+
+/**
+ * Mark a reply so the security-headers onSend serves {@link DEVELOPMENT_CSP}
+ * instead of the strict global CSP (ADR-008 §5, #197). Called ONLY for a
+ * `development`-profile client on a client-scoped surface (the consent screen).
+ * Strict everywhere it is not called — the fail-safe default for a global control.
+ */
+export function markRelaxedCsp(reply: { header(...args: unknown[]): unknown }): void {
+  (reply as unknown as Record<symbol, unknown>)[RELAX_CSP_MARKER] = true;
+}
+
+/**
+ * Relaxed CSP for a `development` consent screen: permits inline `<style>`
+ * without a per-request nonce so a developer iterating on the page is not forced
+ * to nonce every style. Scripts stay `'self'` — the dev relaxation never
+ * loosens the script policy, only styles. Never served outside `development`.
+ */
+const DEVELOPMENT_CSP =
+  "default-src 'self'; " +
+  "base-uri 'self'; " +
+  "script-src 'self'; " +
+  "style-src 'self' 'unsafe-inline'; " +
+  "img-src 'self' data:; " +
+  "font-src 'self' data:; " +
+  "connect-src 'self'; " +
+  "form-action 'self'; " +
+  "object-src 'none'; " +
+  "frame-ancestors 'none'";
+
 /** Relaxed CSP for Swagger UI, which needs its own inline scripts/styles. */
 const SWAGGER_CSP =
   "default-src 'self'; " +
@@ -121,6 +161,12 @@ export const securityHeadersPlugin = fp<FastifyPluginOptions>(
       async (request: FastifyRequest, reply: FastifyReply, payload: unknown) => {
         if (isSwaggerRequest(request)) {
           reply.header('Content-Security-Policy', SWAGGER_CSP);
+        } else if ((reply as unknown as Record<symbol, unknown>)[RELAX_CSP_MARKER]) {
+          // ADR-008 §5 (#197): a `development`-profile consent screen asked for
+          // the relaxed CSP. Overwrite helmet's strict header (this onSend runs
+          // after helmet's). Swagger takes precedence — its own relaxed policy
+          // already covers that prefix.
+          reply.header('Content-Security-Policy', DEVELOPMENT_CSP);
         }
         return payload;
       }

--- a/apps/auth-server/src/app/routes/oauth/authorize.test.ts
+++ b/apps/auth-server/src/app/routes/oauth/authorize.test.ts
@@ -802,3 +802,77 @@ describe('GET /oauth/authorize — Bearer path step-up (ADR-007 §2, #185)', () 
     expect(fastify.repositories.authorizationCodes.create).toHaveBeenCalledOnce();
   });
 });
+
+describe('GET /oauth/authorize — environment localhost redirect gate (ADR-008 §5, #197)', () => {
+  // A client that has registered an http://localhost redirect (exact-matched).
+  const LOCALHOST_CLIENT = {
+    ...CLIENT,
+    redirectUris: ['http://localhost:3000/cb'],
+  };
+  const LOCALHOST_QUERY = {
+    ...BASE_QUERY,
+    redirect_uri: 'http://localhost:3000/cb',
+  };
+
+  async function run(realmEnv: string, clientEnv: string) {
+    const { fastify, ctx } = makeFastify();
+    (fastify.repositories.realms.findByName as unknown as Mock).mockResolvedValue({
+      id: 'realm-1',
+      name: 'master',
+      enabled: true,
+      maxEnvironmentLaxity: realmEnv,
+    });
+    await authorizeRoute(fastify);
+    (fastify.repositories.oauthClients.findByClientId as unknown as Mock).mockResolvedValue({
+      ...LOCALHOST_CLIENT,
+      environment: clientEnv,
+    });
+    (fastify.jwtUtils.extractFromHeader as unknown as Mock).mockReturnValue(null);
+    (fastify.sessionUtils.getSession as unknown as Mock).mockResolvedValue(null);
+
+    const { reply, state } = createReply();
+    return {
+      fastify,
+      state,
+      call: () =>
+        ctx.handler!(
+          {
+            query: LOCALHOST_QUERY,
+            url: '/oauth/authorize?response_type=code&client_id=app-123',
+            headers: {},
+            ip: '127.0.0.1',
+          },
+          reply
+        ),
+    };
+  }
+
+  it('production realm/client REJECTS an http://localhost redirect (https-only)', async () => {
+    const { fastify, call } = await run('production', 'production');
+    await expect(call()).rejects.toThrow(/redirect_uri/);
+    expect(fastify.repositories.authorizationCodes.create).not.toHaveBeenCalled();
+  });
+
+  it('staging client REJECTS an http://localhost redirect (https-only)', async () => {
+    const { call } = await run('staging', 'staging');
+    await expect(call()).rejects.toThrow(/redirect_uri/);
+  });
+
+  it('an UNSET environment fails safe to production and REJECTS http://localhost', async () => {
+    const { call } = await run('bogus', 'also-bogus');
+    await expect(call()).rejects.toThrow(/redirect_uri/);
+  });
+
+  it('development realm/client PERMITS http://localhost (passes the gate, proceeds to login)', async () => {
+    const { state, call } = await run('development', 'development');
+    // Not rejected by the gate — flows on to the unauthenticated login redirect
+    // (the request carries no session), proving the localhost URI was allowed.
+    await call();
+    expect(state.redirected).toContain('/ui/login?return_to=');
+  });
+
+  it('a production realm caps a development client and REJECTS http://localhost (ceiling wins)', async () => {
+    const { call } = await run('production', 'development');
+    await expect(call()).rejects.toThrow(/redirect_uri/);
+  });
+});

--- a/apps/auth-server/src/app/routes/oauth/authorize.ts
+++ b/apps/auth-server/src/app/routes/oauth/authorize.ts
@@ -10,8 +10,9 @@ import { resolveBrowserSession } from '../../helpers/browser-session';
 import { findExceedingAgentScopesForClient, resolveAudience } from '../../helpers/client-auth';
 import { resolveClient } from '../../helpers/client-resolution';
 import { canSkipConsent, filterRequestedScopes } from '../../helpers/consent';
+import { resolveEnvironmentPolicy } from '../../helpers/environment-policy';
 import { getOrCreateSystemClient } from '../../helpers/oauth-client';
-import { buildRedirectUrl } from '../../helpers/oauth-redirect';
+import { buildRedirectUrl, isRedirectUriAllowedForPolicy } from '../../helpers/oauth-redirect';
 import { getOrCreateDefaultRealm } from '../../helpers/realm';
 import {
   evaluateStepUp,
@@ -119,6 +120,35 @@ export default async function (fastify: FastifyInstance) {
           metadata: { error: 'redirect_uri not registered', client_id: query.client_id },
         });
         throw new BadRequestError('redirect_uri not registered');
+      }
+
+      // ADR-008 §5/§7 (#197): resolve the effective environment policy now that
+      // both the client and its realm are in scope, and apply the localhost
+      // redirect gate. `http://localhost` (loopback) redirect URIs are a
+      // `development`-only convenience; `staging`/`production` are https-only.
+      // This is a SECOND gate after the exact-match check above — the URI is
+      // registered, but a plain-HTTP loopback target is withheld outside
+      // development. Fail-safe: an unset client/realm resolves to `production`,
+      // which rejects it. We reject BEFORE redirecting (the redirect target is
+      // the very thing under suspicion), matching the unregistered-URI handling.
+      const policy = resolveEnvironmentPolicy(client, realm);
+      if (!isRedirectUriAllowedForPolicy(redirectUri, policy)) {
+        await fastify.repositories.auditLogs.create({
+          userId: null,
+          oauthClientId: client.id,
+          event: 'oauth.authorize.failure',
+          eventType: 'token',
+          success: false,
+          ipAddress: request.ip,
+          userAgent: request.headers['user-agent'] || null,
+          metadata: {
+            error: 'redirect_uri not permitted for this environment',
+            reason: 'http_localhost_redirect_requires_development',
+            client_id: query.client_id,
+            environment: policy.environment,
+          },
+        });
+        throw new BadRequestError('redirect_uri not permitted for this environment');
       }
 
       if (!client.enabled) {
@@ -283,7 +313,13 @@ export default async function (fastify: FastifyInstance) {
       // browser flow (which enforces the dangerous-op re-auth gate). Bearer is
       // legacy first-party and not exposed to dynamically-registered clients,
       // so this only affects first-party callers requesting dangerous scopes.
-      if (!browserSession) {
+      // ADR-008 §5 (#197): the automatic dangerous-scope refusal is gated by the
+      // environment policy. Staging/production (and the fail-safe default) keep
+      // it; a `development` client relaxes it so local Bearer-path iteration
+      // with dangerous scopes is not forced through the browser flow. This only
+      // relaxes the SERVER-inferred dangerous gate — every other Bearer check
+      // (token validity, scope allowlist, agent cap) still applies.
+      if (!browserSession && policy.agentStepUpEnforced) {
         const bearerDangerous = scopes.filter(isDangerousScope);
         if (bearerDangerous.length > 0) {
           await fastify.repositories.auditLogs.create({
@@ -340,6 +376,9 @@ export default async function (fastify: FastifyInstance) {
           authTimeMs: browserSession.createdAt,
           nowMs: Date.now(),
           freshAuthWindowMs: STEP_UP_FRESH_AUTH_WINDOW_MS,
+          // ADR-008 §5 (#197): relax the automatic dangerous-scope fresh-login
+          // for a development client; explicit prompt/max_age still enforced.
+          enforceDangerousStepUp: policy.agentStepUpEnforced,
         });
 
         // OIDC Core §3.1.2.1: `prompt=none` forbids ANY user-facing UI. If

--- a/apps/auth-server/src/app/routes/oauth/token.environment.test.ts
+++ b/apps/auth-server/src/app/routes/oauth/token.environment.test.ts
@@ -1,0 +1,262 @@
+/**
+ * Environment-aware authorization posture at the token endpoint
+ * (ADR-008 §5/§7, issue #197).
+ *
+ * Proves the production profile delivers the hardened bundle (short access-token
+ * lifespan, PKCE downgrade rejected), development relaxes ONLY the sanctioned
+ * knob (long lifespan), staging keeps the short lifespan, and the HARD FLOORS
+ * (client secret hashed + verified, RFC 8707 audience binding, PKCE downgrade)
+ * hold even for a development client.
+ */
+import { InvalidGrantError } from '@qauth-labs/shared-errors';
+import type { FastifyInstance } from 'fastify';
+import { describe, expect, it, type Mock, vi } from 'vitest';
+
+vi.mock('../../helpers/timing', () => ({
+  ensureMinimumResponseTime: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../../config/env', () => ({
+  env: {
+    TOKEN_RATE_LIMIT: 60,
+    TOKEN_RATE_WINDOW: 60,
+    // ADR-008 §5 (#197): short baseline (staging/production) vs the long
+    // development convenience. The handler selects between them by tier.
+    DEV_ACCESS_TOKEN_LIFESPAN: 28800, // 8h
+  },
+}));
+
+import tokenRoute from './token';
+
+const SHORT_LIFESPAN = 900;
+
+interface TestContext {
+  handler?: (request: any, reply: any) => Promise<unknown>;
+}
+
+function createReply(onSend?: (body: unknown) => void) {
+  const reply: any = {
+    header(_k: string, _v: string) {
+      return reply;
+    },
+    send(body: unknown) {
+      onSend?.(body);
+      return body;
+    },
+  };
+  return reply;
+}
+
+/**
+ * Build a token-route stub primed for the authorization_code grant. `realmEnv`
+ * is the realm ceiling and `clientEnv` the client's declared environment; the
+ * effective policy is the stricter of the two (fail-safe to production).
+ */
+function makeAuthCodeStub(opts: {
+  realmEnv: string;
+  clientEnv: string;
+  /** Override the bound code challenge (empty string ⇒ no PKCE on the code). */
+  codeChallenge?: string;
+}) {
+  const ctx: TestContext = {};
+  const fastify: any = {
+    withTypeProvider: () => ({
+      post: (_url: string, _o: unknown, handler: any) => {
+        ctx.handler = handler;
+        return fastify;
+      },
+    }),
+    repositories: {
+      realms: {
+        findByName: vi.fn().mockResolvedValue({
+          id: 'realm-1',
+          name: 'default',
+          enabled: true,
+          maxEnvironmentLaxity: opts.realmEnv,
+        }),
+        create: vi.fn(),
+      },
+      oauthClients: {
+        findByClientId: vi.fn().mockResolvedValue({
+          id: 'client-uuid',
+          clientId: 'app-123',
+          clientSecretHash: 'argon2-hash',
+          enabled: true,
+          grantTypes: ['authorization_code'],
+          scopes: ['openid'],
+          audience: ['https://api.example.com'],
+          tokenEndpointAuthMethod: 'client_secret_post',
+          environment: opts.clientEnv,
+        }),
+      },
+      authorizationCodes: {
+        findByCode: vi.fn().mockResolvedValue({
+          id: 'code-1',
+          oauthClientId: 'client-uuid',
+          userId: 'user-1',
+          redirectUri: 'https://example.com/cb',
+          codeChallenge: opts.codeChallenge ?? 'bound-challenge',
+          codeChallengeMethod: 'S256',
+          nonce: null,
+          scopes: ['openid'],
+          resource: ['https://api.example.com'],
+          state: null,
+        }),
+        markUsed: vi.fn().mockResolvedValue(undefined),
+      },
+      users: {
+        findById: vi.fn().mockResolvedValue({
+          id: 'user-1',
+          email: 'u@example.com',
+          emailVerified: true,
+          enabled: true,
+        }),
+      },
+      refreshTokens: {
+        create: vi.fn().mockResolvedValue(undefined),
+      },
+      auditLogs: { create: vi.fn().mockResolvedValue(undefined) },
+    },
+    passwordHasher: {
+      verifyPassword: vi.fn().mockResolvedValue(true),
+    },
+    jwtUtils: {
+      signAccessToken: vi.fn().mockResolvedValue('access.jwt'),
+      signIdToken: vi.fn().mockResolvedValue('id.jwt'),
+      generateRefreshToken: vi
+        .fn()
+        .mockReturnValue({ token: 'refresh-token', tokenHash: 'refresh-hash' }),
+      getAccessTokenLifespan: vi.fn().mockReturnValue(SHORT_LIFESPAN),
+      getRefreshTokenLifespan: vi.fn().mockReturnValue(604800),
+    },
+    pkceUtils: {
+      verifyCodeChallenge: vi.fn().mockReturnValue(true),
+    },
+    sessionUtils: { setSession: vi.fn().mockResolvedValue(undefined) },
+    log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    metrics: { tokensIssued: { inc: vi.fn() } },
+  };
+  return { fastify: fastify as FastifyInstance, ctx };
+}
+
+function authCodeRequest() {
+  return {
+    body: {
+      grant_type: 'authorization_code',
+      code: 'the-code',
+      redirect_uri: 'https://example.com/cb',
+      client_id: 'app-123',
+      client_secret: 'the-secret',
+      code_verifier: 'V'.repeat(43),
+    },
+    ip: '127.0.0.1',
+    headers: { 'user-agent': 'vitest' },
+  };
+}
+
+describe('token endpoint — environment-aware access-token lifespan (#197)', () => {
+  it('production client gets the SHORT lifespan baseline', async () => {
+    const { fastify, ctx } = makeAuthCodeStub({ realmEnv: 'production', clientEnv: 'production' });
+    await tokenRoute(fastify);
+    let body: any;
+    await ctx.handler!(
+      authCodeRequest(),
+      createReply((b) => (body = b))
+    );
+
+    expect(body.expires_in).toBe(SHORT_LIFESPAN);
+    expect(fastify.jwtUtils.signAccessToken).toHaveBeenCalledWith(
+      expect.objectContaining({ expiresInOverride: SHORT_LIFESPAN })
+    );
+  });
+
+  it('development client (under a development realm) gets the LONG lifespan', async () => {
+    const { fastify, ctx } = makeAuthCodeStub({
+      realmEnv: 'development',
+      clientEnv: 'development',
+    });
+    await tokenRoute(fastify);
+    let body: any;
+    await ctx.handler!(
+      authCodeRequest(),
+      createReply((b) => (body = b))
+    );
+
+    expect(body.expires_in).toBe(28800);
+    expect(fastify.jwtUtils.signAccessToken).toHaveBeenCalledWith(
+      expect.objectContaining({ expiresInOverride: 28800 })
+    );
+  });
+
+  it('staging client keeps the SHORT lifespan (security/operational baseline)', async () => {
+    const { fastify, ctx } = makeAuthCodeStub({ realmEnv: 'staging', clientEnv: 'staging' });
+    await tokenRoute(fastify);
+    let body: any;
+    await ctx.handler!(
+      authCodeRequest(),
+      createReply((b) => (body = b))
+    );
+    expect(body.expires_in).toBe(SHORT_LIFESPAN);
+  });
+
+  it('a PRODUCTION realm caps a development client back to the SHORT lifespan (ceiling wins)', async () => {
+    const { fastify, ctx } = makeAuthCodeStub({ realmEnv: 'production', clientEnv: 'development' });
+    await tokenRoute(fastify);
+    let body: any;
+    await ctx.handler!(
+      authCodeRequest(),
+      createReply((b) => (body = b))
+    );
+    expect(body.expires_in).toBe(SHORT_LIFESPAN);
+  });
+
+  it('an UNSET client/realm environment fails safe to the short (production) lifespan', async () => {
+    const { fastify, ctx } = makeAuthCodeStub({ realmEnv: 'bogus', clientEnv: 'also-bogus' });
+    await tokenRoute(fastify);
+    let body: any;
+    await ctx.handler!(
+      authCodeRequest(),
+      createReply((b) => (body = b))
+    );
+    expect(body.expires_in).toBe(SHORT_LIFESPAN);
+  });
+});
+
+describe('token endpoint — HARD FLOORS hold even for a development client (#197)', () => {
+  it('PKCE downgrade is rejected for a development client (floor, not a dev relaxation)', async () => {
+    // No challenge bound to the code, but a verifier is presented → downgrade.
+    const { fastify, ctx } = makeAuthCodeStub({
+      realmEnv: 'development',
+      clientEnv: 'development',
+      codeChallenge: '',
+    });
+    await tokenRoute(fastify);
+    await expect(ctx.handler!(authCodeRequest(), createReply())).rejects.toThrow(InvalidGrantError);
+    // No token is minted on a downgrade attempt.
+    expect(fastify.jwtUtils.signAccessToken).not.toHaveBeenCalled();
+  });
+
+  it('client secret is still hashed + verified for a development client', async () => {
+    const { fastify, ctx } = makeAuthCodeStub({
+      realmEnv: 'development',
+      clientEnv: 'development',
+    });
+    await tokenRoute(fastify);
+    await ctx.handler!(authCodeRequest(), createReply());
+    // The argon2 hash is compared — never a plaintext equality, in any environment.
+    expect(fastify.passwordHasher.verifyPassword).toHaveBeenCalledWith('argon2-hash', 'the-secret');
+  });
+
+  it('RFC 8707 audience binding still holds for a development client', async () => {
+    const { fastify, ctx } = makeAuthCodeStub({
+      realmEnv: 'development',
+      clientEnv: 'development',
+    });
+    await tokenRoute(fastify);
+    await ctx.handler!(authCodeRequest(), createReply());
+    // aud is bound to the code's resource, not widened by the dev profile.
+    expect(fastify.jwtUtils.signAccessToken).toHaveBeenCalledWith(
+      expect.objectContaining({ aud: 'https://api.example.com' })
+    );
+  });
+});

--- a/apps/auth-server/src/app/routes/oauth/token.ts
+++ b/apps/auth-server/src/app/routes/oauth/token.ts
@@ -28,6 +28,11 @@ import {
   validateScopes,
 } from '../../helpers/client-auth';
 import { isAgentClient } from '../../helpers/client-resolution';
+import {
+  type EnvironmentPolicy,
+  resolveAccessTokenLifespanSeconds,
+  resolveEnvironmentPolicy,
+} from '../../helpers/environment-policy';
 import { getOrCreateDefaultRealm } from '../../helpers/realm';
 import { highestAgentModeInScopes } from '../../helpers/scope-modes';
 import { ensureMinimumResponseTime } from '../../helpers/timing';
@@ -140,6 +145,14 @@ export default async function (fastify: FastifyInstance) {
         // RFC 6749 §5.1: token responses MUST NOT be cached by intermediaries.
         reply.header('Cache-Control', 'no-store').header('Pragma', 'no-cache');
 
+        // ADR-008 §5/§7 (#197): resolve the effective environment policy ONCE,
+        // here, where both the authenticated client and its realm are in scope.
+        // The grant handlers consult this `policy` (token TTL tier, PKCE
+        // requirement, refresh rotation) instead of re-deriving rules — the
+        // single-resolver pattern from ADR-008 §7. Fail-safe: an unset client
+        // or realm resolves to the `production` profile (hardened default).
+        const policy = resolveEnvironmentPolicy(client, realm);
+
         // Route by grant type.
         if (body.grant_type === 'authorization_code') {
           const responseBody = await handleAuthorizationCode({
@@ -147,6 +160,7 @@ export default async function (fastify: FastifyInstance) {
             request: request as FastifyRequest,
             client,
             body,
+            policy,
           });
           return reply.send(responseBody);
         }
@@ -157,6 +171,7 @@ export default async function (fastify: FastifyInstance) {
             request: request as FastifyRequest,
             client,
             body,
+            policy,
           });
           return reply.send(responseBody);
         }
@@ -167,6 +182,7 @@ export default async function (fastify: FastifyInstance) {
             request: request as FastifyRequest,
             client,
             body,
+            policy,
           });
           return reply.send(responseBody);
         }
@@ -177,6 +193,7 @@ export default async function (fastify: FastifyInstance) {
             request: request as FastifyRequest,
             client,
             body,
+            policy,
           });
           return reply.send(responseBody);
         }
@@ -223,7 +240,31 @@ type HandlerContext<TBody> = {
   request: FastifyRequest;
   client: OAuthClientLike;
   body: TBody;
+  /**
+   * The resolved environment policy for this (client, realm) (ADR-008 §7,
+   * #197). Carries the access-token lifespan tier, PKCE requirement, and
+   * refresh-rotation requirement the handler enforces. Always present — the
+   * dispatch resolves it fail-safe to `production` before calling any handler.
+   */
+  policy: EnvironmentPolicy;
 };
+
+/**
+ * Map the policy's access-token lifespan TIER to a concrete number of seconds,
+ * in ONE place (ADR-008 §5, #197). The concrete numbers stay in config: the
+ * `short` tier (staging/production) is `ACCESS_TOKEN_LIFESPAN`, the `long` tier
+ * (development) is `DEV_ACCESS_TOKEN_LIFESPAN`. `getAccessTokenLifespan()`
+ * remains the source of truth for the strict baseline; the dev relaxation only
+ * lengthens it for a `development`-profile token. Callers pass the returned
+ * value as `signAccessToken({ expiresInOverride })` AND as the response
+ * `expires_in` so the advertised lifetime matches the signed `exp`.
+ */
+function accessTokenLifespanForPolicy(fastify: FastifyInstance, policy: EnvironmentPolicy): number {
+  return resolveAccessTokenLifespanSeconds(policy.accessTokenLifespanTier, {
+    shortSeconds: fastify.jwtUtils.getAccessTokenLifespan(),
+    longSeconds: env.DEV_ACCESS_TOKEN_LIFESPAN,
+  });
+}
 
 /**
  * Handle the authorization_code grant (legacy flow from Phase 1).
@@ -232,7 +273,7 @@ type HandlerContext<TBody> = {
 async function handleAuthorizationCode(
   ctx: HandlerContext<TokenExchangeAuthCodeBody>
 ): Promise<TokenExchangeResponse> {
-  const { fastify, request, client, body } = ctx;
+  const { fastify, request, client, body, policy } = ctx;
 
   if (!client.grantTypes.includes('authorization_code')) {
     await fastify.repositories.auditLogs.create({
@@ -293,10 +334,60 @@ async function handleAuthorizationCode(
     throw new InvalidGrantError('Invalid or expired authorization code');
   }
 
-  const pkceValid = fastify.pkceUtils.verifyCodeChallenge(
-    body.code_verifier,
-    authCode.codeChallenge
-  );
+  // PKCE enforcement (RFC 7636, OAuth 2.1 §4.1.3) under the environment policy
+  // (ADR-008 §5, #197). The strict baseline — `production`/`staging`, and the
+  // OAuth 2.1 default — REQUIRES a bound S256 challenge; `development` only
+  // RECOMMENDS it. Two distinct cases:
+  //
+  //   1. No challenge bound to the code. Today the authorize endpoint always
+  //      binds one (the schema mandates `code_challenge`), so this is a defence-
+  //      in-depth guard for any future dev-only flow that mints a code without
+  //      PKCE: when `policy.pkceRequired` it is rejected; in `development` it is
+  //      allowed (with a warning) since PKCE is merely recommended there.
+  //   2. PKCE DOWNGRADE (RFC 9700 §2.1.1 / §4.5): a `code_verifier` presented
+  //      against a code that carries NO challenge must NEVER be silently
+  //      accepted — that is the downgrade attack. This is a HARD FLOOR enforced
+  //      in EVERY environment (including `development`): a verifier with no
+  //      bound challenge is always `invalid_grant`.
+  const hasBoundChallenge = authCode.codeChallenge.length > 0;
+  if (!hasBoundChallenge) {
+    // Downgrade defence first — a verifier with no bound challenge is rejected
+    // regardless of environment (the resolver can never relax this floor).
+    if (body.code_verifier.length > 0) {
+      await fastify.repositories.auditLogs.create({
+        userId: authCode.userId,
+        oauthClientId: client.id,
+        event: 'oauth.token.exchange.failure',
+        eventType: 'security',
+        success: false,
+        ipAddress: request.ip,
+        userAgent: request.headers['user-agent'] || null,
+        metadata: { error: 'pkce_downgrade: code_verifier presented without a bound challenge' },
+      });
+      throw new InvalidGrantError('Invalid or expired authorization code');
+    }
+    if (policy.pkceRequired) {
+      await fastify.repositories.auditLogs.create({
+        userId: authCode.userId,
+        oauthClientId: client.id,
+        event: 'oauth.token.exchange.failure',
+        eventType: 'token',
+        success: false,
+        ipAddress: request.ip,
+        userAgent: request.headers['user-agent'] || null,
+        metadata: { error: 'invalid_grant: PKCE is required for this environment' },
+      });
+      throw new InvalidGrantError('Invalid or expired authorization code');
+    }
+    fastify.log.warn(
+      { clientId: client.clientId, environment: policy.environment },
+      'authorization_code exchanged without PKCE (recommended in development, required otherwise)'
+    );
+  }
+
+  const pkceValid =
+    !hasBoundChallenge ||
+    fastify.pkceUtils.verifyCodeChallenge(body.code_verifier, authCode.codeChallenge);
   if (!pkceValid) {
     await fastify.repositories.auditLogs.create({
       userId: null,
@@ -356,6 +447,12 @@ async function handleAuthorizationCode(
 
   const scopeString = authCode.scopes.length > 0 ? authCode.scopes.join(' ') : undefined;
 
+  // Access-token lifespan under the environment policy (ADR-008 §5, #197):
+  // `short` (staging/production baseline) vs `long` (development convenience),
+  // mapped to concrete seconds in one place. Passed both as the signed `exp`
+  // override and the response `expires_in` so they always agree.
+  const accessTokenExpiresIn = accessTokenLifespanForPolicy(fastify, policy);
+
   const accessToken = await fastify.jwtUtils.signAccessToken({
     sub: user.id,
     email: user.email,
@@ -363,6 +460,7 @@ async function handleAuthorizationCode(
     clientId: client.clientId,
     scope: scopeString,
     aud: resolveAudience(client, effectiveResource),
+    expiresInOverride: accessTokenExpiresIn,
   });
 
   // OIDC Core §3.1.3.3: when the granted scope includes `openid`, the token
@@ -384,7 +482,6 @@ async function handleAuthorizationCode(
 
   const { token: refreshToken, tokenHash } = fastify.jwtUtils.generateRefreshToken();
 
-  const accessTokenExpiresIn = fastify.jwtUtils.getAccessTokenLifespan();
   const refreshTokenExpiresAt = Date.now() + fastify.jwtUtils.getRefreshTokenLifespan() * 1000;
 
   // Start a fresh refresh-token family. Every rotation (see
@@ -475,7 +572,7 @@ function resolveDisplayName(user: {
 async function handleClientCredentials(
   ctx: HandlerContext<TokenExchangeClientCredsBody>
 ): Promise<TokenExchangeResponse> {
-  const { fastify, request, client, body } = ctx;
+  const { fastify, request, client, body, policy } = ctx;
 
   if (!client.grantTypes.includes('client_credentials')) {
     await fastify.repositories.auditLogs.create({
@@ -572,14 +669,16 @@ async function handleClientCredentials(
     }
   }
 
+  // Access-token lifespan under the environment policy (ADR-008 §5, #197).
+  const accessTokenExpiresIn = accessTokenLifespanForPolicy(fastify, policy);
+
   const accessToken = await fastify.jwtUtils.signAccessToken({
     sub: client.clientId,
     clientId: client.clientId,
     scope: scopeString,
     aud: resolveAudience(client, requestedResource),
+    expiresInOverride: accessTokenExpiresIn,
   });
-
-  const accessTokenExpiresIn = fastify.jwtUtils.getAccessTokenLifespan();
 
   // Per-agent action audit (ADR-007 §2, #186). client_credentials has no
   // subject user and no on-behalf-of `act` chain — the agent acts as itself —
@@ -639,7 +738,19 @@ async function handleClientCredentials(
 async function handleRefreshToken(
   ctx: HandlerContext<TokenExchangeRefreshBody>
 ): Promise<TokenExchangeResponse> {
-  const { fastify, request, client, body } = ctx;
+  const { fastify, request, client, body, policy } = ctx;
+
+  // ADR-008 §5 (#197) refresh-token rotation. The profile knob
+  // `policy.refreshRotationRequired` is true for staging/production and false
+  // for development. QAuth ALWAYS rotates on every refresh — revoke-then-issue
+  // in a single transaction, with family-wide replay detection (see the
+  // rotation block below) — so the requirement is trivially SATISFIED in every
+  // environment, and `development` does NOT relax it below the implemented
+  // behaviour (rotation stays on; the dev knob would only permit a non-rotating
+  // implementation, which QAuth deliberately does not offer). The access-token
+  // LIFESPAN is the only refresh-path knob the environment actually moves
+  // (`policy.accessTokenLifespanTier`, applied below).
+  void policy.refreshRotationRequired;
 
   if (!client.grantTypes.includes('refresh_token')) {
     await fastify.repositories.auditLogs.create({
@@ -854,6 +965,9 @@ async function handleRefreshToken(
 
   const scopeString = grantedScopes.length > 0 ? grantedScopes.join(' ') : undefined;
 
+  // Access-token lifespan under the environment policy (ADR-008 §5, #197).
+  const accessTokenExpiresIn = accessTokenLifespanForPolicy(fastify, policy);
+
   const accessToken = await fastify.jwtUtils.signAccessToken({
     sub: user.id,
     email: user.email,
@@ -861,9 +975,8 @@ async function handleRefreshToken(
     clientId: client.clientId,
     scope: scopeString,
     aud: resolveAudience(client, effectiveResource),
+    expiresInOverride: accessTokenExpiresIn,
   });
-
-  const accessTokenExpiresIn = fastify.jwtUtils.getAccessTokenLifespan();
 
   await fastify.repositories.auditLogs.create({
     userId: user.id,
@@ -962,7 +1075,7 @@ function actDepth(act: ActClaim | undefined): number {
 async function handleTokenExchange(
   ctx: HandlerContext<TokenExchangeTokenExchangeBody>
 ): Promise<TokenExchangeResponse> {
-  const { fastify, request, client, body } = ctx;
+  const { fastify, request, client, body, policy } = ctx;
 
   const auditFailure = async (error: string, extra?: Record<string, unknown>): Promise<void> => {
     await fastify.repositories.auditLogs.create({
@@ -1190,7 +1303,11 @@ async function handleTokenExchange(
   // authority (and so it cannot be re-exchanged to extend it indefinitely).
   // `exp` is in seconds; verifyAccessToken already rejected an expired token,
   // so remaining is > 0 here, but we guard against the boundary defensively.
-  const configuredLifespan = fastify.jwtUtils.getAccessTokenLifespan();
+  // The configured ceiling is the environment-policy lifespan (ADR-008 §5,
+  // #197): a `development` delegated token may match the longer dev TTL, but is
+  // still clamped to the subject token's remaining lifetime (a HARD floor — the
+  // delegated token can never outlive the authority it was derived from).
+  const configuredLifespan = accessTokenLifespanForPolicy(fastify, policy);
   const subjectRemaining =
     subjectPayload.exp !== undefined
       ? subjectPayload.exp - Math.floor(Date.now() / 1000)

--- a/apps/auth-server/src/app/routes/ui/consent.ts
+++ b/apps/auth-server/src/app/routes/ui/consent.ts
@@ -18,8 +18,9 @@ import {
   isLoopbackRedirect,
   redirectHost,
 } from '../../helpers/consent';
+import { resolveEnvironmentPolicy } from '../../helpers/environment-policy';
 import { html, render, safe, safeUrl } from '../../helpers/html';
-import { buildRedirectUrl } from '../../helpers/oauth-redirect';
+import { buildRedirectUrl, isRedirectUriAllowedForPolicy } from '../../helpers/oauth-redirect';
 import { getOrCreateDefaultRealm } from '../../helpers/realm';
 import { highestAgentModeInScopes } from '../../helpers/scope-modes';
 import {
@@ -28,6 +29,7 @@ import {
   generateCsrfToken,
 } from '../../helpers/session-cookie';
 import { evaluateStepUp, isDangerousScope, parsePromptMode } from '../../helpers/step-up';
+import { markRelaxedCsp } from '../../plugins/security-headers';
 import { authorizeQuerySchema, resourceParamSchema } from '../../schemas/oauth';
 
 /**
@@ -348,6 +350,17 @@ export default async function (fastify: FastifyInstance) {
         throw new BadRequestError('redirect_uri not registered');
       }
 
+      // ADR-008 §5/§7 (#197): effective environment policy for this (client,
+      // realm). The consent screen is one of the FEW browser surfaces that
+      // unambiguously carries a `client_id`, so it is where a client-scoped T3
+      // relaxation (below) is safe to apply. The localhost redirect gate also
+      // applies on the render path so we never show a consent screen for a
+      // redirect the POST handler will (correctly) refuse.
+      const policy = resolveEnvironmentPolicy(client, realm);
+      if (!isRedirectUriAllowedForPolicy(query.redirect_uri, policy)) {
+        throw new BadRequestError('redirect_uri not permitted for this environment');
+      }
+
       // ADR-007 §2 (#184): fail fast on the render path too — don't show a
       // consent screen for an over-cap agent scope that the POST handler will
       // (correctly) refuse to mint a code for. Same deny-by-default gate;
@@ -387,9 +400,29 @@ export default async function (fastify: FastifyInstance) {
 
       reply.header('Content-Type', 'text/html; charset=utf-8');
       reply.header('Cache-Control', 'no-store');
-      // Clickjacking / MIME-sniffing / referrer hardening are now applied
-      // globally by the security-headers plugin (issue #113), including the
-      // strict nonce-based CSP that this page's inline <style> relies on.
+      // Clickjacking / MIME-sniffing / referrer hardening are applied globally
+      // by the security-headers plugin (issue #113), including the strict
+      // nonce-based CSP that this page's inline <style> relies on.
+      //
+      // ADR-008 §5 (#197) T3 relaxation, CLIENT-SCOPED. T3 security headers /
+      // CSRF / secure cookies are largely GLOBAL controls with NO client in
+      // scope, so they DEFAULT TO STRICT (production) everywhere — see the
+      // security-headers plugin and session-cookie helper, which stay strict.
+      // The consent screen is the rare browser surface that unambiguously
+      // carries a `client_id`, so it is the one place we may safely relax the
+      // CSP for a `development` client: it permits `'unsafe-inline'` styles so a
+      // developer iterating on this page is not forced to nonce every style.
+      // `t3SecurityEnforced` is true for staging/production (and fail-safe for
+      // an unset client/realm), so this NEVER loosens a hardened deployment.
+      //
+      // The actual header swap is owned by the GLOBAL security-headers plugin's
+      // onSend (the one place that already overrides helmet's CSP, for Swagger):
+      // here we only MARK the reply. That keeps the CSP-override logic in a
+      // single location and means this route needs no onSend of its own (so the
+      // unit-test harness, which mocks a bare `fastify`, is unaffected).
+      if (!policy.t3SecurityEnforced) {
+        markRelaxedCsp(reply);
+      }
 
       return reply.send(
         consentPage({
@@ -508,6 +541,13 @@ export default async function (fastify: FastifyInstance) {
         throw new BadRequestError('redirect_uri not registered');
       }
 
+      // ADR-008 §5/§7 (#197): effective environment policy for this (client,
+      // realm). Gates the localhost redirect and the automatic step-up below.
+      const policy = resolveEnvironmentPolicy(client, realm);
+      if (!isRedirectUriAllowedForPolicy(body.redirect_uri, policy)) {
+        throw new BadRequestError('redirect_uri not permitted for this environment');
+      }
+
       // Deny path: redirect with error=access_denied, state preserved
       // (RFC 6749 §4.1.2.1).
       if (body.decision === 'deny') {
@@ -594,6 +634,10 @@ export default async function (fastify: FastifyInstance) {
         authTimeMs: session.createdAt,
         nowMs: Date.now(),
         freshAuthWindowMs: STEP_UP_FRESH_AUTH_WINDOW_MS,
+        // ADR-008 §5 (#197): relax the automatic dangerous-scope fresh-login on
+        // the mint path for a development client; explicit prompt/max_age still
+        // force step-up in every environment.
+        enforceDangerousStepUp: policy.agentStepUpEnforced,
       });
       if (stepUp.requiresFreshLogin) {
         await fastify.repositories.auditLogs.create({

--- a/libs/server/config/src/lib/schemas/auth.ts
+++ b/libs/server/config/src/lib/schemas/auth.ts
@@ -100,22 +100,44 @@ export const authEnvSchema = z.object({
   LOGOUT_RATE_WINDOW: z.coerce.number().int().min(1).default(60),
 
   /**
-   * Maximum authorize attempts per window
+   * Maximum authorize attempts per window. This is the `strict` rate-limit tier
+   * cap (ADR-008 §5, issue #197), applied to `production`-profile realms.
    */
   AUTHORIZE_RATE_LIMIT: z.coerce.number().int().min(1).default(60),
 
   /**
-   * Authorize rate limit window in seconds (default: 60 = 1 minute)
+   * Maximum authorize attempts per window for the `lenient` rate-limit tier
+   * (ADR-008 §5, issue #197) — `development` / `staging` realms. Defaults
+   * higher than the strict cap so local iteration and load testing are not
+   * throttled. Selected per-request via `resolveRateLimitMax` only when the
+   * realm's effective profile is non-production; an unset realm resolves to
+   * `production` and therefore gets the strict cap (fail-safe).
+   */
+  AUTHORIZE_RATE_LIMIT_LENIENT: z.coerce.number().int().min(1).default(600),
+
+  /**
+   * Authorize rate limit window in seconds (default: 60 = 1 minute). Shared by
+   * both tiers — environment moves the cap, not the window (ADR-008 §5).
    */
   AUTHORIZE_RATE_WINDOW: z.coerce.number().int().min(1).default(60),
 
   /**
-   * Maximum token exchange attempts per window
+   * Maximum token exchange attempts per window. This is the `strict`
+   * rate-limit tier cap (ADR-008 §5, issue #197), applied to `production`.
    */
   TOKEN_RATE_LIMIT: z.coerce.number().int().min(1).default(30),
 
   /**
-   * Token rate limit window in seconds (default: 60 = 1 minute)
+   * Maximum token exchange attempts per window for the `lenient` tier
+   * (ADR-008 §5, issue #197) — `development` / `staging` realms. See
+   * AUTHORIZE_RATE_LIMIT_LENIENT for the selection rationale (fail-safe to
+   * the strict cap for an unset/production realm).
+   */
+  TOKEN_RATE_LIMIT_LENIENT: z.coerce.number().int().min(1).default(300),
+
+  /**
+   * Token rate limit window in seconds (default: 60 = 1 minute). Shared by
+   * both tiers.
    */
   TOKEN_RATE_WINDOW: z.coerce.number().int().min(1).default(60),
 

--- a/libs/server/config/src/lib/schemas/jwt.ts
+++ b/libs/server/config/src/lib/schemas/jwt.ts
@@ -89,9 +89,29 @@ export const jwtEnvSchema = z
     JWT_ISSUER: z.url('JWT issuer must be a valid URL'),
 
     /**
-     * Access token expiration in seconds (default: 900 = 15 minutes)
+     * Access token expiration in seconds (default: 900 = 15 minutes).
+     *
+     * This is the `short` tier baseline used by the `staging` and `production`
+     * environment profiles (ADR-008 §5, issue #197). The `development` profile
+     * uses {@link DEV_ACCESS_TOKEN_LIFESPAN} instead so local tokens can be
+     * long-lived for convenience without ever loosening production.
      */
     ACCESS_TOKEN_LIFESPAN: z.coerce.number().int().positive().default(900),
+
+    /**
+     * Access token expiration in seconds for the `development` environment
+     * profile only (ADR-008 §5, issue #197 — the `long` lifespan tier). Default
+     * 28800 = 8 hours: a comfortable local-dev session that never applies to a
+     * `staging`/`production` client (their effective tier is always `short`,
+     * resolved via `resolveEnvironmentPolicy`). FAIL-SAFE: a client whose
+     * environment is unset resolves to `production` and therefore NEVER receives
+     * this longer lifespan.
+     */
+    DEV_ACCESS_TOKEN_LIFESPAN: z.coerce
+      .number()
+      .int()
+      .positive()
+      .default(8 * 60 * 60),
 
     /**
      * Refresh token expiration in seconds (default: 604800 = 7 days)
@@ -132,6 +152,7 @@ export const jwtEnvSchema = z
       JWT_PUBLIC_KEY: publicKey,
       JWT_ISSUER: data.JWT_ISSUER,
       ACCESS_TOKEN_LIFESPAN: data.ACCESS_TOKEN_LIFESPAN,
+      DEV_ACCESS_TOKEN_LIFESPAN: data.DEV_ACCESS_TOKEN_LIFESPAN,
       REFRESH_TOKEN_LIFESPAN: data.REFRESH_TOKEN_LIFESPAN,
     };
   });


### PR DESCRIPTION
## What

Wires the T3 hardening as the `production` environment **profile** (ADR-008 §5/§7), building on the #196 foundation. Every policy checkpoint where a client + realm are in scope now consults the single `resolveEnvironmentPolicy` resolver instead of re-deriving rules — mirroring `enforceAgentScopeCap` — so `production` enforces the hardened bundle and `development` relaxes only the ADR-sanctioned knobs.

## Checkpoints wired

- **Token TTL + refresh rotation** (`routes/oauth/token.ts`): `accessTokenLifespanTier` (long dev / short prod) mapped to concrete seconds in ONE place; refresh rotation always-on.
- **PKCE** (`pkceRequired`): required for staging/production, recommended for development; PKCE-downgrade defence is a hard floor everywhere.
- **localhost redirect URIs** (`localhostRedirectAllowed`): `http://localhost` allowed only for development; https-only otherwise.
- **Rate limits** (`rateLimitTier`): lenient/strict mapper + `*_LENIENT` config knobs.
- **Agent step-up** (`agentStepUpEnforced`): automatic dangerous-scope fresh-login relaxed for development; explicit `prompt`/`max_age` always honoured.
- **T3 headers / CSRF / secure cookies** (`t3SecurityEnforced`): largely **global** controls, so they **default to strict (production) everywhere**. The only client-scoped relaxation is the CSP on `/ui/consent` (carries a `client_id`) for a development client; session-cookie `Secure` stays strict because `/ui/login` has no client in scope. Documented in code.

## Hard floors (never relax, any env)
Client secrets hashed + verified, RFC 8707 audience binding, signature/issuer validation, confidential-only grants, PKCE-downgrade rejection. None are profile fields — the resolver cannot disable them; tests assert a development policy keeps these floors.

## Testing
- `nx test auth-server` — 493 passed (37 new). `nx lint`/`build` + `server-config` typecheck — green.

## Known follow-up
Rate-limit tier is wired as a mapper + config; applying it to the live route `config.rateLimit` (via async `max`) is a small follow-up — `@fastify/rate-limit` runs before the client is authenticated.

Closes #197

https://claude.ai/code/session_01SGm2UmswGGEXHyvuw57ubh
