### PR TITLE
docs: align schema skill, PRD, and db README with shipped code

### DIFF
--- a/.claude/skills/schema/SKILL.md
+++ b/.claude/skills/schema/SKILL.md
@@ -1,70 +1,144 @@
 ---
 name: schema
-description: Database schema rules for QAuth. Use when working with the identity model, user_credentials, user_attributes, Drizzle ORM, migrations, or claim resolution. Enforces the identifier-abstraction design (no email/password on users table).
+description: Database schema rules for QAuth. Use when working with the identity model, Drizzle ORM, migrations, repositories, or claim resolution. Reflects the CURRENT shipped schema (monolithic users table). The identifier-abstraction model (ADR-002) is planned but NOT yet implemented.
 ---
 
 # Schema Rules
 
-You are working in the QAuth database layer.
+You are working with the QAuth database layer. This document reflects the
+**CURRENT shipped schema** (Phase 1–3 modular monolith, MCP-first per
+[ADR-007]). The planned identifier-abstraction migration ([ADR-002]) is
+**deferred to the Phase 4 wallet-federation gate** and is summarised in the
+"Planned (not yet implemented)" section at the end. Write code against the
+shipped schema, not the planned one.
 
-## Identity Model
+[ADR-007]: ../../docs/adr/007-mcp-first-positioning.md
+[ADR-002]: ../../docs/adr/002-identifier-abstraction.md
 
-The `users` table is an identity anchor only. It has no email, no password_hash,
-and no credential-specific fields. Its columns are: `id`, `realm_id`, `enabled`,
-`metadata`, `created_at`, `updated_at`, `last_login_at`.
+## Identity Model (CURRENT — shipped)
 
-Authentication methods live in `user_credentials`:
+The `users` table IS the identity anchor **and** carries the password
+credential. There is no `user_credentials` or `user_attributes` table today.
+The columns QAuth persists on `users` are (see `libs/infra/db/src/lib/schema/core.ts`):
 
-- `provider_type = 'password'` → `external_sub` is the normalized email address,
-  `credential_data` has `{ password_hash, email_verified, email_verified_at? }`
-- `provider_type = 'wallet'` → `external_sub` is a DID or issuer-assigned subject,
-  `credential_data` has `{ wallet_provider, assurance_level, vc_types, last_vp_verified_at? }`
-- `provider_type = 'oidc_*'` → `external_sub` is the upstream `sub` claim,
-  `credential_data` has `{ iss, email?, email_verified? }`
+- `id` (uuidv7, PK)
+- `realm_id` (FK → realms, cascade delete)
+- `email` (varchar(255), NOT NULL)
+- `email_normalized` (varchar(255), NOT NULL) — `(realm_id, email_normalized)` is `UNIQUE`
+- `password_hash` (text, NOT NULL) — Argon2id hash of the password
+- `email_verified` (boolean, default false)
+- `email_verified_at` (bigint, epoch-ms, nullable)
+- `enabled` (boolean, default true)
+- `first_name`, `last_name` (varchar(255), nullable) — sourced into the OIDC `name` claim
+- `metadata` (jsonb, nullable)
+- `created_at`, `updated_at` (bigint NOT NULL, epoch-ms)
+- `last_login_at` (bigint, nullable)
 
-Attributes (email, name, birthdate) live in `user_attributes` with source tracking.
-Each attribute row has a `source` field indicating where it came from.
+### Login lookup (password auth)
 
-## OIDC Claims
+```sql
+SELECT * FROM users
+WHERE realm_id = $realm_id
+  AND email_normalized = $normalized_email
+```
 
-Email is present in tokens only if verified. The `email` claim is **omitted entirely**
-when no verified email exists — it is not set to null. Applications must handle
-absent email claims. This is correct OIDC behaviour per OIDC Core 1.0.
+The repository method is `usersRepository.findByEmail(realm_id, email, tx?)`,
+which normalises the email before querying. There is no `user_credentials`
+join — password auth reads `users.password_hash` directly.
 
