### PR TITLE
feat(oauth): pre-launch security hardening

### DIFF
--- a/apps/auth-server/src/app/app.ts
+++ b/apps/auth-server/src/app/app.ts
@@ -12,6 +12,7 @@ import { pkcePlugin } from '@qauth-labs/fastify-plugin-pkce';
 import type { FastifyInstance } from 'fastify';
 
 import { env } from '../config/env';
+import { isJtiRevoked } from './helpers/token-revocation';
 import errorHandler from './plugins/error-handler';
 import { metricsPlugin } from './plugins/metrics';
 import { rateLimitPlugin } from './plugins/rate-limit';
@@ -107,6 +108,11 @@ export async function app(fastify: FastifyInstance, opts: object) {
     issuer: env.JWT_ISSUER,
     accessTokenLifespan: env.ACCESS_TOKEN_LIFESPAN,
     refreshTokenLifespan: env.REFRESH_TOKEN_LIFESPAN,
+    // RFC 7009 revocation: the shared `requireJwt` preHandler consults this
+    // Redis-backed denylist after verification so a revoked access token is
+    // rejected everywhere it is used as a bearer credential. Resolved lazily
+    // via the `fastify.redis` decorator (cache plugin registered above).
+    isTokenRevoked: (jti) => isJtiRevoked(fastify, jti),
   });
 
   await fastify.register(rateLimitPlugin);

--- a/apps/auth-server/src/app/constants/redis-keys.ts
+++ b/apps/auth-server/src/app/constants/redis-keys.ts
@@ -10,4 +10,10 @@ export const REDIS_KEYS = {
   FAILED_LOGIN_ATTEMPTS: (identifier: string) => `failed-login:attempts:${identifier}`,
   /** Active failed-login lockout marker, keyed per identifier (#115) */
   FAILED_LOGIN_LOCKOUT: (identifier: string) => `failed-login:lockout:${identifier}`,
+  /**
+   * Access-token revocation denylist entry, keyed by the token's `jti`
+   * (RFC 7009). Stored with a TTL equal to the token's remaining lifetime so
+   * it self-evicts once the token would have expired.
+   */
+  REVOKED_ACCESS_TOKEN: (jti: string) => `revoked-access-token:${jti}`,
 } as const;

--- a/apps/auth-server/src/app/helpers/discovery.ts
+++ b/apps/auth-server/src/app/helpers/discovery.ts
@@ -60,6 +60,7 @@ export function buildAuthorizationServerMetadata(
     authorization_endpoint: `${base}/oauth/authorize`,
     token_endpoint: `${base}/oauth/token`,
     introspection_endpoint: `${base}/oauth/introspect`,
+    revocation_endpoint: `${base}/oauth/revoke`,
     userinfo_endpoint: `${base}/oauth/userinfo`,
     // DCR (#149) lives on a sibling branch; advertise the URL so discovery
     // stays stable and clients can retry once the endpoint ships.
@@ -80,6 +81,7 @@ export function buildAuthorizationServerMetadata(
     code_challenge_methods_supported: ['S256'],
     token_endpoint_auth_methods_supported: ['client_secret_basic', 'client_secret_post', 'none'],
     introspection_endpoint_auth_methods_supported: ['client_secret_basic', 'client_secret_post'],
+    revocation_endpoint_auth_methods_supported: ['client_secret_basic', 'client_secret_post'],
     scopes_supported: Array.from(input.scopesSupported ?? DEFAULT_SCOPES_SUPPORTED),
     // Public subject identifiers — no pairwise salts today.
     subject_types_supported: ['public'],

--- a/apps/auth-server/src/app/helpers/session-cookie.ts
+++ b/apps/auth-server/src/app/helpers/session-cookie.ts
@@ -31,6 +31,13 @@ export interface BrowserSessionData {
   createdAt: number;
   /** Monotonic nonce for CSRF double-submit cookie (rotated on consent POST). */
   csrfToken?: string;
+  /**
+   * The exact scope set rendered on the most recent consent screen for a given
+   * client, keyed by `client_id`. The consent POST handler grants ONLY these
+   * scopes — the hidden `scope` form field is attacker-controllable, so the
+   * granted set is bound to what the user actually saw, not to what is POSTed.
+   */
+  consentScopes?: Record<string, string[]>;
   [key: string]: unknown;
 }
 
@@ -165,4 +172,66 @@ export function csrfTokensEqual(a: string | undefined, b: string | undefined): b
   const bb = Buffer.from(b);
   if (ab.length !== bb.length) return false;
   return timingSafeEqual(ab, bb);
+}
+
+/**
+ * Cookie carrying the CSRF token for the PRE-authentication login form.
+ *
+ * The login page has no session yet, so the consent screen's session-bound
+ * double-submit pattern cannot be reused. Instead we use a SIGNED double-submit
+ * cookie: this `__Host-`-prefixed cookie holds the HMAC-signed CSRF token, and
+ * the form's hidden field holds the same raw token. On POST the server verifies
+ * the cookie signature (so an attacker who cannot read the victim's cookie
+ * cannot forge a matching pair) and timing-compares the cookie token against
+ * the submitted one. This defends against login CSRF (forced login into an
+ * attacker-controlled account) without any server-side state.
+ */
+export const LOGIN_CSRF_COOKIE_NAME = '__Host-qauth_login_csrf';
+
+/**
+ * Emit the signed login-CSRF cookie. `Secure` follows the same global default
+ * as the session cookie (`env.SESSION_COOKIE_SECURE`); `__Host-` requires it in
+ * production. SameSite=Lax + HttpOnly mirror the session cookie. The value is
+ * `<token>.<hmac>` using the same secret/scheme as the session id.
+ */
+export function setLoginCsrfCookie(reply: FastifyReply, token: string): void {
+  const attrs = [
+    `${LOGIN_CSRF_COOKIE_NAME}=${token}${SEPARATOR}${hmac(token)}`,
+    'Path=/',
+    'HttpOnly',
+    'SameSite=Lax',
+    `Max-Age=${env.SESSION_COOKIE_TTL}`,
+  ];
+  if (env.SESSION_COOKIE_SECURE) attrs.push('Secure');
+  reply.header('Set-Cookie', attrs.join('; '));
+}
+
+/**
+ * Clear the login-CSRF cookie (burned after a successful login POST).
+ */
+export function clearLoginCsrfCookie(reply: FastifyReply): void {
+  const attrs = [`${LOGIN_CSRF_COOKIE_NAME}=`, 'Path=/', 'HttpOnly', 'SameSite=Lax', 'Max-Age=0'];
+  if (env.SESSION_COOKIE_SECURE) attrs.push('Secure');
+  reply.header('Set-Cookie', attrs.join('; '));
+}
+
+/**
+ * Verify the signed login-CSRF cookie value and return the embedded token if
+ * the signature is valid, otherwise null. Same `<token>.<hmac>` scheme +
+ * timing-safe verification as {@link verifySignedSessionId}.
+ */
+export function verifyLoginCsrfCookie(cookieValue: string | undefined | null): string | null {
+  if (!cookieValue) return null;
+  const idx = cookieValue.lastIndexOf(SEPARATOR);
+  if (idx <= 0 || idx === cookieValue.length - 1) return null;
+
+  const token = cookieValue.slice(0, idx);
+  const providedSig = cookieValue.slice(idx + 1);
+  const expectedSig = hmac(token);
+
+  const providedBuf = Buffer.from(providedSig, 'base64url');
+  const expectedBuf = Buffer.from(expectedSig, 'base64url');
+  if (providedBuf.length !== expectedBuf.length) return null;
+  if (!timingSafeEqual(providedBuf, expectedBuf)) return null;
+  return token;
 }

--- a/apps/auth-server/src/app/helpers/token-revocation.ts
+++ b/apps/auth-server/src/app/helpers/token-revocation.ts
@@ -1,0 +1,57 @@
+import type { FastifyInstance } from 'fastify';
+
+import { REDIS_KEYS } from '../constants/redis-keys';
+
+/**
+ * Access-token revocation denylist (RFC 7009).
+ *
+ * Access tokens are stateless EdDSA JWTs, so they cannot be invalidated by
+ * deleting a row — they remain cryptographically valid until `exp`. To support
+ * RFC 7009 revocation we keep a denylist of revoked `jti` values in Redis,
+ * each with a TTL equal to the token's remaining lifetime. Once the token would
+ * have expired anyway the key auto-evicts, so the denylist never grows
+ * unbounded. The blast radius of an un-revoked token is therefore bounded by
+ * the (short) access-token lifespan even before this denylist is consulted.
+ *
+ * This lives in the auth-server layer (not @qauth-labs/server-jwt) deliberately:
+ * the JWT lib stays pure and side-effect free; the store dependency belongs to
+ * the application. Both helpers fail SAFE — see the per-function notes.
+ */
+
+/**
+ * Add an access token's `jti` to the revocation denylist.
+ *
+ * @param jti - The `jti` claim of the access token being revoked.
+ * @param ttlSeconds - Remaining lifetime of the token (`exp - now`). The key is
+ *   stored with this TTL so it self-evicts once the token expires. Values <= 0
+ *   are a no-op: a token that has already expired is inert and never needs a
+ *   denylist entry.
+ */
+export async function revokeJti(
+  fastify: FastifyInstance,
+  jti: string,
+  ttlSeconds: number
+): Promise<void> {
+  if (!jti || ttlSeconds <= 0) return;
+  // SET with EX (ioredis `setex`) — value is a marker; only key presence + TTL
+  // matter. Rounded up so a sub-second remaining lifetime still denylists.
+  await fastify.redis.setex(REDIS_KEYS.REVOKED_ACCESS_TOKEN(jti), Math.ceil(ttlSeconds), '1');
+}
+
+/**
+ * Whether an access token's `jti` is on the revocation denylist.
+ *
+ * FAIL-SAFE: a token with no `jti` (legacy, minted before the claim existed)
+ * cannot be individually revoked, so it is treated as NOT revoked — its bounded
+ * lifespan is the compensating control. A Redis failure is propagated to the
+ * caller rather than silently treated as "not revoked"; callers on security-
+ * sensitive paths decide how to fail.
+ */
+export async function isJtiRevoked(
+  fastify: FastifyInstance,
+  jti: string | undefined
+): Promise<boolean> {
+  if (!jti) return false;
+  const hit = await fastify.redis.exists(REDIS_KEYS.REVOKED_ACCESS_TOKEN(jti));
+  return hit === 1;
+}

--- a/apps/auth-server/src/app/plugins/error-handler.test.ts
+++ b/apps/auth-server/src/app/plugins/error-handler.test.ts
@@ -3,6 +3,7 @@ import {
   InvalidClientError,
   JWTExpiredError,
   JWTInvalidError,
+  UniqueConstraintError,
 } from '@qauth-labs/shared-errors';
 import type { FastifyInstance } from 'fastify';
 import Fastify from 'fastify';
@@ -28,6 +29,12 @@ async function buildTestApp(): Promise<FastifyInstance> {
 
   app.post('/test-forbidden', async () => {
     throw new ForbiddenError('Static API keys are disabled for production clients.');
+  });
+
+  app.post('/test-unique-constraint', async () => {
+    // The DB layer surfaces the offending constraint name; the handler must NOT
+    // leak it (account-enumeration oracle, e.g. duplicate-email registration).
+    throw new UniqueConstraintError('users_email_realm_key');
   });
 
   return app;
@@ -126,6 +133,31 @@ describe('error-handler plugin', () => {
       code: 'INVALID_CLIENT',
       statusCode: 401,
     });
+
+    await app.close();
+  });
+
+  it('does not leak the constraint name on UniqueConstraintError (enumeration defence)', async () => {
+    const app = await buildTestApp();
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/test-unique-constraint',
+    });
+
+    expect(response.statusCode).toBe(409);
+
+    const json = response.json();
+    // Code + status preserved so legitimate clients can branch on the conflict.
+    expect(json).toMatchObject({
+      error: 'Resource already exists',
+      code: 'UNIQUE_CONSTRAINT_VIOLATION',
+      statusCode: 409,
+    });
+    // The constraint name must NOT appear anywhere in the response — not as a
+    // dedicated field, and not embedded in the generic error message.
+    expect(json.constraint).toBeUndefined();
+    expect(JSON.stringify(json)).not.toContain('users_email_realm_key');
 
     await app.close();
   });

--- a/apps/auth-server/src/app/plugins/error-handler.ts
+++ b/apps/auth-server/src/app/plugins/error-handler.ts
@@ -29,7 +29,6 @@ interface ErrorResponse {
   code?: string;
   statusCode: number;
   feedback?: string[];
-  constraint?: string;
   retryAfter?: number;
 }
 
