### PR TITLE
fix(oauth): cap DCR scopes to realm allowlist instead of rejecting

### DIFF
--- a/apps/auth-server/src/app/helpers/dynamic-client-registration.test.ts
+++ b/apps/auth-server/src/app/helpers/dynamic-client-registration.test.ts
@@ -54,28 +54,39 @@ describe('validateAndNormalize', () => {
     expect(n.scopeString).toBe('openid email');
   });
 
-  it('rejects scopes outside the realm allowlist', () => {
-    expect(() =>
-      validateAndNormalize(
-        {
-          redirect_uris: ['https://app.example/cb'],
-          scope: 'openid memory:admin',
-        },
-        allowedScopes
-      )
-    ).toThrow(/invalid_client_metadata.*memory:admin/);
+  it('caps out scopes outside the realm allowlist instead of rejecting (RFC 7591 §2)', () => {
+    const n = validateAndNormalize(
+      {
+        redirect_uris: ['https://app.example/cb'],
+        scope: 'openid memory:admin',
+      },
+      allowedScopes
+    );
+    expect(n.scopes).toEqual(['openid']);
+    expect(n.scopeString).toBe('openid');
   });
 
-  it('rejects all scopes when the realm allowlist is empty', () => {
-    expect(() =>
-      validateAndNormalize(
-        {
-          redirect_uris: ['https://app.example/cb'],
-          scope: 'openid',
-        },
-        []
-      )
-    ).toThrow(BadRequestError);
+  it('de-dupes requested scopes while capping', () => {
+    const n = validateAndNormalize(
+      {
+        redirect_uris: ['https://app.example/cb'],
+        scope: 'openid openid email memory:admin',
+      },
+      allowedScopes
+    );
+    expect(n.scopes).toEqual(['openid', 'email']);
+  });
+
+  it('drops all scopes when the realm allowlist is empty', () => {
+    const n = validateAndNormalize(
+      {
+        redirect_uris: ['https://app.example/cb'],
+        scope: 'openid',
+      },
+      []
+    );
+    expect(n.scopes).toEqual([]);
+    expect(n.scopeString).toBeUndefined();
   });
 
   it('requires redirect_uris for authorization_code grants', () => {

--- a/apps/auth-server/src/app/helpers/dynamic-client-registration.ts
+++ b/apps/auth-server/src/app/helpers/dynamic-client-registration.ts
@@ -169,20 +169,21 @@ export function validateAndNormalize(
     validateRedirectUri(uri);
   }
 
-  // Scope cap: intersect with the realm's allowlist. An empty allowlist
-  // means "no custom scopes allowed" and we reject any requested scope.
+  // Scope cap: intersect requested scopes with the realm's allowlist. Per
+  // RFC 7591 §2, the authorization server MAY register the client with a
+  // narrower scope than requested rather than rejecting — and we do, so
+  // discover-then-register MCP clients register cleanly. Such clients echo
+  // back the protected resource's full advertised `scopes_supported`
+  // (RFC 9728), which routinely includes privileged scopes a public dynamic
+  // client can't hold; hard-rejecting the whole registration on those would
+  // break every standards-compliant MCP client. We drop the disallowed
+  // scopes and register the permitted subset (empty allowlist → no scopes).
+  // De-dupe while preserving request order.
   let scopes: string[] = [];
   const scopeString = body.scope;
   if (scopeString && scopeString.trim().length > 0) {
     const requested = scopeString.split(/\s+/).filter((s) => s.length > 0);
-    const disallowed = requested.filter((s) => !realmAllowedScopes.includes(s));
-    if (disallowed.length > 0) {
-      rejectRegistration(
-        'invalid_client_metadata',
-        `scope not permitted for dynamic registration: ${disallowed.join(' ')}`
-      );
-    }
-    scopes = requested;
+    scopes = [...new Set(requested.filter((s) => realmAllowedScopes.includes(s)))];
   }
 
   // Auth method gating.

--- a/apps/auth-server/src/app/routes/oauth/register.test.ts
+++ b/apps/auth-server/src/app/routes/oauth/register.test.ts
@@ -199,27 +199,32 @@ describe('POST /oauth/register — Dynamic Client Registration (RFC 7591)', () =
     expect(result.client_secret_expires_at).toBe(0);
   });
 
-  it('rejects scopes outside the realm allowlist (scope cap)', async () => {
+  it('caps scopes outside the realm allowlist instead of rejecting (RFC 7591 §2)', async () => {
     const { fastify, ctx } = createFastifyStub();
     await registerRoute(fastify);
 
     const { reply } = createReply();
 
-    await expect(
-      ctx.handler!(
-        {
-          body: {
-            redirect_uris: ['https://app.example/cb'],
-            grant_types: ['authorization_code'],
-            response_types: ['code'],
-            scope: 'openid memory:admin',
-          },
-          ip: '127.0.0.1',
-          headers: {},
+    // A discover-then-register MCP client echoes back the resource's full
+    // advertised `scopes_supported`, which can include privileged scopes a
+    // public dynamic client may not hold (here `memory:admin`). Rather than
+    // failing the whole registration, we register the permitted subset.
+    const result = (await ctx.handler!(
+      {
+        body: {
+          redirect_uris: ['https://app.example/cb'],
+          grant_types: ['authorization_code'],
+          response_types: ['code'],
+          scope: 'openid memory:admin',
         },
-        reply
-      )
-    ).rejects.toBeInstanceOf(BadRequestError);
+        ip: '127.0.0.1',
+        headers: {},
+      },
+      reply
+    )) as Record<string, unknown>;
+
+    expect(result.client_id).toBeDefined();
+    expect(result.scope).toBe('openid');
   });
 
   it('rejects http:// redirect_uris for non-loopback hosts (OAuth 2.1 §10.3)', async () => {


### PR DESCRIPTION
## Problem

Discover-then-register MCP clients (OpenCode, and the MCP SDK generally) echo back the protected resource's full advertised `scopes_supported` (RFC 9728) at dynamic registration. When that set includes a privileged scope a public dynamic client can't hold (e.g. `memory:read:stats`), qauth's DCR **hard-rejected the whole registration** with `invalid_client_metadata` — breaking the entire OAuth flow before the user ever saw a consent screen.

This contradicted `validateAndNormalize`'s own docstring ("Caps requested scopes to the realm's allowlist / intersect with the allowlist") and RFC 7591 §2 (the AS MAY register a client with a narrower scope than requested).

## Fix

`validateAndNormalize` now intersects requested scopes with the realm allowlist and registers the permitted subset (de-duped, order-preserving). Empty allowlist → no scopes. The RFC 7591 `scope` echo-back reflects the effective (capped) scope.

The operator-facing admin clients CRUD route keeps its hard-reject (a misconfigured admin should get a clear error, not silent capping) — it doesn't share this code path.

## Tests

- `dynamic-client-registration.test.ts`: flipped the two reject assertions to capping; added a de-dupe case.
- `register.test.ts`: DCR route now asserts a successful registration with capped scope.
- All 64 tests in the touched files pass.

Unblocks OpenCode → majordomo-memory MCP auth.