-OIDC `sub` claim is always `users.id` (UUID). Never email. Never `external_sub`.
+### Registration (`POST /auth/register`)
+
+1. `INSERT INTO users (realm_id, email, email_normalized, password_hash, email_verified=false)` —
+   identity anchor + password credential in one row.
+2. `INSERT INTO email_verification_tokens (user_id → users.id, token_hash, expires_at)` —
+   the verification token references `users.id`, NOT a credential id.
+3. On email verification: set `users.email_verified=true` and `users.email_verified_at=now()`.
+
+## OIDC Claims (shipped behaviour)
+
+- `sub` — always `users.id` (UUIDv7). Never the email.
+- `email` — `users.email`. **Present even when unverified** today; the login
+  route does NOT block unverified emails (the check is commented out at
+  `apps/auth-server/src/app/routes/auth/login.ts:85`). This is an MVP posture
+  — see finding F-08 and the planned `REQUIRE_EMAIL_VERIFIED` config flag.
+- `email_verified` — `users.email_verified`.
+- `name` — derived from `users.first_name` + `users.last_name` (omitted when
+  both are empty, never an empty string).
+
+> NOTE: OIDC Core 1.0 says `email` should be **omitted** when unverified. The
+> planned identifier-abstraction model (ADR-002) tightens this; today QAuth
+> emits it. Document this trade-off rather than silently changing it.
+
+## Core Tables (shipped)
+
+Schema lives in `libs/infra/db/src/lib/schema/`:
+
+| Table                       | Schema file   | Purpose                                                                                                       |
+| --------------------------- | ------------- | ------------------------------------------------------------------------------------------------------------- |
+| `realms`                    | `core.ts`     | Multi-tenancy root; realm-level policy (env ceiling, rate-limit tier, allowed scopes, password policy)        |
+| `users`                     | `core.ts`     | Identity anchor + password credential (monolithic, not abstracted yet)                                        |
+| `oauth_clients`             | `core.ts`     | OAuth 2.1 client registrations; ADR-007 `is_agent`/`max_agent_mode`, ADR-008 `environment`                    |
+| `api_keys`                  | `core.ts`     | Static developer API keys (ADR-008 §6, env-gated)                                                             |
+| `oauth_consents`            | `consents.ts` | User consent grants; unique per `(user_id, client_id) WHERE revoked_at IS NULL`                               |
+| `email_verification_tokens` | `tokens.ts`   | Token hash + `user_id` (references `users.id`)                                                                |
+| `authorization_codes`       | `tokens.ts`   | OAuth codes with PKCE (S256) challenge, nonce, RFC 8707 `resource`                                            |
+| `refresh_tokens`            | `tokens.ts`   | Opaque refresh tokens with `family_id` (RFC 9700 rotation family) + `resource`                                |
+| `audit_logs`                | `audit.ts`    | Auth/token/consent/client events with agent attribution (`actor_client_id`, `delegation_chain`, `scope_mode`) |
+| `sessions`                  | `sessions.ts` | DB session table (PHASE-5+, **currently unused** — sessions live in Redis via `fastify.sessionUtils`)         |
+| `roles`, `user_roles`       | `roles.ts`    | RBAC (PHASE-5+, **currently unused** by auth-server routes)                                                   |
+
+See `libs/infra/db/src/qauth-schema.dbml` for the full visual schema.
 
 ## Constraints
 
-- Never add `email`, `password_hash`, or credential columns directly to `users`
-- `email_verification_tokens.credential_id` references `user_credentials.id` (not `users.id`)
-- `UNIQUE` on `user_credentials` is `(realm_id, provider_type, external_sub)`
-- All primary keys use `uuidv7()` (PostgreSQL 18+ native). Use `gen_random_uuid()` only as a documented fallback.
-- Use Drizzle ORM. Never write raw SQL in service code. Use the `sql` template tag only for expressions in schema definitions.
-- Drizzle schema lives in `libs/infra/db/src/lib/schema/`
-- Repositories live in `libs/infra/db/src/lib/repositories/`
-
-## Trust Order for Claim Resolution
-
-When multiple sources provide the same attribute, use the highest-trust source:
-
-```
-wallet > oidc_* > self_reported
-```
-
-For SQL ordering: `CASE source WHEN 'wallet' THEN 1 WHEN 'self_reported' THEN 4 ELSE 2 END`
-
-## Adding a New Provider Type
-
-1. Add the `provider_type` string as a constant in `libs/server/federation/`
-2. Implement `CredentialProvider` interface
-3. No schema changes required — the JSONB `credential_data` column accommodates new shapes
+- All primary keys use `uuidv7()` (PostgreSQL 18+ native). Plugins/extensionless.
+- Use `bigint` epoch-ms timestamps (via the `EPOCH_MS_NOW` SQL helper), not `TIMESTAMP`.
+- `code_challenge_method` enum is `['S256']` only — `plain` is not supported.
+- `oauth_clients.audience` has a check: `IS NULL OR jsonb_typeof = 'array'`.
+- FKs use explicit `onDelete` (cascade for children, `set null` for optional refs).
+- Use the Drizzle ORM. Never write raw SQL in service code. The `sql` template
+  tag is only for expressions inside schema definitions.
+- Repositories live in `libs/infra/db/src/lib/repositories/` and are exposed
+  via **factory functions** (`createUsersRepository(db)`, etc.), NOT singletons.
+  In the Fastify app the `@qauth-labs/fastify-plugin-db` plugin instantiates them
+  and decorates `fastify.repositories.*` — route code uses those decorators.
 
 ## Migrations
 
-After schema changes, generate a migration with:
+After schema changes, generate a migration and review it:
 
 ```bash
-pnpm nx run infra-db:generate
+pnpm nx run infra-db:db:generate
 ```
 