@@ -121,13 +120,22 @@ export default fp(async function (fastify: FastifyInstance) {
         return reply.code(error.statusCode).send(response);
       }
 
-      // Handle UniqueConstraintError (includes constraint)
+      // Handle UniqueConstraintError. The offending constraint name is an
+      // account-enumeration oracle (a duplicate-email registration would
+      // otherwise reveal that the email is already registered), so it is logged
+      // for operators but NEVER returned to the caller. The wire `error`
+      // message is genericised for the same reason — `error.message` embeds the
+      // constraint name. `code` + `statusCode` are preserved so legitimate
+      // clients can still branch on the conflict.
       if (error instanceof UniqueConstraintError) {
+        fastify.log.warn(
+          { constraint: error.constraint, url: request.url },
+          'Unique constraint violation'
+        );
         const response: ErrorResponse = {
-          error: error.message,
+          error: 'Resource already exists',
           code: error.code,
           statusCode: error.statusCode,
-          constraint: error.constraint,
         };
         return reply.code(error.statusCode).send(response);
       }

--- a/apps/auth-server/src/app/routes/oauth/authorize.test.ts
+++ b/apps/auth-server/src/app/routes/oauth/authorize.test.ts
@@ -98,6 +98,7 @@ function makeFastify() {
     jwtUtils: {
       extractFromHeader: vi.fn(),
       verifyAccessToken: vi.fn(),
+      getIssuer: () => 'https://auth.example.com',
     },
     sessionUtils: {
       getSession: vi.fn(),
@@ -390,7 +391,11 @@ describe('GET /oauth/authorize — CIMD (Client ID Metadata Documents)', () => {
         authorizationCodes: { create: vi.fn().mockResolvedValue({ id: 'code-1' }) },
         auditLogs: { create: vi.fn().mockResolvedValue(undefined) },
       },
-      jwtUtils: { extractFromHeader: vi.fn(), verifyAccessToken: vi.fn() },
+      jwtUtils: {
+        extractFromHeader: vi.fn(),
+        verifyAccessToken: vi.fn(),
+        getIssuer: () => 'https://auth.example.com',
+      },
       sessionUtils: { getSession: vi.fn() },
       log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
     };

--- a/apps/auth-server/src/app/routes/oauth/authorize.ts
+++ b/apps/auth-server/src/app/routes/oauth/authorize.ts
@@ -247,6 +247,8 @@ export default async function (fastify: FastifyInstance) {
           const systemClient = await getOrCreateSystemClient(realm.id, fastify);
           const payload = await fastify.jwtUtils.verifyAccessToken(bearer as string, {
             audience: resolveAudience(systemClient),
+            // RFC 9700 mix-up defence: only accept a token this AS issued.
+            issuer: fastify.jwtUtils.getIssuer(),
           });
           userId = payload.sub;
         } catch {

--- a/apps/auth-server/src/app/routes/oauth/introspect.test.ts
+++ b/apps/auth-server/src/app/routes/oauth/introspect.test.ts
@@ -64,6 +64,12 @@ function createFastifyStub() {
     },
     jwtUtils: {
       verifyAccessToken: vi.fn(),
+      getIssuer: () => 'https://auth.example.com',
+    },
+    redis: {
+      // Default: nothing is revoked. Individual tests override `exists`.
+      exists: vi.fn().mockResolvedValue(0),
+      setex: vi.fn().mockResolvedValue('OK'),
     },
     log: {
       debug: vi.fn(),
@@ -156,6 +162,47 @@ describe('POST /oauth/introspect route', () => {
     // `tokenSub` is only added when `sub` is not UUID-shaped.
     const auditCall = auditLogMock.mock.calls[0][0];
     expect(auditCall.metadata).not.toHaveProperty('tokenSub');
+  });
+
+  it('returns active: false for a signature-valid token whose jti is revoked (RFC 7009)', async () => {
+    const { fastify, ctx } = createFastifyStub();
+    await introspectRoute(fastify);
+
+    const client = {
+      id: 'client-1',
+      clientId: 'client-123',
+      clientSecretHash: 'hashed-secret',
+      enabled: true,
+      audience: null,
+    };
+
+    (fastify.repositories.oauthClients.findByClientId as unknown as Mock).mockResolvedValue(client);
+    (fastify.passwordHasher.verifyPassword as unknown as Mock).mockResolvedValue(true);
+    (fastify.jwtUtils.verifyAccessToken as unknown as Mock).mockResolvedValue({
+      sub: '019dbc24-7a2d-724d-bf26-1923f21f2234',
+      clientId: client.clientId,
+      jti: 'revoked-jti',
+      exp: 1234567890,
+      iat: 1234567800,
+      iss: 'https://auth.example.com',
+    });
+    // The token's jti is on the denylist.
+    (fastify.redis.exists as unknown as Mock).mockResolvedValue(1);
+
+    const replyBody: any[] = [];
+    const reply = { send: (b: unknown) => (replyBody.push(b), b) };
+
+    const result = await ctx.handler!(
+      {
+        body: { token: 'revoked-token', client_id: client.clientId, client_secret: 'secret' },
+        ip: '127.0.0.1',
+        headers: { 'user-agent': 'vitest' },
+      },
+      reply
+    );
+
+    expect(fastify.redis.exists).toHaveBeenCalledWith('revoked-access-token:revoked-jti');
+    expect(result).toEqual({ active: false });
   });
 
   it('nulls out user_id on the audit row when sub is not UUID-shaped (client_credentials)', async () => {

--- a/apps/auth-server/src/app/routes/oauth/introspect.ts
+++ b/apps/auth-server/src/app/routes/oauth/introspect.ts
@@ -7,6 +7,7 @@ import { MIN_RESPONSE_TIME_MS } from '../../constants';
 import { authenticateClient, extractClientCredentials } from '../../helpers/client-auth';
 import { getOrCreateDefaultRealm } from '../../helpers/realm';
 import { ensureMinimumResponseTime } from '../../helpers/timing';
+import { isJtiRevoked } from '../../helpers/token-revocation';
 import {
   type IntrospectRequest,
   introspectRequestSchema,
@@ -114,9 +115,12 @@ export default async function (fastify: FastifyInstance) {
 
         let payload;
         try {
-          // Note: Currently checks signature and expiry only.
-          // TODO: integrate access token revocation (e.g. jti-based store) when available.
-          payload = await fastify.jwtUtils.verifyAccessToken(token);
+          // RFC 9700 mix-up defence: pin the issuer so a token minted by a
+          // different AS (even one sharing our signing key) is reported
+          // inactive rather than introspected as ours.
+          payload = await fastify.jwtUtils.verifyAccessToken(token, {
+            issuer: fastify.jwtUtils.getIssuer(),
+          });
         } catch (error) {
           if (error instanceof JWTExpiredError || error instanceof JWTInvalidError) {
             await fastify.repositories.auditLogs.create({
@@ -140,6 +144,28 @@ export default async function (fastify: FastifyInstance) {
           }
 
           throw error;
+        }
+
+        // RFC 7009 revocation: a signature-valid, unexpired token that has been
+        // explicitly revoked MUST be reported inactive. Checked before the
+        // authorization branch so a revoked token is never surfaced as active.
+        if (await isJtiRevoked(fastify, payload.jti)) {
+          await fastify.repositories.auditLogs.create({
+            userId: null,
+            oauthClientId: client.id,
+            event: 'oauth.introspect.failure',
+            eventType: 'token',
+            success: false,
+            ipAddress: request.ip,
+            userAgent: request.headers['user-agent'] || null,
+            metadata: { error: 'Token revoked' },
+          });
+
+          await ensureMinimumResponseTime(startTime, MIN_RESPONSE_TIME_MS.INTROSPECT);
+
+          return reply.send({
+            active: false as const,
+          });
         }
 
         // Authorize the introspection: same-client OR audience-authoritative.

--- a/apps/auth-server/src/app/routes/oauth/revoke.test.ts
+++ b/apps/auth-server/src/app/routes/oauth/revoke.test.ts
@@ -1,0 +1,281 @@
+import { InvalidClientError } from '@qauth-labs/shared-errors';
+import type { FastifyInstance } from 'fastify';
+import { describe, expect, it, type Mock, vi } from 'vitest';
+
+vi.mock('../../helpers/timing', () => ({
+  ensureMinimumResponseTime: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../../config/env', () => ({
+  env: {
+    DATABASE_URL: 'postgresql://test:test@localhost:5432/test',
+    EMAIL_FROM_ADDRESS: 'noreply@example.com',
+    EMAIL_BASE_URL: 'http://localhost:3000',
+    INTROSPECT_RATE_LIMIT: 60,
+    INTROSPECT_RATE_WINDOW: 60,
+  },
+}));
+
+import revokeRoute from './revoke';
+
+interface TestContext {
+  handler?: (request: any, reply: any) => Promise<unknown>;
+}
+
+const ISSUER = 'https://auth.example.com';
+
+function createFastifyStub() {
+  const ctx: TestContext = {};
+
+  const fastify: any = {
+    withTypeProvider: () => ({
+      post: (
+        _url: string,
+        _opts: unknown,
+        handler: (request: any, reply: any) => Promise<unknown>
+      ) => {
+        ctx.handler = handler;
+        return fastify;
+      },
+    }),
+    repositories: {
+      realms: {
+        findByName: vi.fn().mockResolvedValue({ id: 'realm-1', name: 'default', enabled: true }),
+        create: vi.fn().mockResolvedValue({ id: 'realm-1', name: 'default', enabled: true }),
+      },
+      oauthClients: {
+        findByClientId: vi.fn(),
+      },
+      refreshTokens: {
+        findByTokenHashIncludingRevoked: vi.fn(),
+        revokeFamily: vi.fn().mockResolvedValue(1),
+      },
+      auditLogs: {
+        create: vi.fn(),
+      },
+    },
+    passwordHasher: {
+      verifyPassword: vi.fn().mockResolvedValue(true),
+    },
+    jwtUtils: {
+      verifyAccessToken: vi.fn(),
+      hashRefreshToken: (t: string) => `hash:${t}`,
+      getIssuer: () => ISSUER,
+    },
+    redis: {
+      setex: vi.fn().mockResolvedValue('OK'),
+      exists: vi.fn().mockResolvedValue(0),
+    },
+    log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  };
+
+  return { fastify: fastify as FastifyInstance, ctx };
+}
+
+const client = {
+  id: 'client-row-1',
+  clientId: 'client-123',
+  clientSecretHash: 'hashed-secret',
+  enabled: true,
+  audience: null,
+};
+
+function makeReply() {
+  const replies: any[] = [];
+  let statusCode = 200;
+  const reply = {
+    code(c: number) {
+      statusCode = c;
+      return reply;
+    },
+    send(body: unknown) {
+      replies.push(body);
+      return body;
+    },
+    get statusCode() {
+      return statusCode;
+    },
+  };
+  return { reply, replies };
+}
+
+describe('POST /oauth/revoke route (RFC 7009)', () => {
+  it('revokes the family of an owned refresh token and returns 200', async () => {
+    const { fastify, ctx } = createFastifyStub();
+    await revokeRoute(fastify);
+
+    (fastify.repositories.oauthClients.findByClientId as unknown as Mock).mockResolvedValue(client);
+    (
+      fastify.repositories.refreshTokens.findByTokenHashIncludingRevoked as unknown as Mock
+    ).mockResolvedValue({
+      id: 'rt-1',
+      oauthClientId: client.id,
+      familyId: 'fam-1',
+    });
+
+    const { reply } = makeReply();
+    await ctx.handler!(
+      {
+        body: { token: 'rt-token', client_id: client.clientId, client_secret: 'secret' },
+        ip: '127.0.0.1',
+        headers: { 'user-agent': 'vitest' },
+      },
+      reply
+    );
+
+    expect(reply.statusCode).toBe(200);
+    expect(fastify.repositories.refreshTokens.revokeFamily).toHaveBeenCalledWith(
+      'fam-1',
+      'client_revocation'
+    );
+  });
+
+  it('is a no-op (still 200) when the refresh token belongs to a different client', async () => {
+    const { fastify, ctx } = createFastifyStub();
+    await revokeRoute(fastify);
+
+    (fastify.repositories.oauthClients.findByClientId as unknown as Mock).mockResolvedValue(client);
+    (
+      fastify.repositories.refreshTokens.findByTokenHashIncludingRevoked as unknown as Mock
+    ).mockResolvedValue({
+      id: 'rt-2',
+      oauthClientId: 'some-other-client',
+      familyId: 'fam-2',
+    });
+    // Not a JWT either, so the access-token fallback verify rejects.
+    (fastify.jwtUtils.verifyAccessToken as unknown as Mock).mockRejectedValue(new Error('bad'));
+
+    const { reply } = makeReply();
+    await ctx.handler!(
+      {
+        body: { token: 'rt-token', client_id: client.clientId, client_secret: 'secret' },
+        ip: '127.0.0.1',
+        headers: { 'user-agent': 'vitest' },
+      },
+      reply
+    );
+
+    expect(reply.statusCode).toBe(200);
+    // Cross-client revocation must NOT touch the family.
+    expect(fastify.repositories.refreshTokens.revokeFamily).not.toHaveBeenCalled();
+  });
+
+  it('returns 200 with no revocation for an unknown/invalid token', async () => {
+    const { fastify, ctx } = createFastifyStub();
+    await revokeRoute(fastify);
+
+    (fastify.repositories.oauthClients.findByClientId as unknown as Mock).mockResolvedValue(client);
+    (
+      fastify.repositories.refreshTokens.findByTokenHashIncludingRevoked as unknown as Mock
+    ).mockResolvedValue(undefined);
+    (fastify.jwtUtils.verifyAccessToken as unknown as Mock).mockRejectedValue(new Error('bad jwt'));
+
+    const { reply } = makeReply();
+    await ctx.handler!(
+      {
+        body: { token: 'garbage', client_id: client.clientId, client_secret: 'secret' },
+        ip: '127.0.0.1',
+        headers: { 'user-agent': 'vitest' },
+      },
+      reply
+    );
+
+    expect(reply.statusCode).toBe(200);
+    expect(fastify.repositories.refreshTokens.revokeFamily).not.toHaveBeenCalled();
+    expect(fastify.redis.setex).not.toHaveBeenCalled();
+  });
+
+  it('denylists the jti of an owned access token with its remaining TTL', async () => {
+    const { fastify, ctx } = createFastifyStub();
+    await revokeRoute(fastify);
+
+    (fastify.repositories.oauthClients.findByClientId as unknown as Mock).mockResolvedValue(client);
+    // No refresh-token row → falls through to the access-token path.
+    (
+      fastify.repositories.refreshTokens.findByTokenHashIncludingRevoked as unknown as Mock
+    ).mockResolvedValue(undefined);
+    const futureExp = Math.floor(Date.now() / 1000) + 600;
+    (fastify.jwtUtils.verifyAccessToken as unknown as Mock).mockResolvedValue({
+      sub: 'user-1',
+      clientId: client.clientId,
+      jti: 'jti-123',
+      exp: futureExp,
+    });
+
+    const { reply } = makeReply();
+    await ctx.handler!(
+      {
+        body: {
+          token: 'access-token',
+          token_type_hint: 'access_token',
+          client_id: client.clientId,
+          client_secret: 'secret',
+        },
+        ip: '127.0.0.1',
+        headers: { 'user-agent': 'vitest' },
+      },
+      reply
+    );
+
+    expect(reply.statusCode).toBe(200);
+    expect(fastify.redis.setex).toHaveBeenCalledTimes(1);
+    const [key, ttl] = (fastify.redis.setex as unknown as Mock).mock.calls[0];
+    expect(key).toBe('revoked-access-token:jti-123');
+    expect(ttl).toBeGreaterThan(0);
+    expect(ttl).toBeLessThanOrEqual(600);
+  });
+
+  it('does NOT denylist an access token issued to a different client', async () => {
+    const { fastify, ctx } = createFastifyStub();
+    await revokeRoute(fastify);
+
+    (fastify.repositories.oauthClients.findByClientId as unknown as Mock).mockResolvedValue(client);
+    (
+      fastify.repositories.refreshTokens.findByTokenHashIncludingRevoked as unknown as Mock
+    ).mockResolvedValue(undefined);
+    (fastify.jwtUtils.verifyAccessToken as unknown as Mock).mockResolvedValue({
+      sub: 'user-1',
+      clientId: 'a-different-client',
+      jti: 'jti-999',
+      exp: Math.floor(Date.now() / 1000) + 600,
+    });
+
+    const { reply } = makeReply();
+    await ctx.handler!(
+      {
+        body: {
+          token: 'access-token',
+          token_type_hint: 'access_token',
+          client_id: client.clientId,
+          client_secret: 'secret',
+        },
+        ip: '127.0.0.1',
+        headers: { 'user-agent': 'vitest' },
+      },
+      reply
+    );
+
+    expect(reply.statusCode).toBe(200);
+    expect(fastify.redis.setex).not.toHaveBeenCalled();
+  });
+
+  it('rejects with invalid_client when client authentication fails', async () => {
+    const { fastify, ctx } = createFastifyStub();
+    await revokeRoute(fastify);
+
+    (fastify.repositories.oauthClients.findByClientId as unknown as Mock).mockResolvedValue(client);
+    (fastify.passwordHasher.verifyPassword as unknown as Mock).mockResolvedValue(false);
+
+    const { reply } = makeReply();
+    await expect(
+      ctx.handler!(
+        {
+          body: { token: 'whatever', client_id: client.clientId, client_secret: 'wrong' },
+          ip: '127.0.0.1',
+          headers: { 'user-agent': 'vitest' },
+        },
+        reply
+      )
+    ).rejects.toBeInstanceOf(InvalidClientError);
+  });
+});

--- a/apps/auth-server/src/app/routes/oauth/revoke.ts
+++ b/apps/auth-server/src/app/routes/oauth/revoke.ts
@@ -1,0 +1,168 @@
+import { InvalidClientError } from '@qauth-labs/shared-errors';
+import type { FastifyInstance } from 'fastify';
+import { ZodTypeProvider } from 'fastify-type-provider-zod';
+
+import { env } from '../../../config/env';
+import { MIN_RESPONSE_TIME_MS } from '../../constants';
+import { authenticateClient, extractClientCredentials } from '../../helpers/client-auth';
+import { getOrCreateDefaultRealm } from '../../helpers/realm';
+import { ensureMinimumResponseTime } from '../../helpers/timing';
+import { revokeJti } from '../../helpers/token-revocation';
+import { type RevokeRequest, revokeRequestSchema } from '../../schemas/oauth';
+
+/**
+ * POST /oauth/revoke
+ * RFC 7009 OAuth 2.0 Token Revocation.
+ *
+ * - Accepts a `token` (access or refresh) in an
+ *   `application/x-www-form-urlencoded` body, with an advisory
+ *   `token_type_hint`.
+ * - Requires confidential client authentication (client_secret_basic or
+ *   client_secret_post), reusing the same path as introspection.
+ * - Only the client that owns a token may revoke it. A token belonging to a
+ *   different client (or an unknown/invalid token) is a NO-OP — never an error,
+ *   per RFC 7009 §2.2, so the endpoint cannot be used to probe token existence
+ *   or ownership.
+ * - ALWAYS returns HTTP 200 with an empty body on success (RFC 7009 §2.2),
+ *   regardless of whether anything was actually revoked. The only non-200
+ *   outcome is a client-authentication failure (`invalid_client`, §2.2.1),
+ *   matching the introspection endpoint.
+ *
+ * Revocation mechanics:
+ * - Refresh token: looked up by hash; if owned by the authenticated client, the
+ *   whole token family is revoked (consistent with the rotation/replay model in
+ *   the token endpoint) so no descendant can be exchanged.
+ * - Access token (stateless JWT): verified, and if it was issued to the
+ *   authenticated client its `jti` is added to the Redis denylist with a TTL of
+ *   its remaining lifetime. The `requireJwt` preHandler and the introspection
+ *   endpoint both consult that denylist.
+ */
+export default async function (fastify: FastifyInstance) {
+  fastify.withTypeProvider<ZodTypeProvider>().post(
+    '/revoke',
+    {
+      schema: {
+        description:
+          'RFC 7009 token revocation. Send the token and confidential client credentials in an application/x-www-form-urlencoded body. Always returns 200 with an empty body on success.',
+        tags: ['OAuth', 'Revocation'],
+        body: revokeRequestSchema,
+      },
+      config: {
+        rateLimit: {
+          // Consistent with introspection — both are confidential-client,
+          // token-bearing endpoints (#211 follow-up; reuses the introspect cap).
+          max: env.INTROSPECT_RATE_LIMIT,
+          timeWindow: env.INTROSPECT_RATE_WINDOW * 1000,
+          keyGenerator: (request) => request.ip || 'unknown',
+        },
+      },
+    },
+    async (request, reply) => {
+      const startTime = Date.now();
+      const body = request.body as RevokeRequest;
+      const { token, token_type_hint } = body;
+
+      const realm = await getOrCreateDefaultRealm(fastify);
+
+      // Confidential client authentication (RFC 7009 §2.1). A failure here is
+      // the ONLY non-200 outcome (`invalid_client`, §2.2.1).
+      let client;
+      try {
+        const creds = extractClientCredentials(request, body.client_id, body.client_secret);
+        client = await authenticateClient(fastify, realm.id, creds);
+      } catch (err) {
+        await fastify.repositories.auditLogs.create({
+          userId: null,
+          oauthClientId: null,
+          event: 'oauth.revoke.failure',
+          eventType: 'token',
+          success: false,
+          ipAddress: request.ip,
+          userAgent: request.headers['user-agent'] || null,
+          metadata: { error: 'Client authentication failed' },
+        });
+        await ensureMinimumResponseTime(startTime, MIN_RESPONSE_TIME_MS.INTROSPECT);
+        throw err;
+      }
+
+      // Try refresh-token revocation first unless the hint says access_token.
+      // RFC 7009 §2.1: the hint is advisory; if it is wrong we still attempt the
+      // other type. Either way the response is an empty 200.
+      let revoked = false;
+
+      if (token_type_hint !== 'access_token') {
+        revoked = await tryRevokeRefreshToken(fastify, client.id, token);
+      }
+
+      if (!revoked) {
+        await tryRevokeAccessToken(fastify, client.clientId, token);
+      }
+
+      await fastify.repositories.auditLogs.create({
+        userId: null,
+        oauthClientId: client.id,
+        event: 'oauth.revoke.success',
+        eventType: 'token',
+        success: true,
+        ipAddress: request.ip,
+        userAgent: request.headers['user-agent'] || null,
+        // No token material is logged; only the (advisory) hint.
+        metadata: { tokenTypeHint: token_type_hint ?? null },
+      });
+
+      await ensureMinimumResponseTime(startTime, MIN_RESPONSE_TIME_MS.INTROSPECT);
+
+      // RFC 7009 §2.2: empty body, HTTP 200.
+      return reply.code(200).send();
+    }
+  );
+}
+
+/**
+ * Revoke a refresh token (and its whole family) IFF it hashes to a stored row
+ * owned by the authenticated client. Returns true when a matching, owned token
+ * was found (regardless of prior revoked state — re-revocation is idempotent),
+ * false otherwise. A token owned by a DIFFERENT client is a no-op (returns
+ * false) so cross-client revocation is impossible.
+ */
+async function tryRevokeRefreshToken(
+  fastify: FastifyInstance,
+  clientRowId: string,
+  token: string
+): Promise<boolean> {
+  const hash = fastify.jwtUtils.hashRefreshToken(token);
+  const stored = await fastify.repositories.refreshTokens.findByTokenHashIncludingRevoked(hash);
+  if (!stored) return false;
+  // Ownership: only the owning client may revoke. A mismatch is a silent no-op.
+  if (stored.oauthClientId !== clientRowId) return false;
+  // Revoke the entire family so no rotated descendant remains exchangeable
+  // (consistent with the replay-revocation model in the token endpoint).
+  await fastify.repositories.refreshTokens.revokeFamily(stored.familyId, 'client_revocation');
+  return true;
+}
+
+/**
+ * Revoke an access token by denylisting its `jti` IFF it is a valid JWT issued
+ * to the authenticated client. A token belonging to another client, an invalid
+ * token, or one already expired is a silent no-op (RFC 7009 §2.2).
+ */
+async function tryRevokeAccessToken(
+  fastify: FastifyInstance,
+  clientId: string,
+  token: string
+): Promise<void> {
+  let payload;
+  try {
+    payload = await fastify.jwtUtils.verifyAccessToken(token, {
+      issuer: fastify.jwtUtils.getIssuer(),
+    });
+  } catch {
+    // Invalid/expired/foreign-issuer token — nothing to revoke.
+    return;
+  }
+  // Ownership: only the client the token was issued for may revoke it.
+  if (payload.clientId !== clientId) return;
+  if (!payload.jti || payload.exp === undefined) return;
+  const remainingSeconds = payload.exp - Math.floor(Date.now() / 1000);
+  await revokeJti(fastify, payload.jti, remainingSeconds);
+}

--- a/apps/auth-server/src/app/routes/oauth/signature-verification.test.ts
+++ b/apps/auth-server/src/app/routes/oauth/signature-verification.test.ts
@@ -1,0 +1,294 @@
+/**
+ * Real-crypto signature-rejection tests for the token-consuming endpoints
+ * (#212 follow-up — closes a genuine coverage gap).
+ *
+ * The existing introspect/userinfo unit tests STUB `jwtUtils.verifyAccessToken`,
+ * so they never exercise actual EdDSA signature verification — a token with a
+ * forged/foreign signature would be accepted if the route's wiring were wrong
+ * and those tests could not catch it. This suite builds the endpoints with the
+ * REAL `jwtPlugin` (keyed by a fresh Ed25519 pair, the same plugin production
+ * uses) and feeds them a token signed by a DIFFERENT key, asserting:
+ *
+ *   - `/oauth/introspect` returns `active: false` for a bad-signature token
+ *     (RFC 7662 — an untrusted token is reported inactive, never errored).
+ *   - `/oauth/userinfo` rejects a bad-signature bearer token with 401 /
+ *     JWT-invalid (the `requireJwt` preHandler runs the real verification).
+ *
+ * Crypto stays inside the jwt plugin (security boundary). The repositories are
+ * lightweight stubs — only the signature path is under test here, not the DB —
+ * so this runs in the standard (Docker-free) unit suite.
+ */
+import { generateKeyPairSync } from 'node:crypto';
+
+import formbody from '@fastify/formbody';
+import { jwtPlugin } from '@qauth-labs/fastify-plugin-jwt';
+import Fastify, { type FastifyInstance } from 'fastify';
+import { serializerCompiler, validatorCompiler, ZodTypeProvider } from 'fastify-type-provider-zod';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../helpers/timing', () => ({
+  ensureMinimumResponseTime: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../../config/env', () => ({
+  env: {
+    INTROSPECT_RATE_LIMIT: 60,
+    INTROSPECT_RATE_WINDOW: 60,
+    USERINFO_RATE_LIMIT: 60,
+    USERINFO_RATE_WINDOW: 60,
+    DEFAULT_REALM_NAME: 'master',
+  },
+}));
+
+import errorHandler from '../../plugins/error-handler';
+import introspectRoute from './introspect';
+import userinfoRoute from './userinfo';
+
+const ISSUER = 'https://auth.test.example.com';
+const CLIENT_ID = 'sig-test-client';
+const USER_ID = '019dbc24-7a2d-724d-bf26-1923f21f2234';
+
+/** Generate a fresh extractable Ed25519 key pair as PEM strings. */
+function generateEd25519Pem(): { privateKeyPem: string; publicKeyPem: string } {
+  const { privateKey, publicKey } = generateKeyPairSync('ed25519');
+  return {
+    privateKeyPem: privateKey.export({ type: 'pkcs8', format: 'pem' }).toString(),
+    publicKeyPem: publicKey.export({ type: 'spki', format: 'pem' }).toString(),
+  };
+}
+
+const CONFIDENTIAL_CLIENT = {
+  id: 'client-row-sig-1',
+  clientId: CLIENT_ID,
+  clientSecretHash: 'argon2id$hash',
+  enabled: true,
+  audience: null as string[] | null,
+};
+
+/**
+ * Build a Fastify app with the REAL jwt plugin (fresh EdDSA pair) plus the
+ * introspect + userinfo routes and the global error handler. Repositories are
+ * stubbed; only the signature path matters here.
+ */
+async function buildApp(): Promise<FastifyInstance> {
+  const { privateKeyPem, publicKeyPem } = generateEd25519Pem();
+
+  const app = Fastify({ logger: false });
+  app.setValidatorCompiler(validatorCompiler);
+  app.setSerializerCompiler(serializerCompiler);
+  // The introspect route consumes application/x-www-form-urlencoded bodies, the
+  // same parser production wires up in app.ts.
+  await app.register(formbody);
+
+  await app.register(jwtPlugin, {
+    privateKey: privateKeyPem,
+    publicKey: publicKeyPem,
+    issuer: ISSUER,
+    accessTokenLifespan: 900,
+    refreshTokenLifespan: 86_400,
+  });
+
+  // Minimal repository + redis stubs the two routes touch.
+  app.decorate('repositories', {
+    realms: {
+      findByName: vi.fn().mockResolvedValue({ id: 'realm-1', name: 'master', enabled: true }),
+      create: vi.fn().mockResolvedValue({ id: 'realm-1', name: 'master', enabled: true }),
+    },
+    oauthClients: {
+      findByClientId: vi.fn().mockResolvedValue(CONFIDENTIAL_CLIENT),
+    },
+    users: {
+      findById: vi.fn().mockResolvedValue({
+        id: USER_ID,
+        email: 'user@example.com',
+        emailVerified: true,
+      }),
+    },
+    auditLogs: { create: vi.fn().mockResolvedValue(undefined) },
+  } as unknown as FastifyInstance['repositories']);
+
+  app.decorate('passwordHasher', {
+    verifyPassword: vi.fn().mockResolvedValue(true),
+  } as unknown as FastifyInstance['passwordHasher']);
+
+  // introspect consults the revocation denylist; nothing is revoked here.
+  app.decorate('redis', {
+    exists: vi.fn().mockResolvedValue(0),
+    setex: vi.fn().mockResolvedValue('OK'),
+  } as unknown as FastifyInstance['redis']);
+
+  await app.register(errorHandler);
+  await app.register(async (instance) => {
+    await introspectRoute(instance.withTypeProvider<ZodTypeProvider>());
+    await userinfoRoute(instance.withTypeProvider<ZodTypeProvider>());
+  });
+
+  await app.ready();
+  return app;
+}
+
+describe('real EdDSA signature verification — token-consuming endpoints', () => {
+  it('introspect returns active: false for a token signed by a foreign key', async () => {
+    const app = await buildApp();
+    const otherApp = await buildApp(); // independent signing key
+    try {
+      // Minted on the OTHER server (different key); THIS server must not trust it.
+      const foreignToken = await otherApp.jwtUtils.signAccessToken({
+        sub: USER_ID,
+        clientId: CLIENT_ID,
+        email: 'user@example.com',
+        email_verified: true,
+        scope: 'openid',
+      });
+
+      const res = await app.inject({
+        method: 'POST',
+        url: '/introspect',
+        headers: { 'content-type': 'application/x-www-form-urlencoded' },
+        payload: new URLSearchParams({
+          token: foreignToken,
+          client_id: CLIENT_ID,
+          client_secret: 'secret',
+        }).toString(),
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toEqual({ active: false });
+    } finally {
+      await app.close();
+      await otherApp.close();
+    }
+  });
+
+  it('introspect returns active: false for a token with a structurally mutated signature', async () => {
+    const app = await buildApp();
+    try {
+      // A token THIS server signed, then tampered: flip the signature segment.
+      const valid = await app.jwtUtils.signAccessToken({
+        sub: USER_ID,
+        clientId: CLIENT_ID,
+        scope: 'openid',
+      });
+      const [h, p] = valid.split('.');
+      const tampered = `${h}.${p}.${'A'.repeat(86)}`;
+
+      const res = await app.inject({
+        method: 'POST',
+        url: '/introspect',
+        headers: { 'content-type': 'application/x-www-form-urlencoded' },
+        payload: new URLSearchParams({
+          token: tampered,
+          client_id: CLIENT_ID,
+          client_secret: 'secret',
+        }).toString(),
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toEqual({ active: false });
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('introspect returns active: true for a genuinely signed same-client token (control)', async () => {
+    const app = await buildApp();
+    try {
+      const token = await app.jwtUtils.signAccessToken({
+        sub: USER_ID,
+        clientId: CLIENT_ID,
+        scope: 'openid',
+      });
+
+      const res = await app.inject({
+        method: 'POST',
+        url: '/introspect',
+        headers: { 'content-type': 'application/x-www-form-urlencoded' },
+        payload: new URLSearchParams({
+          token,
+          client_id: CLIENT_ID,
+          client_secret: 'secret',
+        }).toString(),
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toMatchObject({ active: true, client_id: CLIENT_ID });
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('userinfo rejects a bearer token signed by a foreign key (401 / JWT invalid)', async () => {
+    const app = await buildApp();
+    const otherApp = await buildApp();
+    try {
+      const foreignToken = await otherApp.jwtUtils.signAccessToken({
+        sub: USER_ID,
+        clientId: CLIENT_ID,
+        email: 'user@example.com',
+        email_verified: true,
+        scope: 'openid email',
+      });
+
+      const res = await app.inject({
+        method: 'GET',
+        url: '/userinfo',
+        headers: { authorization: `Bearer ${foreignToken}` },
+      });
+
+      expect(res.statusCode).toBe(401);
+      // The user lookup must never run when the signature is untrusted.
+      const usersRepo = app.repositories.users as unknown as { findById: ReturnType<typeof vi.fn> };
+      expect(usersRepo.findById).not.toHaveBeenCalled();
+    } finally {
+      await app.close();
+      await otherApp.close();
+    }
+  });
+
+  it('userinfo rejects a bearer token with a structurally mutated signature (401)', async () => {
+    const app = await buildApp();
+    try {
+      const valid = await app.jwtUtils.signAccessToken({
+        sub: USER_ID,
+        clientId: CLIENT_ID,
+        scope: 'openid email',
+      });
+      const [h, p] = valid.split('.');
+      const tampered = `${h}.${p}.${'A'.repeat(86)}`;
+
+      const res = await app.inject({
+        method: 'GET',
+        url: '/userinfo',
+        headers: { authorization: `Bearer ${tampered}` },
+      });
+
+      expect(res.statusCode).toBe(401);
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('userinfo accepts a genuinely signed bearer token (control)', async () => {
+    const app = await buildApp();
+    try {
+      const token = await app.jwtUtils.signAccessToken({
+        sub: USER_ID,
+        clientId: CLIENT_ID,
+        email: 'user@example.com',
+        email_verified: true,
+        scope: 'openid email',
+      });
+
+      const res = await app.inject({
+        method: 'GET',
+        url: '/userinfo',
+        headers: { authorization: `Bearer ${token}` },
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toMatchObject({ sub: USER_ID, email: 'user@example.com' });
+    } finally {
+      await app.close();
+    }
+  });
+});

--- a/apps/auth-server/src/app/routes/oauth/token.test.ts
+++ b/apps/auth-server/src/app/routes/oauth/token.test.ts
@@ -1789,7 +1789,18 @@ describe('POST /oauth/token route — token-exchange grant (RFC 8693, ADR-007 §
 
     (fastify.repositories.oauthClients.findByClientId as unknown as Mock).mockResolvedValue(client);
     (fastify.passwordHasher.verifyPassword as unknown as Mock).mockResolvedValue(true);
-    (fastify.jwtUtils.verifyAccessToken as unknown as Mock).mockResolvedValue(subjectPayload);
+    // Issuer is now enforced INSIDE verifyAccessToken (RFC 9700). Model that:
+    // when the route pins `issuer` and it does not match the token's `iss`, the
+    // mock rejects exactly as jose would, instead of the route doing a manual
+    // post-verification issuer comparison.
+    (fastify.jwtUtils.verifyAccessToken as unknown as Mock).mockImplementation(
+      (_token: string, options?: { issuer?: string }) => {
+        if (options?.issuer !== undefined && subjectPayload.iss !== options.issuer) {
+          return Promise.reject(new Error('unexpected "iss" claim value'));
+        }
+        return Promise.resolve(subjectPayload);
+      }
+    );
     (fastify.repositories.users.findById as unknown as Mock).mockResolvedValue(
       opts.userFound === false ? null : user
     );

--- a/apps/auth-server/src/app/routes/oauth/token.test.ts
+++ b/apps/auth-server/src/app/routes/oauth/token.test.ts
@@ -1186,6 +1186,69 @@ describe('POST /oauth/token route — authorization_code grant', () => {
     ).rejects.toThrow(InvalidGrantError);
   });
 
+  it('rejects a used / expired / unknown code (findByCode filters them out → invalid_grant)', async () => {
+    // Single-use + expiry are enforced at the repository layer: findByCode
+    // returns ONLY codes that are `used = false` AND unexpired (see the
+    // repository integration tests for the markUsed CAS + expiry filter). So a
+    // second redemption of an already-used code — and an expired one — both
+    // surface to the route as `findByCode` → undefined. The token endpoint must
+    // map that to invalid_grant (RFC 6749 §5.2), not a 500.
+    const { fastify, ctx } = setupAuthCodeStub();
+    (fastify.repositories.authorizationCodes.findByCode as unknown as Mock).mockResolvedValue(
+      undefined
+    );
+    await tokenRoute(fastify);
+    const handler = ctx.handler;
+    if (!handler) throw new Error('Handler missing');
+
+    const reply = createReply();
+    await expect(handler(baseRequest(), reply)).rejects.toThrow(InvalidGrantError);
+    // No token issued, and the code was never (re-)marked used.
+    expect(fastify.jwtUtils.signAccessToken).not.toHaveBeenCalled();
+    expect(fastify.repositories.authorizationCodes.markUsed).not.toHaveBeenCalled();
+  });
+
+  it('marks the authorization code used before issuing tokens (single-use)', async () => {
+    // The route MUST consume the code via markUsed (the atomic CAS that makes a
+    // replay of the same code fail on the second exchange — see the repository
+    // integration test for the race). Assert the consume happens AND precedes
+    // token signing on a successful exchange.
+    const { fastify, ctx, authCode } = setupAuthCodeStub();
+    await tokenRoute(fastify);
+    const handler = ctx.handler;
+    if (!handler) throw new Error('Handler missing');
+
+    const reply = createReply();
+    await handler(baseRequest(), reply);
+
+    expect(fastify.repositories.authorizationCodes.markUsed).toHaveBeenCalledWith(authCode.id);
+    const markUsedOrder = (fastify.repositories.authorizationCodes.markUsed as unknown as Mock).mock
+      .invocationCallOrder[0];
+    const signOrder = (fastify.jwtUtils.signAccessToken as unknown as Mock).mock
+      .invocationCallOrder[0];
+    expect(markUsedOrder).toBeLessThan(signOrder);
+  });
+
+  it('rejects replay via the markUsed CAS losing the race (NotFoundError → no token)', async () => {
+    // Models the concurrent-redemption window: a code passes findByCode (it was
+    // still live when read), but a parallel exchange consumed it first, so the
+    // atomic markUsed CAS (`WHERE used = false`) matches no row and throws
+    // NotFoundError. The route must surface that and issue NO token, rather than
+    // minting a second access token for the same code.
+    const { fastify, ctx } = setupAuthCodeStub();
+    (fastify.repositories.authorizationCodes.markUsed as unknown as Mock).mockRejectedValue(
+      new NotFoundError('AuthorizationCode', 'authcode-uuid-1')
+    );
+    await tokenRoute(fastify);
+    const handler = ctx.handler;
+    if (!handler) throw new Error('Handler missing');
+
+    const reply = createReply();
+    await expect(handler(baseRequest(), reply)).rejects.toThrow(NotFoundError);
+    expect(fastify.jwtUtils.signAccessToken).not.toHaveBeenCalled();
+    expect(fastify.repositories.refreshTokens.create).not.toHaveBeenCalled();
+  });
+
   it('rejects when PKCE verification fails', async () => {
     const { fastify, ctx } = setupAuthCodeStub();
     (fastify.pkceUtils.verifyCodeChallenge as unknown as Mock).mockReturnValue(false);

--- a/apps/auth-server/src/app/routes/oauth/token.ts
+++ b/apps/auth-server/src/app/routes/oauth/token.ts
@@ -1141,12 +1141,18 @@ async function handleTokenExchange(
     throw new InvalidRequestError('unsupported actor_token_type');
   }
 
-  // GATE 3 — verify the subject token (EdDSA signature + exp). Only QAuth's
-  // signing key verifies, so a valid signature establishes provenance; an
-  // unverifiable or expired token is "unacceptable" → invalid_request.
+  // GATE 3 — verify the subject token (EdDSA signature + exp + issuer). The
+  // issuer is pinned in `verifyAccessToken` (RFC 9700 mix-up defence), so a
+  // token minted by a different AS — even one sharing our signing key — fails
+  // verification here. Only QAuth's signing key + issuer verifies, so success
+  // establishes provenance; an unverifiable / expired / foreign-issuer token is
+  // "unacceptable" → invalid_request.
+  const expectedIssuer = fastify.jwtUtils.getIssuer();
   let subjectPayload: Awaited<ReturnType<typeof fastify.jwtUtils.verifyAccessToken>>;
   try {
-    subjectPayload = await fastify.jwtUtils.verifyAccessToken(body.subject_token);
+    subjectPayload = await fastify.jwtUtils.verifyAccessToken(body.subject_token, {
+      issuer: expectedIssuer,
+    });
   } catch {
     await auditFailure('invalid_request: subject_token failed verification');
     throw new InvalidRequestError('subject_token is not a valid access token');
@@ -1156,38 +1162,37 @@ async function handleTokenExchange(
     throw new InvalidRequestError('subject_token has no subject');
   }
 
-  // GATE 3b — token-confusion defence. `verifyAccessToken` proves the EdDSA
-  // signature + exp only; it does NOT assert issuer or token purpose. Without
-  // this check, ANY JWT QAuth signs with the same key (e.g. a future ID token)
-  // would verify and, if its `sub` resolved to a user, be accepted as a
-  // subject token. Require (a) our own issuer and (b) the access-token
-  // `token_use` marker. The marker is absent on legacy access tokens minted
-  // before it existed, so we accept its absence only when the structural
-  // access-token markers (`client_id` + `aud`) are present — never accept a
-  // token that positively declares a non-access `token_use`.
-  const expectedIssuer = fastify.jwtUtils.getIssuer();
-  const issuerOk = subjectPayload.iss === expectedIssuer;
+  // GATE 3b — token-confusion defence. Issuer is now asserted by
+  // `verifyAccessToken` above; the remaining check is token PURPOSE. Without
+  // it, ANY JWT QAuth signs with the same key (e.g. an ID token) would verify
+  // and, if its `sub` resolved to a user, be accepted as a subject token.
+  // Require the access-token `token_use` marker. The marker is absent on legacy
+  // access tokens minted before it existed, so we accept its absence only when
+  // the structural access-token markers (`client_id` + `aud`) are present —
+  // never accept a token that positively declares a non-access `token_use`.
   const tokenUse = subjectPayload.token_use;
   const isAccessToken =
     tokenUse === 'access' ||
     (tokenUse === undefined &&
       subjectPayload.clientId !== undefined &&
       subjectPayload.aud !== undefined);
-  if (!issuerOk || !isAccessToken) {
+  if (!isAccessToken) {
     await auditFailure('invalid_request: subject_token is not a QAuth access token', {
-      issuerOk,
       tokenUse: tokenUse ?? null,
     });
     throw new InvalidRequestError('subject_token is not a QAuth-issued access token');
   }
 
-  // If an actor_token is supplied, verify it too. We do not trust the agent's
-  // self-declared identity from an unverified token — the actor identity used
-  // in the `act` claim is the authenticated agent's own client_id (below).
+  // If an actor_token is supplied, verify it too (issuer pinned). We do not
+  // trust the agent's self-declared identity from an unverified token — the
+  // actor identity used in the `act` claim is the authenticated agent's own
+  // client_id (below).
   let actorPayload: Awaited<ReturnType<typeof fastify.jwtUtils.verifyAccessToken>> | undefined;
   if (body.actor_token !== undefined) {
     try {
-      actorPayload = await fastify.jwtUtils.verifyAccessToken(body.actor_token);
+      actorPayload = await fastify.jwtUtils.verifyAccessToken(body.actor_token, {
+        issuer: expectedIssuer,
+      });
     } catch {
       await auditFailure('invalid_request: actor_token failed verification');
       throw new InvalidRequestError('actor_token is not a valid access token');

--- a/apps/auth-server/src/app/routes/oauth/userinfo.test.ts
+++ b/apps/auth-server/src/app/routes/oauth/userinfo.test.ts
@@ -120,6 +120,8 @@ describe('GET /userinfo route', () => {
         sub: 'user-1',
         email: 'user@example.com',
         email_verified: true,
+        // OIDC §5.4: email claims require the `email` scope on the token.
+        scope: 'openid email',
       },
       ip: '127.0.0.1',
       headers: {
@@ -174,7 +176,8 @@ describe('GET /userinfo route', () => {
     });
 
     const request = {
-      jwtPayload: { sub: 'user-3' },
+      // `profile` releases the name claim; `email` releases the email claims.
+      jwtPayload: { sub: 'user-3', scope: 'openid profile email' },
       ip: '127.0.0.1',
       headers: { authorization: 'Bearer token', 'user-agent': 'vitest' },
     } as unknown as FastifyRequest;
@@ -193,6 +196,92 @@ describe('GET /userinfo route', () => {
       email_verified: true,
       name: 'Ada Lovelace',
     });
+  });
+
+  it('omits email and name when the token grants only openid (OIDC §5.4)', async () => {
+    const { fastify, ctx } = createFastifyStub();
+    await userinfoRoute(fastify);
+
+    const handler = ctx.handler;
+    const findByIdMock = fastify.repositories.users.findById as unknown as Mock;
+    findByIdMock.mockResolvedValue({
+      id: 'user-4',
+      email: 'grace@example.com',
+      emailVerified: true,
+      firstName: 'Grace',
+      lastName: 'Hopper',
+    });
+
+    const request = {
+      jwtPayload: { sub: 'user-4', scope: 'openid' },
+      ip: '127.0.0.1',
+      headers: { authorization: 'Bearer token', 'user-agent': 'vitest' },
+    } as unknown as FastifyRequest;
+    const reply = { send: (body: unknown) => body } as unknown as FastifyReply;
+
+    if (!handler) throw new Error('Userinfo handler was not registered');
+    const result = await handler(request, reply);
+
+    // Only `sub` is released — no email, email_verified, or name.
+    expect(result).toEqual({ sub: 'user-4' });
+  });
+
+  it('includes email but not name when the token grants openid email only', async () => {
+    const { fastify, ctx } = createFastifyStub();
+    await userinfoRoute(fastify);
+
+    const handler = ctx.handler;
+    const findByIdMock = fastify.repositories.users.findById as unknown as Mock;
+    findByIdMock.mockResolvedValue({
+      id: 'user-5',
+      email: 'katherine@example.com',
+      emailVerified: false,
+      firstName: 'Katherine',
+      lastName: 'Johnson',
+    });
+
+    const request = {
+      jwtPayload: { sub: 'user-5', scope: 'openid email' },
+      ip: '127.0.0.1',
+      headers: { authorization: 'Bearer token', 'user-agent': 'vitest' },
+    } as unknown as FastifyRequest;
+    const reply = { send: (body: unknown) => body } as unknown as FastifyReply;
+
+    if (!handler) throw new Error('Userinfo handler was not registered');
+    const result = await handler(request, reply);
+
+    expect(result).toEqual({
+      sub: 'user-5',
+      email: 'katherine@example.com',
+      email_verified: false,
+    });
+  });
+
+  it('includes name but not email when the token grants openid profile only', async () => {
+    const { fastify, ctx } = createFastifyStub();
+    await userinfoRoute(fastify);
+
+    const handler = ctx.handler;
+    const findByIdMock = fastify.repositories.users.findById as unknown as Mock;
+    findByIdMock.mockResolvedValue({
+      id: 'user-6',
+      email: 'dorothy@example.com',
+      emailVerified: true,
+      firstName: 'Dorothy',
+      lastName: 'Vaughan',
+    });
+
+    const request = {
+      jwtPayload: { sub: 'user-6', scope: 'openid profile' },
+      ip: '127.0.0.1',
+      headers: { authorization: 'Bearer token', 'user-agent': 'vitest' },
+    } as unknown as FastifyRequest;
+    const reply = { send: (body: unknown) => body } as unknown as FastifyReply;
+
+    if (!handler) throw new Error('Userinfo handler was not registered');
+    const result = await handler(request, reply);
+
+    expect(result).toEqual({ sub: 'user-6', name: 'Dorothy Vaughan' });
   });
 
   it('throws NotFoundError when user is not found', async () => {
@@ -260,6 +349,9 @@ describe('GET /userinfo route', () => {
     const request = {
       jwtPayload: {
         sub: 'user-2',
+        // The `email` scope IS granted; the user simply has no email on record,
+        // so only `email_verified` is released (no `email` string).
+        scope: 'openid email',
       },
       ip: '127.0.0.1',
       headers: {

--- a/apps/auth-server/src/app/routes/oauth/userinfo.ts
+++ b/apps/auth-server/src/app/routes/oauth/userinfo.ts
@@ -56,6 +56,15 @@ export default async function (fastify: FastifyInstance) {
           throw new NotFoundError('User', userId);
         }
 
+        // OIDC Core §5.4: userinfo claims are gated by the scopes the access
+        // token was granted. `sub` is ALWAYS returned; `email`/`email_verified`
+        // require the `email` scope; `name` (a profile claim) requires
+        // `profile`. Parsing the space-delimited `scope` claim into a set is the
+        // same convention used across the token/authorize paths.
+        const grantedScopes = new Set(
+          (payload.scope ?? '').split(/\s+/).filter((s) => s.length > 0)
+        );
+
         const responseBody: {
           sub: string;
           email?: string;
@@ -65,22 +74,26 @@ export default async function (fastify: FastifyInstance) {
           sub: user.id,
         };
 
-        if (typeof user.email === 'string' && user.email.length > 0) {
-          responseBody.email = user.email;
-        }
-
-        if (typeof user.emailVerified === 'boolean') {
-          responseBody.email_verified = user.emailVerified;
+        if (grantedScopes.has('email')) {
+          if (typeof user.email === 'string' && user.email.length > 0) {
+            responseBody.email = user.email;
+          }
+          if (typeof user.emailVerified === 'boolean') {
+            responseBody.email_verified = user.emailVerified;
+          }
         }
 
         // OIDC Core §5.1 `name` — the end-user display name, derived from the
-        // stored first/last name parts. Omitted when neither is set, keeping
-        // the claim set consistent with the ID token.
-        const nameParts = [user.firstName, user.lastName].filter(
-          (p): p is string => typeof p === 'string' && p.trim().length > 0
-        );
-        if (nameParts.length > 0) {
-          responseBody.name = nameParts.join(' ');
+        // stored first/last name parts. Released only under the `profile` scope;
+        // omitted when neither part is set, keeping the claim set consistent
+        // with the ID token.
+        if (grantedScopes.has('profile')) {
+          const nameParts = [user.firstName, user.lastName].filter(
+            (p): p is string => typeof p === 'string' && p.trim().length > 0
+          );
+          if (nameParts.length > 0) {
+            responseBody.name = nameParts.join(' ');
+          }
         }
 
         await fastify.repositories.auditLogs.create({

--- a/apps/auth-server/src/app/routes/ui/consent.test.ts
+++ b/apps/auth-server/src/app/routes/ui/consent.test.ts
@@ -268,6 +268,7 @@ describe('UI /ui/consent POST — allow/deny', () => {
       sessionId: 'sid-a',
       csrfToken: csrf,
       createdAt: Date.now(),
+      consentScopes: { 'app-123': ['email'] },
     });
     (fastify.repositories.oauthClients.findByClientId as unknown as Mock).mockResolvedValue(CLIENT);
 
@@ -316,6 +317,7 @@ describe('UI /ui/consent POST — allow/deny', () => {
       sessionId: 'sid-res',
       csrfToken: csrf,
       createdAt: Date.now(),
+      consentScopes: { 'app-123': ['email'] },
     });
     (fastify.repositories.oauthClients.findByClientId as unknown as Mock).mockResolvedValue(CLIENT);
 
@@ -360,6 +362,7 @@ describe('UI /ui/consent POST — allow/deny', () => {
       sessionId: 'sid-once',
       csrfToken: csrf,
       createdAt: Date.now(),
+      consentScopes: { 'app-123': ['email'] },
     });
     (fastify.repositories.oauthClients.findByClientId as unknown as Mock).mockResolvedValue(CLIENT);
 
@@ -386,6 +389,55 @@ describe('UI /ui/consent POST — allow/deny', () => {
     expect(fastify.repositories.authorizationCodes.create).toHaveBeenCalledOnce();
     expect(state.redirected).toContain('https://example.com/cb');
   });
+
+  it('refuses to grant scopes the hidden field tampered beyond what was rendered (#150 binding)', async () => {
+    const { fastify, ctx } = makeFastify();
+    await consentRoute(fastify);
+    const { signSessionId } = await import('../../helpers/session-cookie');
+    const signed = signSessionId('sid-tamper');
+    const csrf = 'csrf-tamper';
+    // The GET render bound only `email` (what the user saw). Both `email` and
+    // `read:foo` are in the client allowlist, so a tampered `scope=email
+    // read:foo` survives the allowlist filter — the binding check is what stops
+    // the grant of the unseen `read:foo`.
+    (fastify.sessionUtils.getSession as unknown as Mock).mockResolvedValue({
+      userId: 'user-1',
+      email: 'a@b.com',
+      sessionId: 'sid-tamper',
+      csrfToken: csrf,
+      createdAt: Date.now(),
+      consentScopes: { 'app-123': ['email'] },
+    });
+    (fastify.repositories.oauthClients.findByClientId as unknown as Mock).mockResolvedValue(CLIENT);
+
+    const { reply, state } = createReply();
+    await ctx.post!(
+      {
+        body: {
+          decision: 'allow',
+          allow_forever: '1',
+          csrf_token: csrf,
+          client_id: 'app-123',
+          redirect_uri: 'https://example.com/cb',
+          state: 'xyz',
+          // Tampered: user only saw `email`.
+          scope: 'email read:foo',
+          code_challenge: 'A'.repeat(43),
+          code_challenge_method: 'S256',
+          response_type: 'code',
+        },
+        headers: { cookie: `__Host-qauth_session=${signed}` },
+        ip: '127.0.0.1',
+      },
+      reply
+    );
+
+    // No code minted, no grant persisted — redirected with invalid_scope.
+    expect(state.redirected).toContain('error=invalid_scope');
+    expect(state.redirected).toContain('state=xyz');
+    expect(fastify.repositories.authorizationCodes.create).not.toHaveBeenCalled();
+    expect(fastify.repositories.oauthConsents.upsertGrant).not.toHaveBeenCalled();
+  });
 });
 
 describe('UI /ui/consent — agent scope-mode cap (ADR-007 §2, #184)', () => {
@@ -411,6 +463,10 @@ describe('UI /ui/consent — agent scope-mode cap (ADR-007 §2, #184)', () => {
       sessionId: sid,
       csrfToken: csrf,
       createdAt: Date.now(),
+      // The over-cap / non-agent tests reject at the agent-cap gate BEFORE the
+      // scope-presentation binding check; the in-cap success test POSTs
+      // `agent:readonly`, so bind that so its grant matches what was rendered.
+      consentScopes: { 'app-123': ['agent:readonly'] },
     };
   }
 
@@ -595,13 +651,18 @@ describe('UI /ui/consent — step-up authentication (ADR-007 §2, #185)', () => 
     };
   }
 
-  function session(createdAt: number) {
+  // Scope-presentation binding (#150 hardening): the consent GET render binds the
+  // visible scope set to the session; the POST grants ONLY that set. The bound
+  // set must equal what the test POSTs, so callers pass the scope they submit
+  // (default `write:foo`, the dangerous scope these step-up tests exercise).
+  function session(createdAt: number, boundScope = 'write:foo') {
     return {
       userId: 'user-1',
       email: 'a@b.com',
       sessionId: 'sid-su',
       csrfToken: 'csrf-su',
       createdAt,
+      consentScopes: { 'app-123': boundScope.split(/\s+/).filter((s) => s.length > 0) },
     };
   }
 
@@ -681,7 +742,7 @@ describe('UI /ui/consent — step-up authentication (ADR-007 §2, #185)', () => 
     const { signSessionId } = await import('../../helpers/session-cookie');
     const signed = signSessionId('sid-su');
     (fastify.sessionUtils.getSession as unknown as Mock).mockResolvedValue(
-      session(Date.now() - 5000)
+      session(Date.now() - 5000, 'agent:exec')
     );
     // An EXEC-capped agent elevating to the dangerous `agent:exec` scope.
     const EXEC_AGENT = {
@@ -758,7 +819,7 @@ describe('UI /ui/consent — step-up authentication (ADR-007 §2, #185)', () => 
     const { signSessionId } = await import('../../helpers/session-cookie');
     const signed = signSessionId('sid-su');
     (fastify.sessionUtils.getSession as unknown as Mock).mockResolvedValue(
-      session(Date.now() - 10 * MINUTE)
+      session(Date.now() - 10 * MINUTE, 'email')
     );
     (fastify.repositories.oauthClients.findByClientId as unknown as Mock).mockResolvedValue(CLIENT);
 
@@ -782,7 +843,7 @@ describe('UI /ui/consent — step-up authentication (ADR-007 §2, #185)', () => 
     const { signSessionId } = await import('../../helpers/session-cookie');
     const signed = signSessionId('sid-su');
     (fastify.sessionUtils.getSession as unknown as Mock).mockResolvedValue(
-      session(Date.now() - 10 * MINUTE)
+      session(Date.now() - 10 * MINUTE, 'email')
     );
     (fastify.repositories.oauthClients.findByClientId as unknown as Mock).mockResolvedValue(CLIENT);
 

--- a/apps/auth-server/src/app/routes/ui/consent.ts
+++ b/apps/auth-server/src/app/routes/ui/consent.ts
@@ -45,6 +45,18 @@ function parseResourceFromUrl(url: string): string[] {
 }
 
 /**
+ * Order-independent equality of two scope sets. Used by the consent POST to
+ * confirm the POSTed (allowlist-filtered) scopes match exactly the set bound to
+ * the session on the GET render — defence against a tampered hidden `scope`
+ * field. Both inputs are already de-duplicated by `filterRequestedScopes`.
+ */
+function scopeSetsEqual(a: readonly string[], b: readonly string[]): boolean {
+  if (a.length !== b.length) return false;
+  const set = new Set(a);
+  return b.every((s) => set.has(s));
+}
+
+/**
  * Consent screen & Allow/Deny POST handler (issue #150).
  *
  * GET  /ui/consent — server-renders the consent page given the same query
@@ -390,13 +402,20 @@ export default async function (fastify: FastifyInstance) {
       // The token is still burned on successful POST, and a new session
       // (re-login) always mints a new one.
       const csrfToken = session.csrfToken ?? generateCsrfToken();
-      if (!session.csrfToken) {
-        await fastify.sessionUtils.setSession<BrowserSessionData>(
-          session.sessionId,
-          { ...session, csrfToken },
-          env.SESSION_COOKIE_TTL
-        );
-      }
+
+      // Scope-presentation integrity (#150 hardening): bind the EXACT scope set
+      // the user is about to see to the session, keyed by client_id. The POST
+      // handler grants only these scopes — the hidden `scope` form field is
+      // attacker-controllable, so the persisted grant must match what was
+      // rendered, not what is submitted. Always persisted (the scope set can
+      // change between GETs for the same client), so this write also covers the
+      // first-time CSRF-token mint above.
+      const consentScopes = { ...(session.consentScopes ?? {}), [client.clientId]: scopes };
+      await fastify.sessionUtils.setSession<BrowserSessionData>(
+        session.sessionId,
+        { ...session, csrfToken, consentScopes },
+        env.SESSION_COOKIE_TTL
+      );
 
       reply.header('Content-Type', 'text/html; charset=utf-8');
       reply.header('Cache-Control', 'no-store');
@@ -608,7 +627,45 @@ export default async function (fastify: FastifyInstance) {
         );
       }
 
-      const scopes = filterRequestedScopes(body.scope, client);
+      // Scope-presentation integrity (#150 hardening). The hidden `scope` field
+      // is attacker-controllable, so we do NOT trust it to determine the granted
+      // set. The GET render bound the EXACT scopes shown to the user into the
+      // session, keyed by client_id. We grant those. As defence-in-depth we
+      // still re-filter the POSTed scopes against the client allowlist and
+      // require them to match the bound set: any divergence (a tampered hidden
+      // field that survived the allowlist intersection) is refused rather than
+      // silently granting a set the user never saw. A missing binding (a POST
+      // with no preceding GET in this session) is likewise refused.
+      const boundScopes = session.consentScopes?.[client.clientId];
+      const postedScopes = filterRequestedScopes(body.scope, client);
+      if (boundScopes === undefined || !scopeSetsEqual(boundScopes, postedScopes)) {
+        await fastify.repositories.auditLogs.create({
+          userId: session.userId,
+          oauthClientId: client.id,
+          event: 'oauth.consent.denied',
+          eventType: 'auth',
+          success: false,
+          ipAddress: request.ip,
+          userAgent: request.headers['user-agent'] || null,
+          metadata: {
+            error: 'invalid_scope',
+            reason: 'consent_scope_mismatch',
+            client_id: body.client_id,
+            bound: boundScopes ?? null,
+            posted: postedScopes,
+          },
+        });
+        return reply.redirect(
+          buildRedirectUrl(body.redirect_uri, {
+            error: 'invalid_scope',
+            error_description: 'consent scope does not match the rendered authorization request',
+            state: body.state ?? undefined,
+          }),
+          302
+        );
+      }
+      // Grant the bound (user-visible) scopes — never the raw POST body.
+      const scopes = boundScopes;
 
       // ADR-007 §2 (#185): step-up gate on the mint path. Re-authentication is
       // enforced HERE, not only pre-consent, because the hidden `scope`/`prompt`/

--- a/apps/auth-server/src/app/routes/ui/login.test.ts
+++ b/apps/auth-server/src/app/routes/ui/login.test.ts
@@ -1,0 +1,212 @@
+import type { FastifyInstance } from 'fastify';
+import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
+
+vi.mock('../../helpers/timing', () => ({
+  ensureMinimumResponseTime: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../../config/env', () => ({
+  env: {
+    DEFAULT_REALM_NAME: 'master',
+    SESSION_COOKIE_SECRET: 'test-secret-at-least-32-characters-long-padding',
+    SESSION_COOKIE_TTL: 3600,
+    SESSION_COOKIE_SECURE: false,
+    LOGIN_RATE_LIMIT: 5,
+    LOGIN_RATE_WINDOW: 900,
+  },
+}));
+
+import loginRoute from './login';
+
+interface TestContext {
+  get?: (request: any, reply: any) => Promise<unknown>;
+  post?: (request: any, reply: any) => Promise<unknown>;
+}
+
+function createReply() {
+  const state: {
+    statusCode?: number;
+    headers: Record<string, string>;
+    setCookies: string[];
+    redirected?: string;
+    body?: unknown;
+  } = { headers: {}, setCookies: [] };
+  const reply: any = {
+    cspNonce: { script: 'test-script-nonce', style: 'test-style-nonce' },
+    code(n: number) {
+      state.statusCode = n;
+      return reply;
+    },
+    header(k: string, v: string) {
+      // Mirror Fastify: Set-Cookie accumulates rather than overwriting.
+      if (k.toLowerCase() === 'set-cookie') {
+        state.setCookies.push(v);
+      } else {
+        state.headers[k] = v;
+      }
+      return reply;
+    },
+    redirect(url: string, code: number) {
+      state.redirected = url;
+      state.statusCode = code;
+      return reply;
+    },
+    send(body: unknown) {
+      state.body = body;
+      return body;
+    },
+  };
+  return { reply, state };
+}
+
+function makeFastify() {
+  const ctx: TestContext = {};
+  const fastify: any = {
+    withTypeProvider: () => ({
+      get: (_url: string, _opts: unknown, handler: any) => {
+        ctx.get = handler;
+        return fastify;
+      },
+      post: (_url: string, _opts: unknown, handler: any) => {
+        ctx.post = handler;
+        return fastify;
+      },
+    }),
+    repositories: {
+      realms: {
+        findByName: vi.fn().mockResolvedValue({ id: 'realm-1', name: 'master', enabled: true }),
+        create: vi.fn(),
+      },
+      users: {
+        findByEmail: vi.fn(),
+        updateLastLogin: vi.fn().mockResolvedValue(undefined),
+      },
+      auditLogs: {
+        create: vi.fn().mockResolvedValue(undefined),
+      },
+    },
+    passwordHasher: {
+      verifyPassword: vi.fn(),
+    },
+    sessionUtils: {
+      setSession: vi.fn().mockResolvedValue(undefined),
+    },
+    log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  };
+  return { fastify: fastify as FastifyInstance, ctx };
+}
+
+/** Extract the raw login-CSRF token from the Set-Cookie header rendered on GET. */
+function csrfCookieValue(setCookies: string[]): string {
+  const cookie = setCookies.find((c) => c.startsWith('__Host-qauth_login_csrf='));
+  if (!cookie) throw new Error('login CSRF cookie was not set');
+  return cookie.split('=')[1].split(';')[0];
+}
+
+describe('UI /ui/login — CSRF defence', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('GET sets a signed login-CSRF cookie and embeds the token in the form', async () => {
+    const { fastify, ctx } = makeFastify();
+    await loginRoute(fastify);
+
+    const { reply, state } = createReply();
+    await ctx.get!({ query: {}, headers: {}, ip: '127.0.0.1' }, reply);
+
+    const cookieValue = csrfCookieValue(state.setCookies);
+    // `<token>.<hmac>` — the raw token is the part before the separator.
+    const rawToken = cookieValue.split('.')[0];
+    expect(rawToken.length).toBeGreaterThan(0);
+    expect(state.body as string).toContain('name="csrf_token"');
+    expect(state.body as string).toContain(`value="${rawToken}"`);
+  });
+
+  it('POST rejects (403) when the CSRF token is missing/invalid — no credential check', async () => {
+    const { fastify, ctx } = makeFastify();
+    await loginRoute(fastify);
+
+    const { reply, state } = createReply();
+    await ctx.post!(
+      {
+        body: { email: 'user@example.com', password: 'pw', csrf_token: 'forged' },
+        // No valid CSRF cookie present.
+        headers: {},
+        ip: '127.0.0.1',
+      },
+      reply
+    );
+
+    expect(state.statusCode).toBe(403);
+    // The DB / password path must never be reached on a CSRF failure.
+    expect(fastify.repositories.users.findByEmail).not.toHaveBeenCalled();
+    expect(fastify.passwordHasher.verifyPassword).not.toHaveBeenCalled();
+    const events = (fastify.repositories.auditLogs.create as unknown as Mock).mock.calls.map(
+      (c) => (c[0] as { event: string }).event
+    );
+    expect(events).toContain('ui.login.csrf_failure');
+  });
+
+  it('POST succeeds when the submitted token matches the signed cookie', async () => {
+    const { fastify, ctx } = makeFastify();
+    await loginRoute(fastify);
+
+    // First GET to obtain a valid signed cookie + matching token.
+    const getReply = createReply();
+    await ctx.get!({ query: {}, headers: {}, ip: '127.0.0.1' }, getReply.reply);
+    const cookieValue = csrfCookieValue(getReply.state.setCookies);
+    const rawToken = cookieValue.split('.')[0];
+
+    (fastify.repositories.users.findByEmail as unknown as Mock).mockResolvedValue({
+      id: 'user-1',
+      email: 'user@example.com',
+      passwordHash: 'hash',
+      enabled: true,
+    });
+    (fastify.passwordHasher.verifyPassword as unknown as Mock).mockResolvedValue(true);
+
+    const { reply, state } = createReply();
+    await ctx.post!(
+      {
+        body: { email: 'user@example.com', password: 'correct', csrf_token: rawToken },
+        headers: { cookie: `__Host-qauth_login_csrf=${cookieValue}` },
+        ip: '127.0.0.1',
+      },
+      reply
+    );
+
+    expect(state.redirected).toBe('/');
+    expect(state.statusCode).toBe(302);
+    expect(fastify.sessionUtils.setSession).toHaveBeenCalledOnce();
+    // The login-CSRF cookie is burned on success (Max-Age=0).
+    const cleared = state.setCookies.find(
+      (c) => c.startsWith('__Host-qauth_login_csrf=') && c.includes('Max-Age=0')
+    );
+    expect(cleared).toBeDefined();
+  });
+
+  it('POST with a tampered token whose signature does not validate is rejected (403)', async () => {
+    const { fastify, ctx } = makeFastify();
+    await loginRoute(fastify);
+
+    // Obtain a valid cookie, then submit a DIFFERENT token value that the cookie
+    // signature does not cover.
+    const getReply = createReply();
+    await ctx.get!({ query: {}, headers: {}, ip: '127.0.0.1' }, getReply.reply);
+    const cookieValue = csrfCookieValue(getReply.state.setCookies);
+
+    const { reply, state } = createReply();
+    await ctx.post!(
+      {
+        body: { email: 'user@example.com', password: 'pw', csrf_token: 'a-different-token' },
+        headers: { cookie: `__Host-qauth_login_csrf=${cookieValue}` },
+        ip: '127.0.0.1',
+      },
+      reply
+    );
+
+    expect(state.statusCode).toBe(403);
+    expect(fastify.passwordHasher.verifyPassword).not.toHaveBeenCalled();
+  });
+});

--- a/apps/auth-server/src/app/routes/ui/login.ts
+++ b/apps/auth-server/src/app/routes/ui/login.ts
@@ -9,7 +9,16 @@ import { env } from '../../../config/env';
 import { MIN_RESPONSE_TIME_MS } from '../../constants';
 import { html, render } from '../../helpers/html';
 import { getOrCreateDefaultRealm } from '../../helpers/realm';
-import { setSessionCookie } from '../../helpers/session-cookie';
+import {
+  clearLoginCsrfCookie,
+  csrfTokensEqual,
+  generateCsrfToken,
+  LOGIN_CSRF_COOKIE_NAME,
+  readCookie,
+  setLoginCsrfCookie,
+  setSessionCookie,
+  verifyLoginCsrfCookie,
+} from '../../helpers/session-cookie';
 import { ensureMinimumResponseTime } from '../../helpers/timing';
 
 /**
@@ -39,10 +48,12 @@ function loginPage(opts: {
   returnTo: string;
   /** Per-request CSP nonce (issue #113) stamped onto the inline <style> tag. */
   cspNonce: string;
+  /** Signed double-submit CSRF token; mirrored in the __Host- login cookie. */
+  csrfToken: string;
   error?: string;
   email?: string;
 }): string {
-  const { returnTo, cspNonce, error, email } = opts;
+  const { returnTo, cspNonce, csrfToken, error, email } = opts;
   return render(
     html`<!doctype html>
       <html lang="en">
@@ -123,6 +134,7 @@ function loginPage(opts: {
             <h1>Sign in to QAuth</h1>
             ${error ? html`<div class="error">${error}</div>` : ''}
             <input type="hidden" name="return_to" value="${returnTo}" />
+            <input type="hidden" name="csrf_token" value="${csrfToken}" />
             <label>
               Email
               <input
@@ -148,6 +160,9 @@ const loginFormSchema = z.object({
   email: z.string().min(1),
   password: z.string().min(1),
   return_to: z.string().optional(),
+  // Signed double-submit CSRF token (login CSRF defence). Compared against the
+  // value carried in the __Host- login-CSRF cookie.
+  csrf_token: z.string().min(1),
 });
 
 type LoginForm = z.infer<typeof loginFormSchema>;
@@ -169,9 +184,21 @@ export default async function (fastify: FastifyInstance) {
     async (request, reply) => {
       const q = request.query as { return_to?: string; error?: string };
       const returnTo = isSafeReturnTo(q.return_to) ? q.return_to : '/';
+
+      // Login CSRF defence (signed double-submit). Reuse an already-valid CSRF
+      // cookie if the browser sent one (keeps a refreshed/multi-tab login page
+      // consistent with its cookie); otherwise mint a fresh token and set it.
+      const existing = verifyLoginCsrfCookie(readCookie(request, LOGIN_CSRF_COOKIE_NAME));
+      const csrfToken = existing ?? generateCsrfToken();
+      if (!existing) {
+        setLoginCsrfCookie(reply, csrfToken);
+      }
+
       reply.header('Content-Type', 'text/html; charset=utf-8');
       reply.header('Cache-Control', 'no-store');
-      return reply.send(loginPage({ returnTo, cspNonce: reply.cspNonce.style, error: q.error }));
+      return reply.send(
+        loginPage({ returnTo, cspNonce: reply.cspNonce.style, csrfToken, error: q.error })
+      );
     }
   );
 
@@ -195,6 +222,41 @@ export default async function (fastify: FastifyInstance) {
       const startTime = Date.now();
       const body = request.body as LoginForm;
       const returnTo = isSafeReturnTo(body.return_to) ? body.return_to : '/';
+
+      // Login CSRF defence (signed double-submit). Verify the __Host- cookie's
+      // signature, then timing-compare its token against the submitted field.
+      // A forged cross-site POST cannot present a matching pair because the
+      // attacker can neither read the victim's cookie nor sign one. Checked
+      // BEFORE any credential work so a CSRF probe never reaches the DB.
+      const cookieCsrf = verifyLoginCsrfCookie(readCookie(request, LOGIN_CSRF_COOKIE_NAME));
+      if (!cookieCsrf || !csrfTokensEqual(cookieCsrf, body.csrf_token)) {
+        await fastify.repositories.auditLogs.create({
+          userId: null,
+          oauthClientId: null,
+          event: 'ui.login.csrf_failure',
+          eventType: 'auth',
+          success: false,
+          ipAddress: request.ip,
+          userAgent: request.headers['user-agent'] || null,
+          metadata: {},
+        });
+        // Re-render with a fresh token so the user can retry legitimately.
+        const freshCsrf = generateCsrfToken();
+        setLoginCsrfCookie(reply, freshCsrf);
+        reply.header('Content-Type', 'text/html; charset=utf-8');
+        reply.header('Cache-Control', 'no-store');
+        reply.code(403);
+        return reply.send(
+          loginPage({
+            returnTo,
+            cspNonce: reply.cspNonce.style,
+            csrfToken: freshCsrf,
+            error: 'Your session expired. Please try again.',
+            email: body.email,
+          })
+        );
+      }
+
       const normalizedEmail = normalizeEmail(body.email);
 
       const realm = await getOrCreateDefaultRealm(fastify);
@@ -227,6 +289,9 @@ export default async function (fastify: FastifyInstance) {
           loginPage({
             returnTo,
             cspNonce: reply.cspNonce.style,
+            // The CSRF cookie is still valid on a credential failure — reuse it
+            // so the re-rendered form keeps matching the cookie.
+            csrfToken: cookieCsrf,
             error: 'Invalid email or password.',
             email: body.email,
           })
@@ -260,6 +325,10 @@ export default async function (fastify: FastifyInstance) {
       });
 
       setSessionCookie(reply, sessionId);
+      // Burn the login-CSRF cookie now that authentication succeeded. Fastify
+      // accumulates multiple Set-Cookie headers into an array, so this does not
+      // clobber the session cookie set just above.
+      clearLoginCsrfCookie(reply);
       reply.header('Cache-Control', 'no-store');
       return reply.redirect(returnTo, 302);
     }

--- a/apps/auth-server/src/app/schemas/oauth.ts
+++ b/apps/auth-server/src/app/schemas/oauth.ts
@@ -230,6 +230,22 @@ export const introspectRequestSchema = z.object({
 export type IntrospectRequest = z.infer<typeof introspectRequestSchema>;
 
 /**
+ * Token revocation request body (POST /oauth/revoke).
+ * RFC 7009 §2.1. The client authenticates with `client_secret_post` (body) or
+ * `client_secret_basic` (Authorization header); the route enforces that at
+ * least one auth method is used. `token_type_hint` is advisory only (§2.1):
+ * the server still determines the actual token type.
+ */
+export const revokeRequestSchema = z.object({
+  token: z.string().min(1),
+  token_type_hint: z.enum(['access_token', 'refresh_token']).optional(),
+  client_id: z.string().min(1).optional(),
+  client_secret: z.string().min(1).optional(),
+});
+
+export type RevokeRequest = z.infer<typeof revokeRequestSchema>;
+
+/**
  * Token introspection response body.
  * RFC 7662 2.2.
  */

--- a/libs/fastify/plugins/jwt/src/lib/fastify-plugin-jwt.ts
+++ b/libs/fastify/plugins/jwt/src/lib/fastify-plugin-jwt.ts
@@ -130,7 +130,22 @@ export const jwtPlugin = fp<JwtPluginOptions>(
       if (!token) {
         throw new JWTInvalidError('Missing or malformed Authorization header');
       }
-      request.jwtPayload = await jwtUtils.verifyAccessToken(token);
+      // RFC 9700 mix-up defence: every bearer-protected route MUST only accept
+      // tokens this server issued. Pin the issuer here so the shared preHandler
+      // rejects a foreign-issuer token even if it verifies under the same key.
+      const payload = await jwtUtils.verifyAccessToken(token, {
+        issuer: options.issuer,
+      });
+
+      // RFC 7009 revocation: reject a signature-valid but explicitly revoked
+      // token. The denylist check runs only AFTER verification (so an attacker
+      // cannot probe the store with unsigned tokens) and only when the host app
+      // wired a denylist; otherwise behaviour is unchanged.
+      if (options.isTokenRevoked && (await options.isTokenRevoked(payload.jti))) {
+        throw new JWTInvalidError('Token has been revoked');
+      }
+
+      request.jwtPayload = payload;
     }
 
     fastify.decorate('requireJwt', requireJwt);

--- a/libs/fastify/plugins/jwt/src/types.ts
+++ b/libs/fastify/plugins/jwt/src/types.ts
@@ -20,6 +20,14 @@ export interface JwtPluginOptions extends FastifyPluginOptions {
    * Required once key rotation is enabled; absent for a single-active-key setup.
    */
   keyId?: string;
+  /**
+   * Optional revocation denylist check (RFC 7009). When provided, the
+   * `requireJwt` preHandler calls it AFTER a successful signature/issuer
+   * verification with the verified token's `jti`; a truthy result rejects the
+   * request as if the token were invalid. Kept as a callback so the JWT plugin
+   * stays store-agnostic — the auth-server supplies a Redis-backed denylist.
+   */
+  isTokenRevoked?: (jti: string | undefined) => Promise<boolean> | boolean;
 }
 
 /**
@@ -97,11 +105,17 @@ export interface JwtUtils {
   /**
    * Verify an access token and return payload.
    * When `audience` is provided, the token's `aud` claim MUST match
-   * (string or array intersection per RFC 7519 §4.1.3).
+   * (string or array intersection per RFC 7519 §4.1.3). When `issuer` is
+   * provided, the token's `iss` claim MUST equal it (RFC 9700 mix-up
+   * defence); omit it only when the caller deliberately accepts any issuer.
    * @throws JWTExpiredError if token has expired
-   * @throws JWTInvalidError if token is invalid or audience mismatches
+   * @throws JWTInvalidError if token is invalid, audience mismatches, or the
+   *   issuer mismatches
    */
-  verifyAccessToken(token: string, options?: { audience?: string | string[] }): Promise<JWTPayload>;
+  verifyAccessToken(
+    token: string,
+    options?: { audience?: string | string[]; issuer?: string }
+  ): Promise<JWTPayload>;
   /**
    * Extract JWT token from Authorization header
    * @param authHeader - Authorization header value (e.g., "Bearer <token>")

--- a/libs/server/jwt/src/lib/jwt-service.test.ts
+++ b/libs/server/jwt/src/lib/jwt-service.test.ts
@@ -257,4 +257,60 @@ describe('verifyAccessToken', () => {
     expect(decoded.sub).toBe(payload.sub);
     expect(decoded.email).toBe(payload.email);
   });
+
+  it('rejects a token whose issuer does not match the expected issuer', async () => {
+    const { privateKey, publicKey } = await generateEdDSAKeyPair();
+    const token = await signAccessToken(
+      { sub: 'user-iss', email: 'iss@example.com', email_verified: true, clientId: 'client-iss' },
+      privateKey,
+      'https://attacker.example.com',
+      900
+    );
+
+    // RFC 9700 mix-up defence: a valid signature is NOT sufficient — the issuer
+    // must also match. A token from a different AS (even under the same key) is
+    // rejected when the expected issuer is supplied.
+    await expect(
+      verifyAccessToken(token, publicKey, { issuer: 'https://auth.example.com' })
+    ).rejects.toThrow(JWTInvalidError);
+  });
+
+  it('accepts a token whose issuer matches the expected issuer', async () => {
+    const { privateKey, publicKey } = await generateEdDSAKeyPair();
+    const token = await signAccessToken(
+      { sub: 'user-iss-ok', email: 'ok@example.com', email_verified: true, clientId: 'client-ok' },
+      privateKey,
+      'https://auth.example.com',
+      900
+    );
+
+    const decoded = await verifyAccessToken(token, publicKey, {
+      issuer: 'https://auth.example.com',
+    });
+    expect(decoded.sub).toBe('user-iss-ok');
+    expect(decoded.iss).toBe('https://auth.example.com');
+  });
+});
+
+describe('access token jti claim (RFC 7009 revocation support)', () => {
+  it('stamps a unique jti on every access token and surfaces it on verify', async () => {
+    const { privateKey, publicKey } = await generateEdDSAKeyPair();
+    const payload = {
+      sub: 'user-jti',
+      email: 'jti@example.com',
+      email_verified: true,
+      clientId: 'client-jti',
+    };
+
+    const tokenA = await signAccessToken(payload, privateKey, 'https://auth.example.com', 900);
+    const tokenB = await signAccessToken(payload, privateKey, 'https://auth.example.com', 900);
+
+    const decodedA = await verifyAccessToken(tokenA, publicKey);
+    const decodedB = await verifyAccessToken(tokenB, publicKey);
+
+    expect(decodedA.jti).toBeDefined();
+    expect(decodedB.jti).toBeDefined();
+    // Each token gets its own id so a single token can be revoked individually.
+    expect(decodedA.jti).not.toBe(decodedB.jti);
+  });
 });

--- a/libs/server/jwt/src/lib/jwt-service.ts
+++ b/libs/server/jwt/src/lib/jwt-service.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from 'node:crypto';
+
 import { JWTExpiredError, JWTInvalidError } from '@qauth-labs/shared-errors';
 import { jwtVerify, SignJWT } from 'jose';
 
@@ -36,6 +38,10 @@ export async function signAccessToken(
   const claims: Record<string, unknown> = {
     sub: payload.sub,
     client_id: payload.clientId,
+    // RFC 7519 §4.1.7 `jti` — a unique identifier per access token. Enables
+    // targeted revocation (RFC 7009): the auth-server maintains a denylist
+    // keyed by `jti` so a specific unexpired token can be invalidated.
+    jti: randomUUID(),
     // Token-use marker (token-confusion defence): every token minted by this
     // function is an OAuth access token. Consumers that must accept ONLY access
     // tokens — e.g. RFC 8693 token-exchange subject tokens — assert this so a
@@ -176,11 +182,15 @@ export async function signIdToken(
 export async function verifyAccessToken(
   token: string,
   publicKey: KeyLike,
-  options: { audience?: string | string[] } = {}
+  options: { audience?: string | string[]; issuer?: string } = {}
 ): Promise<JWTPayload> {
   try {
     const { payload } = await jwtVerify(token, publicKey, {
       algorithms: ['EdDSA'],
+      // RFC 9700 / mix-up defence: when the caller supplies the expected
+      // issuer, jose asserts the `iss` claim matches and rejects otherwise.
+      // The alg stays pinned to EdDSA so `none`/alg-confusion is impossible.
+      ...(options.issuer !== undefined ? { issuer: options.issuer } : {}),
       ...(options.audience !== undefined ? { audience: options.audience } : {}),
     });
 
@@ -197,6 +207,10 @@ export async function verifyAccessToken(
       iat: payload.iat as number | undefined,
       exp: payload.exp as number | undefined,
       iss: payload.iss as string | undefined,
+      // RFC 7009 revocation: surface the unique token id so the auth-server
+      // layer can denylist a specific access token. The lib stays pure — it
+      // never consults any revocation store itself.
+      jti: payload.jti as string | undefined,
       token_use: payload['token_use'] as string | undefined,
     };
   } catch (error) {

--- a/libs/server/jwt/src/types/jwt-service.ts
+++ b/libs/server/jwt/src/types/jwt-service.ts
@@ -98,6 +98,13 @@ export interface JWTPayload extends SignAccessTokenPayload {
   /** Issuer */
   iss?: string;
   /**
+   * JWT ID (RFC 7519 §4.1.7). `signAccessToken` stamps a unique value on every
+   * access token so a specific token can be revoked (RFC 7009) by adding its
+   * `jti` to the auth-server's denylist. Absent on legacy tokens minted before
+   * this claim existed.
+   */
+  jti?: string;
+  /**
    * Token-use marker. `signAccessToken` always stamps `'access'` so consumers
    * can distinguish a genuine access token from any other JWT signed with the
    * same key (token-confusion defence — e.g. an ID token must not be accepted


### PR DESCRIPTION
## Summary

Pre-launch hardening pass on the auth surface. Findings came from a code-traced security review (each issue confirmed in the route handlers, not inferred). The dependency audit was clean (prod + dev, no known vulnerabilities). The baseline is already strong — PKCE S256-only with a downgrade floor, exact-match redirect URIs, atomic refresh-token rotation with family replay revocation, RFC 8693 delegation gating, SSRF-hardened CIMD fetch, `__Host-` signed sessions, timing-safe password verify, deny-by-default scopes — so these are the residual gaps.

## Findings fixed

| # | Severity | Fix |
|---|----------|-----|
| 1 | Medium | **Register enumeration** — duplicate-email no longer leaks the DB `constraint` name (or it via the message); logged for operators only, generic response. |
| 2 | Medium | **userinfo scope-gating** (OIDC Core §5.4) — `email`/`email_verified` require the `email` scope, `name` requires `profile`; `sub` always returned. |
| 3 | Medium | **Login CSRF** — `/ui/login` POST now requires a signed (`__Host-`) double-submit CSRF token, verified before any credential work. Defends against forced-login. |
| 4 | Medium | **JWT `iss` validation** — `verifyAccessToken` now pins the issuer (RFC 9700 mix-up defence) across `requireJwt`, introspect, authorize and token-exchange; the duplicated manual issuer check is removed (the `token_use` purpose assertion is kept). |
| 5 | Medium | **Token revocation (RFC 7009)** — new `POST /oauth/revoke` (confidential-client auth, owner-only, always-200) + a Redis `jti` denylist for stateless access tokens, enforced in `requireJwt` and introspection. `jti` added to access tokens; `revocation_endpoint` advertised in discovery. |
| 6 | Low | **Consent scope integrity** — the rendered scope set is bound to the session on GET and granted verbatim on POST; a tampered hidden `scope` field is rejected (`invalid_scope` + audit). |

## Design notes

- **Revocation hot-path is fail-closed.** The `jti` denylist check runs only *after* signature verification (no unsigned-token probing) and only when the host app wires it. The denylist helper propagates Redis errors rather than silently treating a token as un-revoked, and `requireJwt` doesn't swallow them — a Redis outage denies rather than admits a possibly-revoked token. Consistent with Redis already being a hard dependency (sessions, rate-limit). Denylist entries carry a TTL = the token's remaining lifetime, so the store self-evicts and never grows unbounded.
- **JWT lib stays pure.** The denylist lives in the auth-server layer; `@qauth-labs/server-jwt` / `fastify-plugin-jwt` remain store-agnostic (wired via an `isTokenRevoked` plugin option), preserving the plugin boundary.
- `/oauth/revoke` reuses the introspect rate-limit tier; no new env keys.

## Tests

New: `revoke.test.ts` (family revoke, cross-client no-op, unknown-token 200, jti denylist + TTL, foreign-client access token, invalid_client), `login.test.ts` (CSRF cookie/token, missing/invalid → 403 with no DB hit, valid succeeds + burns cookie, bad signature). Updated: jwt-service (issuer reject/accept, unique jti), userinfo (scope-gating), error-handler (no constraint leak), consent (tamper-binding), introspect (revoked → inactive), authorize/token stubs for issuer pinning.

**Verified locally:** affected `test` + `lint` (0 errors) + `build` + `typecheck` all pass — 545 auth-server + 44 server-jwt + 7 fastify-plugin-jwt tests green.

## Reviewer note

The login success path emits two `Set-Cookie` headers (new session + cleared CSRF), relying on Fastify accumulating `Set-Cookie` into an array (standard behavior; asserted in `login.test.ts`).