### PR TITLE
feat(oauth): apply environment rate-limit tier to /oauth/token and /oauth/authorize (ADR-008)

### DIFF
--- a/apps/auth-server/src/app/helpers/realm-rate-limit.test.ts
+++ b/apps/auth-server/src/app/helpers/realm-rate-limit.test.ts
@@ -1,0 +1,81 @@
+import type { FastifyInstance } from 'fastify';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// The resolver pulls in `./realm`, which loads `../../config/env` (validated at
+// import time). Mock it so the suite doesn't require a full env — only
+// DEFAULT_REALM_NAME is read by getOrCreateDefaultRealm.
+vi.mock('../../config/env', () => ({ env: { DEFAULT_REALM_NAME: 'default' } }));
+
+import {
+  REALM_TIER_CACHE_TTL_MS,
+  resetRealmRateLimitTierCache,
+  resolveRealmRateLimitMax,
+} from './realm-rate-limit';
+
+const CONFIG = { lenientMax: 300, strictMax: 30 } as const;
+
+/**
+ * Build a minimal FastifyInstance whose default-realm lookup returns a realm
+ * with the given `maxEnvironmentLaxity`. The `findByName` spy lets tests assert
+ * how often the database was consulted (cache behaviour).
+ */
+function fastifyWithRealmCeiling(maxEnvironmentLaxity: string | null) {
+  const findByName = vi
+    .fn()
+    .mockResolvedValue({ id: 'realm-1', name: 'default', maxEnvironmentLaxity });
+  return {
+    instance: { repositories: { realms: { findByName } } } as unknown as FastifyInstance,
+    findByName,
+  };
+}
+
+describe('resolveRealmRateLimitMax', () => {
+  beforeEach(() => {
+    resetRealmRateLimitTierCache();
+  });
+
+  it('returns the strict cap when the realm ceiling is production', async () => {
+    const { instance } = fastifyWithRealmCeiling('production');
+    await expect(resolveRealmRateLimitMax(instance, CONFIG, 0)).resolves.toBe(CONFIG.strictMax);
+  });
+
+  it('returns the lenient cap when the realm ceiling is development', async () => {
+    const { instance } = fastifyWithRealmCeiling('development');
+    await expect(resolveRealmRateLimitMax(instance, CONFIG, 0)).resolves.toBe(CONFIG.lenientMax);
+  });
+
+  it('keeps strict (production-grade) limits for staging', async () => {
+    // ADR-008 §5: staging shares the lenient tier (load testing), production is strict.
+    const { instance } = fastifyWithRealmCeiling('staging');
+    await expect(resolveRealmRateLimitMax(instance, CONFIG, 0)).resolves.toBe(CONFIG.lenientMax);
+  });
+
+  it('fails safe to the strict cap when the realm ceiling is unset/invalid', async () => {
+    const { instance } = fastifyWithRealmCeiling(null);
+    await expect(resolveRealmRateLimitMax(instance, CONFIG, 0)).resolves.toBe(CONFIG.strictMax);
+  });
+
+  it('fails safe to the strict cap when the realm lookup throws', async () => {
+    const findByName = vi.fn().mockRejectedValue(new Error('db down'));
+    const instance = { repositories: { realms: { findByName } } } as unknown as FastifyInstance;
+    await expect(resolveRealmRateLimitMax(instance, CONFIG, 0)).resolves.toBe(CONFIG.strictMax);
+  });
+
+  it('caches the resolved tier within the TTL and re-reads after it expires', async () => {
+    const { instance, findByName } = fastifyWithRealmCeiling('development');
+
+    // First call reads the realm.
+    expect(await resolveRealmRateLimitMax(instance, CONFIG, 0)).toBe(CONFIG.lenientMax);
+    // Second call within the TTL is served from cache (no extra DB read).
+    expect(await resolveRealmRateLimitMax(instance, CONFIG, REALM_TIER_CACHE_TTL_MS - 1)).toBe(
+      CONFIG.lenientMax
+    );
+    expect(findByName).toHaveBeenCalledTimes(1);
+
+    // Past the TTL the realm is re-read.
+    expect(await resolveRealmRateLimitMax(instance, CONFIG, REALM_TIER_CACHE_TTL_MS)).toBe(
+      CONFIG.lenientMax
+    );
+    expect(findByName).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/auth-server/src/app/helpers/realm-rate-limit.ts
+++ b/apps/auth-server/src/app/helpers/realm-rate-limit.ts
@@ -1,0 +1,64 @@
+import type { FastifyInstance } from 'fastify';
+
+import {
+  ENVIRONMENT_PROFILES,
+  parseEnvironment,
+  type RateLimitTier,
+  type RateLimitTierConfig,
+  resolveRateLimitMax,
+} from './environment-policy';
+import { getOrCreateDefaultRealm } from './realm';
+
+/**
+ * How long a resolved realm rate-limit tier is cached in-process before the
+ * default realm's `max_environment_laxity` is re-read.
+ *
+ * `@fastify/rate-limit` evaluates the `max` callback on EVERY request to a
+ * rate-limited route, so reading the realm from the database each time would
+ * add a round-trip to hot OAuth endpoints (`/oauth/token`, `/oauth/authorize`).
+ * A short TTL keeps the cost negligible while still picking up an operator's
+ * ceiling change within seconds. Module-scoped because the default realm is
+ * process-wide.
+ */
+export const REALM_TIER_CACHE_TTL_MS = 30_000;
+
+let cachedTier: { tier: RateLimitTier; expiresAt: number } | null = null;
+
+/** Test-only: clear the in-process realm tier cache. */
+export function resetRealmRateLimitTierCache(): void {
+  cachedTier = null;
+}
+
+/**
+ * Resolve the per-window request cap for a rate-limited route from the default
+ * realm's environment ceiling (ADR-008 §5, issue #209).
+ *
+ * `@fastify/rate-limit` evaluates `max` BEFORE the route handler runs — i.e.
+ * before the specific client is authenticated — so a per-client policy is not
+ * available here. The honest seam is realm-level: a `production` realm forces
+ * the strict cap regardless of any client, while a `development` / `staging`
+ * realm ceiling permits the lenient cap (e.g. for load testing).
+ *
+ * Fail-safe: any error (database unavailable, etc.) returns the strict cap, so
+ * a misconfiguration or outage never relaxes the limit.
+ *
+ * @param now Injectable clock (milliseconds) for deterministic tests; defaults
+ * to the wall clock.
+ */
+export async function resolveRealmRateLimitMax(
+  fastify: FastifyInstance,
+  config: RateLimitTierConfig,
+  now: number = Date.now()
+): Promise<number> {
+  try {
+    if (!cachedTier || now >= cachedTier.expiresAt) {
+      const realm = await getOrCreateDefaultRealm(fastify);
+      const environment = parseEnvironment(realm.maxEnvironmentLaxity);
+      const tier = ENVIRONMENT_PROFILES[environment].rateLimitTier;
+      cachedTier = { tier, expiresAt: now + REALM_TIER_CACHE_TTL_MS };
+    }
+    return resolveRateLimitMax(cachedTier.tier, config);
+  } catch {
+    return config.strictMax;
+  }
+}

--- a/apps/auth-server/src/app/routes/oauth/authorize.ts
+++ b/apps/auth-server/src/app/routes/oauth/authorize.ts
@@ -14,6 +14,7 @@ import { resolveEnvironmentPolicy } from '../../helpers/environment-policy';
 import { getOrCreateSystemClient } from '../../helpers/oauth-client';
 import { buildRedirectUrl, isRedirectUriAllowedForPolicy } from '../../helpers/oauth-redirect';
 import { getOrCreateDefaultRealm } from '../../helpers/realm';
+import { resolveRealmRateLimitMax } from '../../helpers/realm-rate-limit';
 import {
   evaluateStepUp,
   isDangerousScope,
@@ -70,7 +71,15 @@ export default async function (fastify: FastifyInstance) {
       },
       config: {
         rateLimit: {
-          max: env.AUTHORIZE_RATE_LIMIT,
+          // Environment-aware cap (ADR-008 §5, #209): a production realm ceiling
+          // forces the strict cap; a development/staging ceiling permits the
+          // lenient cap. Resolved at the realm level because rate limiting runs
+          // before the client is authenticated. Fail-safe to strict.
+          max: () =>
+            resolveRealmRateLimitMax(fastify, {
+              lenientMax: env.AUTHORIZE_RATE_LIMIT_LENIENT,
+              strictMax: env.AUTHORIZE_RATE_LIMIT,
+            }),
           timeWindow: env.AUTHORIZE_RATE_WINDOW * 1000,
           keyGenerator: (req) => req.ip || 'unknown',
         },

--- a/apps/auth-server/src/app/routes/oauth/token.ts
+++ b/apps/auth-server/src/app/routes/oauth/token.ts
@@ -34,6 +34,7 @@ import {
   resolveEnvironmentPolicy,
 } from '../../helpers/environment-policy';
 import { getOrCreateDefaultRealm } from '../../helpers/realm';
+import { resolveRealmRateLimitMax } from '../../helpers/realm-rate-limit';
 import { highestAgentModeInScopes } from '../../helpers/scope-modes';
 import { ensureMinimumResponseTime } from '../../helpers/timing';
 import {
@@ -81,7 +82,15 @@ export default async function (fastify: FastifyInstance) {
       },
       config: {
         rateLimit: {
-          max: env.TOKEN_RATE_LIMIT,
+          // Environment-aware cap (ADR-008 §5, #209): a production realm ceiling
+          // forces the strict cap; a development/staging ceiling permits the
+          // lenient cap. Resolved at the realm level because rate limiting runs
+          // before the client is authenticated. Fail-safe to strict.
+          max: () =>
+            resolveRealmRateLimitMax(fastify, {
+              lenientMax: env.TOKEN_RATE_LIMIT_LENIENT,
+              strictMax: env.TOKEN_RATE_LIMIT,
+            }),
           timeWindow: env.TOKEN_RATE_WINDOW * 1000,
           keyGenerator: (req) => req.ip || 'unknown',
         },


### PR DESCRIPTION
## Summary

Completes the deferred follow-up from #197 (PR #206): the ADR-008 environment policy's `rateLimitTier` is now applied to the **live** route rate limits, not just available as a mapper. Closes #209.

`/oauth/token` and `/oauth/authorize` resolve their per-window cap from the **default realm's `max_environment_laxity` ceiling**:
- `production` realm ceiling → **strict** cap (`TOKEN_RATE_LIMIT` / `AUTHORIZE_RATE_LIMIT`)
- `development` / `staging` ceiling → **lenient** cap (`*_RATE_LIMIT_LENIENT`)

## Why realm-level

`@fastify/rate-limit` evaluates `max` **before** the route handler runs — i.e. before the client is authenticated — so a per-client policy isn't available at limit-check time. The honest seam is the realm ceiling, exactly as ADR-008 §5/§7 anticipated.

## Implementation

- New `helpers/realm-rate-limit.ts` → `resolveRealmRateLimitMax(fastify, {lenientMax, strictMax})`:
  - resolves the default realm's ceiling → tier via the existing `ENVIRONMENT_PROFILES` / `resolveRateLimitMax`,
  - **short in-process TTL cache** (`30s`) so hot endpoints don't hit the DB on every request,
  - **fail-safe to the strict cap** on any error (DB down, unset/invalid ceiling).
- Wired as an async `max` on the `/oauth/token` and `/oauth/authorize` route configs.

## Testing

- `nx test auth-server` — green (new `realm-rate-limit.test.ts`: strict for production, lenient for dev/staging, fail-safe to strict on unset/throw, TTL cache hit + re-read after expiry).
- `nx lint auth-server` (0 errors) and `nx build auth-server` — green.

Closes #209

https://claude.ai/code/session_01SGm2UmswGGEXHyvuw57ubh