-Review the generated SQL before applying. Never apply migrations to production without review.
+Never apply migrations blindly — review the generated SQL first. Migrations
+live in `libs/infra/db/drizzle/` (`0000_young_verim.sql` through the latest
+`00NN_*.sql`) with `meta/_journal.json` tracking order. Integration tests apply
+the real migrations against a PG18 testcontainer.
+
+---
+
+## Planned (NOT yet implemented — Phase 4 gate)
+
+The **identifier-abstraction** model ([ADR-002]) is the planned future schema.
+It is **deferred** to the Phase 4 wallet-federation gate and is NOT the shape
+of the code today. Do NOT write code against it unless explicitly working on the
+ADR-002 migration. For reference, the planned model:
+
+- `users` loses `email` / `email_normalized` / `password_hash` and becomes an
+  identity anchor only (`id`, `realm_id`, `enabled`, `metadata`, timestamps).
+- Credentials live in a new `user_credentials` table keyed by
+  `(realm_id, provider_type, external_sub)` with `credential_data` jsonb
+  (`provider_type ∈ {'password','wallet','oidc_*'}`).
+- Attributes live in a new `user_attributes` table with a `source` trust order
+  (`wallet > oidc_* > self_reported`).
+- `email_verification_tokens.credential_id` → `user_credentials.id`.
+- The OIDC `email` claim is omitted entirely when no verified email exists.
+
+See `docs/adr/002-identifier-abstraction.md` for the full design and the
+migration plan. Only touch this when beginning the Phase 4 wallet work.
+
+## Related
+
+- OAuth flows / token claims: `oauth-oidc`, `auth-oauth`, `auth-engine` skills
+- The schema for agent auth (ADR-007): `oauth-oidc` skill, `auth-engine` skill

--- a/MVP-PRD.md
+++ b/MVP-PRD.md
@@ -1,7 +1,7 @@
 # QAuth - Product Requirements Document (PRD)
 
-> **Version**: 2.2
-> **Last Updated**: 2026-06-23
+> **Version**: 2.3
+> **Last Updated**: 2026-06-30
 > **Author**: Muhammed Taha Ayan
 > **Status**: MCP-first re-baseline — see [ADR-007](./docs/adr/007-mcp-first-positioning.md). Phase 1 complete; near-term focus is MCP / AI-agent authentication.
 
@@ -540,7 +540,7 @@ Response:
 ## Phase 2: Developer Portal
 
 **Timeline**: 3-4 weeks
