### PR TITLE
fix(oauth): allow http loopback redirects when PKCE is enforced (ADR-008)

### DIFF
--- a/apps/auth-server/src/app/helpers/oauth-redirect.test.ts
+++ b/apps/auth-server/src/app/helpers/oauth-redirect.test.ts
@@ -39,13 +39,25 @@ describe('oauth-redirect — isRedirectUriAllowedForPolicy (ADR-008 §5, #197)',
     ).toBe(true);
   });
 
-  it('staging and production reject http://localhost (https-only)', () => {
+  it('staging and production permit http://localhost because PKCE is enforced (RFC 8252 native/CLI)', () => {
     expect(
       isRedirectUriAllowedForPolicy('http://localhost:3000/cb', ENVIRONMENT_PROFILES.staging)
-    ).toBe(false);
+    ).toBe(true);
     expect(
       isRedirectUriAllowedForPolicy('http://127.0.0.1/cb', ENVIRONMENT_PROFILES.production)
-    ).toBe(false);
+    ).toBe(true);
+  });
+
+  it('rejects http://localhost for a hypothetical non-dev profile without PKCE (fail-safe)', () => {
+    // Guards the invariant: loopback is only conceded when PKCE backstops
+    // code interception. A non-`development` profile that drops pkceRequired
+    // must still reject plain-HTTP loopback.
+    const noPkceNonDev = {
+      ...ENVIRONMENT_PROFILES.production,
+      localhostRedirectAllowed: false,
+      pkceRequired: false,
+    };
+    expect(isRedirectUriAllowedForPolicy('http://localhost:3000/cb', noPkceNonDev)).toBe(false);
   });
 
   it('https redirects are permitted in every environment (the gate never widens)', () => {

--- a/apps/auth-server/src/app/helpers/oauth-redirect.ts
+++ b/apps/auth-server/src/app/helpers/oauth-redirect.ts
@@ -43,16 +43,23 @@ export function isHttpLocalhostRedirect(redirectUri: string): boolean {
  * Whether a (already registered, exact-matched) `redirect_uri` is permitted
  * under the effective environment policy (ADR-008 §5, #197).
  *
- * The ONLY environment-gated case is an `http://localhost` (loopback) redirect:
- * permitted for a `development` client (`localhostRedirectAllowed`), rejected as
- * https-only for `staging`/`production`. Everything else — any https URI, any
+ * The ONLY environment-gated case is an `http://localhost` (loopback) redirect.
+ * It is permitted when EITHER the environment opts in
+ * (`localhostRedirectAllowed`, i.e. `development`) OR PKCE is enforced
+ * (`pkceRequired`, i.e. `staging`/`production`). Loopback redirects are the
+ * RFC 8252 standard for native / CLI clients — including every discover-then-
+ * register MCP client — and the traffic never leaves the device; PKCE (S256)
+ * is precisely what backstops loopback authorization-code interception on a
+ * shared host. So loopback + PKCE is safe in any environment, and gating it
+ * on PKCE (rather than https-only) is what lets native clients complete the
+ * auth-code flow against a production AS. Everything else — any https URI, any
  * custom-scheme native redirect — is unaffected and returns true; this gate
- * never widens what is allowed, it only withholds the plain-HTTP-loopback
- * convenience outside development.
+ * never widens what is allowed.
  *
- * FAIL-SAFE: an unset client/realm resolves to the `production` profile, whose
- * `localhostRedirectAllowed` is false, so a misconfigured deployment rejects
- * plain-HTTP loopback redirects (the hardened direction).
+ * FAIL-SAFE: a future non-`development` profile that ALSO drops `pkceRequired`
+ * would once again reject plain-HTTP loopback (no PKCE → interceptable), the
+ * hardened direction. An unset client/realm still resolves to `production`,
+ * which requires PKCE and therefore now permits loopback + PKCE.
  *
  * NB: this is a SECOND gate, layered after the existing exact-match check
  * (`client.redirectUris.includes(redirect_uri)`) — it does not replace it. A
@@ -63,7 +70,7 @@ export function isRedirectUriAllowedForPolicy(
   policy: EnvironmentPolicy
 ): boolean {
   if (!isHttpLocalhostRedirect(redirectUri)) return true;
-  return policy.localhostRedirectAllowed;
+  return policy.localhostRedirectAllowed || policy.pkceRequired;
 }
 
 /**

--- a/apps/auth-server/src/app/routes/oauth/authorize.test.ts
+++ b/apps/auth-server/src/app/routes/oauth/authorize.test.ts
@@ -852,20 +852,28 @@ describe('GET /oauth/authorize — environment localhost redirect gate (ADR-008 
     };
   }
 
-  it('production realm/client REJECTS an http://localhost redirect (https-only)', async () => {
-    const { fastify, call } = await run('production', 'production');
-    await expect(call()).rejects.toThrow(/redirect_uri/);
-    expect(fastify.repositories.authorizationCodes.create).not.toHaveBeenCalled();
+  // ADR-008 (revised): http://localhost (loopback) redirects are the RFC 8252
+  // standard for native / CLI clients (incl. MCP clients). They pass the gate
+  // whenever PKCE is enforced — true for staging/production — so loopback +
+  // PKCE works against a production AS. "Passing the gate" means the request
+  // is not rejected and flows on to the unauthenticated login redirect (these
+  // requests carry no session).
+  it('production realm/client PERMITS http://localhost (PKCE enforced — RFC 8252)', async () => {
+    const { state, call } = await run('production', 'production');
+    await call();
+    expect(state.redirected).toContain('/ui/login?return_to=');
   });
 
-  it('staging client REJECTS an http://localhost redirect (https-only)', async () => {
-    const { call } = await run('staging', 'staging');
-    await expect(call()).rejects.toThrow(/redirect_uri/);
+  it('staging client PERMITS http://localhost (PKCE enforced)', async () => {
+    const { state, call } = await run('staging', 'staging');
+    await call();
+    expect(state.redirected).toContain('/ui/login?return_to=');
   });
 
-  it('an UNSET environment fails safe to production and REJECTS http://localhost', async () => {
-    const { call } = await run('bogus', 'also-bogus');
-    await expect(call()).rejects.toThrow(/redirect_uri/);
+  it('an UNSET environment fails safe to production, which PERMITS http://localhost (PKCE enforced)', async () => {
+    const { state, call } = await run('bogus', 'also-bogus');
+    await call();
+    expect(state.redirected).toContain('/ui/login?return_to=');
   });
 
   it('development realm/client PERMITS http://localhost (passes the gate, proceeds to login)', async () => {
@@ -876,8 +884,9 @@ describe('GET /oauth/authorize — environment localhost redirect gate (ADR-008 
     expect(state.redirected).toContain('/ui/login?return_to=');
   });
 
-  it('a production realm caps a development client and REJECTS http://localhost (ceiling wins)', async () => {
-    const { call } = await run('production', 'development');
-    await expect(call()).rejects.toThrow(/redirect_uri/);
+  it('a production realm caps a development client but still PERMITS http://localhost (PKCE enforced)', async () => {
+    const { state, call } = await run('production', 'development');
+    await call();
+    expect(state.redirected).toContain('/ui/login?return_to=');
   });
 });

--- a/docs/adr/008-environment-aware-authorization.md
+++ b/docs/adr/008-environment-aware-authorization.md
@@ -24,9 +24,22 @@ Two needs collided while finishing the MVP and planning T3:
    ergonomics.
 2. **Production safety.** A static, non-expiring bearer is exactly what you do
    **not** want facing the internet. The same tension applies across the board:
-   `http://localhost` redirect URIs, long token lifespans, lenient rate limits,
-   open dynamic registration, and relaxed agent step-up are all fine for local
-   work and dangerous in production.
+   static API keys, long token lifespans, lenient rate limits, open dynamic
+   registration, and relaxed agent step-up are all fine for local work and
+   dangerous in production.
+
+> **Loopback redirect carve-out (revised).** `http://` loopback redirect URIs
+> (`127.0.0.1` / `[::1]` / `localhost`) were originally `development`-only.
+> They are now permitted in any environment that **enforces PKCE** (i.e.
+> `staging`/`production`). Loopback redirects are the RFC 8252 standard for
+> native / CLI clients — including every discover-then-register MCP client —
+> and the traffic never leaves the device; PKCE (S256) is precisely what
+> backstops loopback authorization-code interception on a shared host. Gating
+> loopback on `https` (rather than on PKCE) only blocked the legitimate
+> native-app flow without adding security, since `validateRedirectUri` already
+> rejects all non-loopback plain-HTTP redirects. The fail-safe still holds: a
+> non-`development` profile that drops PKCE would once again reject plain-HTTP
+> loopback. See `isRedirectUriAllowedForPolicy`.
 
 Today these are scattered, mostly-global knobs. T3 (OIDC conformance &
 hardening — #108 CSRF, #109 secure cookies, #113 helmet, …) is about to add more.
@@ -105,17 +118,17 @@ laxer profiles relax specific knobs. Security-relevant relaxations apply to
 only operational conveniences (so promoting dev→staging surfaces security
 posture before production).
 
-| Knob                                          | development         | staging                    | production |
-| --------------------------------------------- | ------------------- | -------------------------- | ---------- |
-| **Static API keys (#97/#98)**                 | allowed, long-lived | off (or short-TTL, opt-in) | off        |
-| `http://localhost` redirect URIs              | allowed             | https-only                 | https-only |
-| PKCE (`S256`)                                 | recommended         | required                   | required   |
-| Access-token lifespan                         | long                | short                      | short      |
-| Refresh-token rotation                        | optional            | required                   | required   |
-| Rate limits                                   | lenient             | lenient (load testing)     | strict     |
-| Open DCR / CIMD                               | open                | gated                      | gated      |
-| Agent step-up before dangerous ops            | relaxed             | enforced                   | enforced   |
-| Security headers / CSRF / secure cookies (T3) | relaxed             | enforced                   | enforced   |
+| Knob                                          | development         | staging                    | production                 |
+| --------------------------------------------- | ------------------- | -------------------------- | -------------------------- |
+| **Static API keys (#97/#98)**                 | allowed, long-lived | off (or short-TTL, opt-in) | off                        |
+| `http://localhost` (loopback) redirect URIs   | allowed             | allowed (PKCE-backstopped) | allowed (PKCE-backstopped) |
+| PKCE (`S256`)                                 | recommended         | required                   | required                   |
+| Access-token lifespan                         | long                | short                      | short                      |
+| Refresh-token rotation                        | optional            | required                   | required                   |
+| Rate limits                                   | lenient             | lenient (load testing)     | strict                     |
+| Open DCR / CIMD                               | open                | gated                      | gated                      |
+| Agent step-up before dangerous ops            | relaxed             | enforced                   | enforced                   |
+| Security headers / CSRF / secure cookies (T3) | relaxed             | enforced                   | enforced                   |
 
 Each row is a default; an operator may override a single knob, but **only within
 the realm ceiling** and never below the hard security floors (e.g. a client


### PR DESCRIPTION
## Problem

ADR-008's environment gate permitted `http://localhost` (loopback) redirect URIs only in `development`; `staging`/`production` were https-only. But loopback redirects (`127.0.0.1` / `[::1]` / `localhost`) are the **RFC 8252** standard for native / CLI clients — including every discover-then-register MCP client (OpenCode, Claude Code on re-auth) — which can't use an https redirect. A DCR client fail-safes to `production`, so the authorize step rejected its loopback redirect with `redirect_uri not permitted for this environment`, killing the flow after a successful registration.

Since `validateRedirectUri` already rejects **all** non-loopback plain-HTTP redirects, this gate's only effect was blocking the legitimate native-app flow — with no security gain. PKCE (S256), already required in staging/production, is exactly what backstops loopback authorization-code interception on a shared host (the RFC 8252 rationale).

## Fix

`isRedirectUriAllowedForPolicy` now permits a loopback redirect when the policy **either** opts in (`development`) **or** enforces PKCE (`staging`/`production`). Loopback + PKCE is safe in any environment.

**Fail-safe preserved:** a hypothetical non-`development` profile that drops PKCE would once again reject plain-HTTP loopback (covered by a new unit test).

## Tests + docs

- `oauth-redirect.test.ts`: staging/production now permit loopback; added the no-PKCE-non-dev rejection guard.
- `authorize.test.ts`: the four env-gate route tests now assert loopback **passes** the gate (proceeds to login) in production/staging/unset/capped-dev.
- ADR-008 updated (profile table + a 'Loopback redirect carve-out' note).
- All 83 tests across the touched files pass.