-**Status**: In Progress
+**Status**: In Progress — the **client-management REST API** fully shipped (list/create/get/update/delete + regenerate-secret, issues #86–#90), the **environment-gated developer API keys** backend + UI shipped (ADR-008 §6, #97/#98), and the **developer-portal Docker image** shipped (T3). The TanStack Start pages (register/login/dashboard) remain in progress.
 
 **Objective**: Allow developers to register and manage OAuth clients without manual intervention via a web UI. Machine clients (`client_credentials`) can already be provisioned from a JSON manifest using `nx run db:db:seed-oauth-clients` — the portal is the user-facing equivalent for developer-registered clients.
 
@@ -578,24 +578,27 @@ Response:
 
 **Tasks**:
 
-- [ ] Create REST API for client management — partial: `GET /api/clients` (list) shipped; create/update/delete/regenerate still pending
-- [ ] Create "New Client" form
-- [ ] Generate client_id and client_secret
-- [ ] Store client credentials securely (hash client_secret)
-- [ ] Display client details
-- [ ] Edit client (redirect URIs, name)
-- [ ] Delete/revoke client
+- [x] Create REST API for client management (issues #86–#90) — list/create/get/update/delete + regenerate-secret all shipped
+- [ ] Create "New Client" form (portal UI in progress)
+- [x] Generate client_id and client_secret (backend, 32-byte secrets, Argon2id-hashed)
+- [x] Store client credentials securely (hash client_secret)
+- [ ] Display client details (portal UI in progress)
+- [ ] Edit client (redirect URIs, name) (portal UI in progress)
+- [ ] Delete/revoke client (portal UI in progress)
 - [x] List all clients for a developer — `GET /api/clients`, scoped by developer, secret never returned
 
-**REST API Endpoints**:
+**REST API Endpoints** (all shipped in [ADR-006](./docs/adr/006-oauth-grants-and-audience.md)):
 
 ```typescript
-GET    /api/clients                     # shipped
-POST   /api/clients                     # pending
-GET    /api/clients/:id                 # pending
-PATCH  /api/clients/:id                 # pending
-DELETE /api/clients/:id                 # pending
-POST   /api/clients/:id/regenerate-secret  # pending
+GET    /api/clients                        # shipped (#86)
+POST   /api/clients                        # shipped (#86)
+GET    /api/clients/:id                    # shipped (#87)
+PATCH  /api/clients/:id                    # shipped (#88)
+DELETE /api/clients/:id                    # shipped (#89)
+POST   /api/clients/:id/regenerate-secret  # shipped (#90)
+POST   /api/clients/:id/api-keys           # shipped (#97, env-gated)
+GET    /api/clients/:id/api-keys           # shipped (#97)
+DELETE /api/clients/:id/api-keys/:keyId    # shipped (#97)
 ```
 
 **UI Features**:
@@ -655,9 +658,9 @@ POST   /api/clients/:id/regenerate-secret  # pending
 **Deliverables**:
 
 - ⏳ Developer portal (TanStack Start) — scaffolded & typecheck-clean; pages still in progress
-- ⏳ Self-service client registration
-- ⏳ REST API for client management — partial: `GET /api/clients` (list) shipped; create/update/delete/regenerate pending
-- ⏳ API key management
+- ⏳ Self-service client registration (portal UI in progress)
+- ✅ REST API for client management — list/create/get/update/delete + regenerate-secret all shipped (#86–#90)
+- ✅ API key management — environment-gated developer API keys (ADR-008 §6, #97/#98)
 - ⏳ Basic documentation
 
 **What You Can Do After Phase 2**:
@@ -1112,15 +1115,15 @@ These features are NOT part of Phases 1–5:
 
 ## 📊 Development Timeline
 
-| Phase                             | Duration  | Status       |
-| --------------------------------- | --------- | ------------ |
-| Phase 0: Foundation Setup         | 1-2 weeks | ✅ Completed |
-| Phase 1: Core Auth Server         | 6-8 weeks | ✅ Completed |
-| Phase 2: Developer Portal         | 3-4 weeks | In Progress  |
-| Phase 3: Production Hardening     | 4-6 weeks | In Progress  |
-| Phase 4: Wallet Federation Bridge | 6-8 weeks | Not Started  |
-| Phase 5: Post-Quantum Crypto      | 4-6 weeks | Not Started  |
-| Phase 6+: Enterprise & Scale      | TBD       | Not Started  |
+| Phase                             | Duration  | Status                      |
+| --------------------------------- | --------- | --------------------------- |
+| Phase 0: Foundation Setup         | 1-2 weeks | ✅ Completed                |
+| Phase 1: Core Auth Server         | 6-8 weeks | ✅ Completed                |
+| Phase 2: Developer Portal         | 3-4 weeks | In Progress (API ✅, UI ⏳) |
+| Phase 3: Production Hardening     | 4-6 weeks | ✅ Complete (T3)            |
+| Phase 4: Wallet Federation Bridge | 6-8 weeks | Not Started                 |
+| Phase 5: Post-Quantum Crypto      | 4-6 weeks | Not Started                 |
+| Phase 6+: Enterprise & Scale      | TBD       | Not Started                 |
 
 ---
 
@@ -1245,7 +1248,7 @@ These features are NOT part of Phases 1–5:
 
 ## Appendix A: Database Schema
 
-> **Note**: This is a simplified SQL representation. The actual implementation uses Drizzle ORM with TypeScript schemas. For the complete, up-to-date schema, see `libs/infra/db/src/lib/schema/` or the DBML file at `libs/infra/db/src/qauth-schema.dbml`.
+> **Note**: This is a simplified SQL representation reflecting the **Phase 1 tables only**. The actual implementation uses Drizzle ORM with TypeScript schemas and has since been extended with agent-auth (`is_agent`, `max_agent_mode`), environment-aware authorization (`environment`, `max_environment_laxity`), API keys, refresh-token families (`family_id`, `previous_token_hash`, `revoked_reason`), RFC 8707 `resource`, and per-agent audit attribution — none of which are shown here. For the complete, up-to-date schema, see `libs/infra/db/src/lib/schema/` or the DBML file at `libs/infra/db/src/qauth-schema.dbml`.
 
 ### Key Design Decisions
 
@@ -1403,11 +1406,14 @@ CREATE TABLE sessions (
 | `/.well-known/jwks.json`             | GET    | JWKS public keys                                                                                                     | 3.2   |
 | `/metrics`                           | GET    | Prometheus metrics                                                                                                   | 3.3   |
 | `/api/clients`                       | GET    | List OAuth clients (shipped) — scoped by developer, secret never returned                                            | 2.2   |
-| `/api/clients`                       | POST   | Create OAuth client (pending)                                                                                        | 2.2   |
-| `/api/clients/:id`                   | GET    | Get client details (pending)                                                                                         | 2.2   |
-| `/api/clients/:id`                   | PATCH  | Update client (pending)                                                                                              | 2.2   |
-| `/api/clients/:id`                   | DELETE | Delete client (pending)                                                                                              | 2.2   |
-| `/api/clients/:id/regenerate-secret` | POST   | Regenerate client secret (pending)                                                                                   | 2.2   |
+| `/api/clients`                       | POST   | Create OAuth client (shipped #86)                                                                                    | 2.2   |
+| `/api/clients/:id`                   | GET    | Get client details (shipped #87)                                                                                     | 2.2   |
+| `/api/clients/:id`                   | PATCH  | Update client (shipped #88)                                                                                          | 2.2   |
+| `/api/clients/:id`                   | DELETE | Delete client (shipped #89)                                                                                          | 2.2   |
+| `/api/clients/:id/regenerate-secret` | POST   | Regenerate client secret (shipped #90)                                                                               | 2.2   |
+| `/api/clients/:id/api-keys`          | POST   | Mint developer API key (shipped #97, env-gated per ADR-008)                                                          | 2.2   |
+| `/api/clients/:id/api-keys`          | GET    | List masked developer API keys (shipped #97)                                                                         | 2.2   |
+| `/api/clients/:id/api-keys/:keyId`   | DELETE | Revoke developer API key (shipped #97)                                                                               | 2.2   |
 
 ---
 

--- a/libs/infra/db/README.md
+++ b/libs/infra/db/README.md
@@ -58,25 +58,29 @@ CREATE DATABASE qauth_dev;
 
 ### Basic Database Connection
 
+`@qauth-labs/infra-db` exports a **factory**, not singletons. Call
+`createDatabase(config)` to build a `{ db, pool, close, testConnection }`
+instance, then pass `db` to the repository factories.
+
 ```typescript
-import { db, pool, testConnection, schema } from '@qauth-labs/infra-db';
+import { createDatabase, schema } from '@qauth-labs/infra-db';
+
+const database = createDatabase({
+  connectionString: 'postgresql://user:pass@host:5432/db',
+  pool: { max: 20, min: 2 },
+});
+
 const { users, oauthClients, realms } = schema;
+const isConnected = await database.testConnection();
 
-// Test database connection
-const isConnected = await testConnection();
-console.log('Database connected:', isConnected);
-
-// Use Drizzle ORM with schemas
-import { db, schema } from '@qauth-labs/infra-db';
-const { users, realms, oauthClients } = schema;
-
-const allUsers = await db.select().from(users);
-const realm = await db.query.realms.findFirst({
+// Use the Drizzle client directly
+const allUsers = await database.db.select().from(users);
+const realm = await database.db.query.realms.findFirst({
   where: (realms, { eq }) => eq(realms.name, 'my-realm'),
 });
 
 // Create a new OAuth client
-const newClient = await db
+const [newClient] = await database.db
   .insert(oauthClients)
   .values({
     realmId: realm.id,
@@ -88,26 +92,38 @@ const newClient = await db
     responseTypes: ['code'],
   })
   .returning();
+
+await database.close(); // graceful shutdown
 ```
+
+> **Fastify app:** prefer the `@qauth-labs/fastify-plugin-db` plugin (below),
+> which builds the database instance once and decorates
+> `fastify.db` / `fastify.dbPool` / `fastify.repositories.*`. Route code should
+> use those decorators rather than calling `createDatabase` directly.
 
 ### Repository Pattern
 
-The library provides a repository pattern for type-safe database operations with transaction support and proper error handling.
+The library provides a repository pattern for type-safe database operations with
+transaction support and proper error handling. Repositories are created via
+**factory functions** that take the database client; there are **no singleton
+repository exports**.
 
 #### Using Repositories
 
 ```typescript
+import { createDatabase } from '@qauth-labs/infra-db';
 import {
-  usersRepository,
-  realmsRepository,
-  auditLogsRepository,
-  emailVerificationTokensRepository,
+  createUsersRepository,
+  createEmailVerificationTokensRepository,
 } from '@qauth-labs/infra-db';
 import { NotFoundError, UniqueConstraintError } from '@qauth-labs/shared-errors';
 
+const { db } = createDatabase({ connectionString: 'postgresql://…' });
+const usersRepo = createUsersRepository(db);
+
 // Create a new user
 try {
-  const user = await usersRepository.create({
+  const user = await usersRepo.create({
     realmId: 'realm-123',
     email: 'user@example.com',
     passwordHash: 'argon2id_hash',
@@ -123,8 +139,7 @@ try {
 
 // Find user by ID (throws NotFoundError if not found)
 try {
-  const user = await usersRepository.findByIdOrThrow('user-123');
-  console.log('User found:', user);
+  const user = await usersRepo.findByIdOrThrow('user-123');
 } catch (error) {
   if (error instanceof NotFoundError) {
     console.error('User not found');
@@ -132,93 +147,84 @@ try {
 }
 
 // Find user by email (returns undefined if not found)
-const user = await usersRepository.findByEmail('realm-123', 'user@example.com');
-if (user) {
-  console.log('User found:', user);
-}
+const user = await usersRepo.findByEmail('realm-123', 'user@example.com');
 
-// Update user
-const updatedUser = await usersRepository.update('user-123', {
-  emailVerified: true,
-  updatedAt: Date.now(),
-});
-
-// Delete user
-const deleted = await usersRepository.delete('user-123');
-console.log('User deleted:', deleted);
+// Update / delete
+const updatedUser = await usersRepo.update('user-123', { emailVerified: true });
+const deleted = await usersRepo.delete('user-123');
 ```
 
 #### Repository Factory Functions
 
-Repositories are created using factory functions that accept an optional default database client:
+Each repository is a factory taking a default database client (required):
 
 ```typescript
+import { createDatabase } from '@qauth-labs/infra-db';
 import { createUsersRepository, createRealmsRepository } from '@qauth-labs/infra-db';
-import { db } from '@qauth-labs/infra-db';
 
-// Create repository with default db instance
+const { db } = createDatabase({ connectionString: 'postgresql://…' });
+
 const usersRepo = createUsersRepository(db);
-
-// Or use the default instance
-const usersRepo = createUsersRepository();
+const realmsRepo = createRealmsRepository(db);
 ```
 
 #### Transaction Support
 
-All repository methods accept an optional transaction parameter:
+All repository methods accept an optional transaction client (`tx?`) that
+overrides the default `db`. Drive transactions through the Drizzle client:
 
 ```typescript
-import { db } from '@qauth-labs/infra-db';
-import { usersRepository, realmsRepository } from '@qauth-labs/infra-db';
+const { db } = createDatabase({ connectionString: 'postgresql://…' });
+const usersRepo = createUsersRepository(db);
+const realmsRepo = createRealmsRepository(db);
 
-// Use transactions
 await db.transaction(async (tx) => {
-  // Create realm
-  const realm = await realmsRepository.create({ name: 'my-realm' }, tx);
-
-  // Create user in the same transaction
-  const user = await usersRepository.create(
-    {
-      realmId: realm.id,
-      email: 'user@example.com',
-      passwordHash: 'hash',
-    },
+  const realm = await realmsRepo.create({ name: 'my-realm' }, tx);
+  const user = await usersRepo.create(
+    { realmId: realm.id, email: 'user@example.com', passwordHash: 'hash' },
     tx
   );
-
-  // Both operations succeed or both fail
-  return { realm, user };
+  return { realm, user }; // both commit, or both roll back
 });
 ```
 
 #### Available Repositories
 
-- **`usersRepository`**: User CRUD operations
+Each factory takes a `defaultDb: DbClient`. Methods below take an optional
+`tx?: DbClient`.
+
+- **`createUsersRepository(db)`**: User CRUD
   - `create()`, `findById()`, `findByIdOrThrow()`, `findByEmail()`, `findByEmailNormalized()`, `update()`, `updateLastLogin()`, `verifyEmail()`, `delete()`
-
-- **`realmsRepository`**: Realm CRUD operations
+- **`createRealmsRepository(db)`**: Realm CRUD
   - `create()`, `findById()`, `findByIdOrThrow()`, `findByName()`, `update()`, `delete()`
-
-- **`oauthClientsRepository`** (`createOAuthClientsRepository`): OAuth client CRUD operations
+- **`createOAuthClientsRepository(db)`**: OAuth client CRUD
   - `create()`, `findById()`, `findByIdOrThrow()`, `findByClientId()`, `listByDeveloper()`, `upsertCimdClient()`, `update()`, `delete()`
   - `listByDeveloper(developerId, tx?)`: lists a developer's own clients, scoped strictly by `developer_id` and ordered newest-first. Dynamically registered (RFC 7591 / DCR) clients carry a null `developer_id` and are excluded.
   - `upsertCimdClient(data, tx?)`: idempotent `INSERT ... ON CONFLICT` for Client ID Metadata Document (CIMD) clients keyed by `(realm_id, client_id)`. On conflict it refreshes only the document-derived fields (name, description, redirect URIs, grant/response types, auth method, metadata, enabled) and bumps `updatedAt`; identity columns and the secret sentinel are left untouched, so concurrent authorize requests for the same metadata-document `client_id` collapse onto a single row instead of racing a find-then-create.
-
-- **`auditLogsRepository`**: Audit log operations
-  - `create()`, `findByUserId()`, `findByRealmId()`, `findByRealmAndUserId()`
-
-- **`emailVerificationTokensRepository`**: Email verification token operations
-  - `create()`, `findByToken()`, `markUsed()`, `deleteExpired()`
+- **`createApiKeysRepository(db)`**: Static developer API-key CRUD (ADR-008 §6)
+- **`createAuditLogsRepository(db)`**: Audit-log operations
+  - `create()`, `findByUserId()`, `findByRealmId()`, `findByRealmAndUserId()`, plus realm-isolated filters
+- **`createAuthorizationCodesRepository(db)`**: Authorization code lifecycle
+  - `create()`, `findByCode()`, `markUsed()`
+- **`createRefreshTokensRepository(db)`**: Refresh-token lifecycle + family revocation
+  - `create()`, `findByTokenHashIncludingRevoked()`, `revoke()`, `revokeFamily(familyId, reason)`
+- **`createEmailVerificationTokensRepository(db)`**: Verification tokens
+  - `create()`, `findByTokenHash()`, `markUsed()`, `deleteExpired()`
 
 #### Error Handling
 
 Repositories use error classes from `@qauth-labs/shared-errors` with HTTP status codes:
 
 ```typescript
+import { createDatabase } from '@qauth-labs/infra-db';
+import { createUsersRepository } from '@qauth-labs/infra-db';
 import { NotFoundError, UniqueConstraintError } from '@qauth-labs/shared-errors';
 
+const { db } = createDatabase({ connectionString: 'postgresql://…' });
+const usersRepo = createUsersRepository(db);
+
 try {
-  const user = await usersRepository.findByIdOrThrow('invalid-id');
+  const user = await usersRepo.findByIdOrThrow('invalid-id');
 } catch (error) {
   if (error instanceof NotFoundError) {
     // Handle not found
@@ -228,7 +234,11 @@ try {
 }
 
 try {
-  await usersRepository.create({ email: 'existing@example.com', ... });
+  await usersRepo.create({
+    realmId: 'realm-1',
+    email: 'existing@example.com',
+    passwordHash: '…',
+  });
 } catch (error) {
   if (error instanceof UniqueConstraintError) {
     // Handle unique constraint violation
@@ -243,17 +253,21 @@ try {
 For security and multi-tenancy, audit logs can be filtered by realm:
 
 ```typescript
-import { auditLogsRepository } from '@qauth-labs/infra-db';
+import { createDatabase } from '@qauth-labs/infra-db';
+import { createAuditLogsRepository } from '@qauth-labs/infra-db';
+
+const { db } = createDatabase({ connectionString: 'postgresql://…' });
+const auditLogsRepo = createAuditLogsRepository(db);
 
 // Get all audit logs for a realm (security: ensures realm isolation)
-const realmLogs = await auditLogsRepository.findByRealmId('realm-123', {
+const realmLogs = await auditLogsRepo.findByRealmId('realm-123', {
   limit: 50,
   eventType: 'auth',
   success: true,
 });
 
 // Get audit logs for a specific user within a realm
-const userLogs = await auditLogsRepository.findByRealmAndUserId('realm-123', 'user-456', {
+const userLogs = await auditLogsRepo.findByRealmAndUserId('realm-123', 'user-456', {
   limit: 20,
   descending: true,
 });
@@ -282,11 +296,16 @@ This interface ensures consistency across all repositories and reduces code dupl
 
 ### Connection Pool Management
 
+Pool access comes from the instance returned by `createDatabase`, not a
+singleton:
+
 ```typescript
-import { pool, closeDatabase } from '@qauth-labs/infra-db';
+import { createDatabase } from '@qauth-labs/infra-db';
+
+const database = createDatabase({ connectionString: 'postgresql://…' });
 
 // Direct pool access if needed
-const client = await pool.connect();
+const client = await database.pool.connect();
 try {
   const result = await client.query('SELECT NOW()');
   console.log(result.rows[0]);
@@ -295,7 +314,7 @@ try {
 }
 
 // Graceful shutdown
-await closeDatabase();
+await database.close();
 ```
 
 ## Available Nx Commands
@@ -365,34 +384,38 @@ The target realm must already exist. See `src/scripts/seed-oauth-clients.ts` for
 libs/infra/db/
 ├── src/
 │   ├── lib/
-│   │   ├── db.ts              # Database connection and utilities
+│   │   ├── db.ts              # createDatabase factory + pool/Drizzle client
 │   │   ├── repositories/      # Repository pattern implementations
-│   │   │   ├── index.ts        # Repository exports
+│   │   │   ├── index.ts        # Factory exports
 │   │   │   ├── base.repository.ts  # Base repository interface
 │   │   │   ├── users.repository.ts
 │   │   │   ├── realms.repository.ts
+│   │   │   ├── oauth-clients.repository.ts
+│   │   │   ├── oauth-consents.repository.ts
+│   │   │   ├── refresh-tokens.repository.ts
+│   │   │   ├── authorization-codes.repository.ts
+│   │   │   ├── email-verification-tokens.repository.ts
+│   │   │   ├── api-keys.repository.ts
 │   │   │   ├── audit-logs.repository.ts
-│   │   │   └── email-verification-tokens.repository.ts
+│   │   │   └── integration-setup.ts
 │   │   ├── schema/
 │   │   │   ├── index.ts        # Main schema exports
-│   │   │   ├── core.ts         # Core tables: realms, users, oauth_clients
-│   │   │   ├── tokens.ts       # Token tables: email_verification, authorization_codes, refresh_tokens
-│   │   │   ├── sessions.ts     # Session management
-│   │   │   ├── audit.ts        # Audit logging
-│   │   │   ├── roles.ts        # Roles and permissions
+│   │   │   ├── core.ts         # Core tables: realms, users, oauth_clients, api_keys
+│   │   │   ├── tokens.ts       # email_verification_tokens, authorization_codes, refresh_tokens
+│   │   │   ├── consents.ts     # oauth_consents
+│   │   │   ├── sessions.ts     # sessions (Phase 5+, currently unused — Redis holds sessions)
+│   │   │   ├── audit.ts        # audit_logs (with agent attribution)
+│   │   │   ├── roles.ts        # roles, user_roles (Phase 5+, currently unused)
 │   │   │   ├── enums.ts        # PostgreSQL enum types
-│   │   │   └── sql-helpers.ts  # SQL helper functions
-│   │   └── utils/
-│   │       ├── index.ts        # Utility exports
-│   │       └── email.ts        # Email normalization utilities
+│   │   │   └── sql-helpers.ts  # EPOCH_MS_NOW, JSONB_EMPTY_ARRAY
+│   │   └── types/              # Repository/database type definitions
 │   ├── scripts/
 │   │   ├── seed.ts                    # Dev-fixture seeder (drizzle-seed)
 │   │   └── seed-oauth-clients.ts      # Idempotent client provisioner
-│   └── index.ts               # Public API exports
+│   ├── index.ts               # Public API: createDatabase, schema, factories, types
 │   └── qauth-schema.dbml      # Database schema visualization (DBML format)
-├── drizzle/                   # Migration files
-│   ├── 0000_glamorous_valkyrie.sql  # Initial migration
-│   └── meta/                  # Migration metadata
+├── drizzle/                   # Migration files (0000_young_vermin.sql … 00NN)
+│   └── meta/                  # Migration metadata / snapshots
 ├── drizzle.config.ts          # Drizzle configuration
 ├── project.json               # Nx project configuration
 └── README.md                  # This file
@@ -448,10 +471,10 @@ The database schema is available in DBML format at `src/qauth-schema.dbml`. You 
 ### Testing Database Connection
 
 ```typescript
-import { testConnection } from '@qauth-labs/infra-db';
+import { createDatabase } from '@qauth-labs/infra-db';
 
-// Test in your application startup
-const isConnected = await testConnection();
+const database = createDatabase({ connectionString: 'postgresql://…' });
+const isConnected = await database.testConnection();
 if (!isConnected) {
   throw new Error('Failed to connect to database');
 }
@@ -493,7 +516,7 @@ fastify.get('/health', async (request, reply) => {
 });
 ```
 
-The Fastify plugin automatically manages the database connection lifecycle, so you don't need to manually call `closeDatabase()` when using the plugin.
+The Fastify plugin automatically manages the database connection lifecycle, so you don't need to manually call `database.close()` when using the plugin.
 
 ## Schema Design Principles
 


### PR DESCRIPTION
## Summary

Deep code review (`local-docs/deep-review.md`, baseline `34bbc9bc`) found three **High-severity** documentation-drift findings where shipped code contradicted its documentation. This PR fixes all three (Batch 1 of 8 from the review plan).

## Findings fixed

### F-01 — `.claude/skills/schema/SKILL.md` mandated the ADR-002 identifier-abstraction model as if it shipped
- **Problem:** the skill mandated `user_credentials`/`user_attributes` tables and "no `email`/`password_hash` on `users`" — but the code ships the monolithic `users` schema (`libs/infra/db/src/lib/schema/core.ts:114-117`). ADR-002 itself honestly marks the abstraction "not yet implemented, deferred to the Phase 4 gate." Agents following the skill emitted code incompatible with the real schema.
- **Fix:** rewrote the skill to document the **CURRENT shipped** schema (monolithic `users`, with all real columns), kept OIDC-claim behaviour accurate (including the unverified-email login MVP posture), and moved the planned abstraction to a clearly-marked "Planned (NOT yet implemented — Phase 4 gate)" section.

### F-03 — `MVP-PRD.md` Appendix B marked shipped client CRUD as "pending"
- **Problem:** `POST/GET/PATCH/DELETE /api/clients` and `regenerate-secret` marked "pending" though all shipped (#86–#90). Phase 2 status, the 2.2 task list, summary, and timeline table also lagged (Phase 3 marked "In Progress" though T3 is complete; API keys / RFC 8693 / agent type / environment policy absent from the appendix).
- **Fix:** marked client CRUD + regenerate-secret as shipped with issue numbers in section 2.2, the Phase 2 summary, the timeline table, and Appendix B; added the env-gated API-key endpoints (#97); bumped to PRD v2.3; added a staleness note to Appendix A's SQL listing pointing to the live schema.

### F-04 — `libs/infra/db/README.md` documented non-existent singleton exports
- **Problem:** README showed `import { db, pool, testConnection, usersRepository }` as singletons; the library exports only `createDatabase` + `create*Repository` factories. Also listed `findByToken()` when the actual method is `findByTokenHash()`.
- **Fix:** rewrote all connection, repository, transaction, audit-filter, connection-pool, and test-connection examples to use the factory pattern (`createDatabase(config)` → `db`, `createUsersRepository(db)`); corrected `findByToken`→`findByTokenHash`; updated the project-structure tree and the migration-name reference (`0000_glamorous_valkyrie.sql` → `0000_young_vermin.sql`); added the `createApiKeysRepository`, `createAuthorizationCodesRepository`, `createRefreshTokensRepository` entries.

## Verification
- `pnpm prettier --check` passes on all three files.
- Doc-only PR — no code or tests touched; no build/typecheck affected.

## Plan
This is Batch 1 of 8 from the review fix plan. Batches 2–8 cover security hardening, infra/cache, JWT lib, type-safety, low-priority fixes, test gaps, and tradeoff documentation. Each batch ships as its own focused PR.

## Review
- Deep review report: `local-docs/deep-review.md` (gitignored, baseline `34bbc9bc`)
- Findings F-01, F-03, F-04 (all High severity)