### PR TITLE
fix(auth): add CSRF token check to state-changing /consents JSON endpoints (F-02)

### DIFF
--- a/apps/auth-server/src/app/helpers/session-cookie.ts
+++ b/apps/auth-server/src/app/helpers/session-cookie.ts
@@ -32,6 +32,16 @@ export interface BrowserSessionData {
   /** Monotonic nonce for CSRF double-submit cookie (rotated on consent POST). */
   csrfToken?: string;
   /**
+   * CSRF token for the cookie-authed JSON API (e.g. `DELETE /consents/:id`).
+   * Distinct from {@link csrfToken} (which the consent screen burns after use)
+   * so the two flows don't invalidate each other. Long-lived per session —
+   * minted lazily by the GET that lists consents, validated via the
+   * `X-CSRF-Token` header on state-changing JSON requests. The custom header
+   * forces a CORS preflight, so naive cross-site CSRF is blocked even before
+   * the token comparison runs.
+   */
+  apiCsrfToken?: string;
+  /**
    * The exact scope set rendered on the most recent consent screen for a given
    * client, keyed by `client_id`. The consent POST handler grants ONLY these
    * scopes — the hidden `scope` form field is attacker-controllable, so the

--- a/apps/auth-server/src/app/routes/consents/consents.test.ts
+++ b/apps/auth-server/src/app/routes/consents/consents.test.ts
@@ -1,4 +1,4 @@
-import { NotFoundError } from '@qauth-labs/shared-errors';
+import { BadRequestError, NotFoundError } from '@qauth-labs/shared-errors';
 import type { FastifyInstance } from 'fastify';
 import { describe, expect, it, type Mock, vi } from 'vitest';
 
@@ -64,10 +64,21 @@ function makeFastify() {
       },
       auditLogs: { create: vi.fn().mockResolvedValue(undefined) },
     },
-    sessionUtils: { getSession: vi.fn() },
+    sessionUtils: { getSession: vi.fn(), setSession: vi.fn().mockResolvedValue(undefined) },
     log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
   };
   return { fastify: fastify as FastifyInstance, ctx };
+}
+
+/** Session with the CSRF token already minted — for GET tests that don't care about minting. */
+function sessionWith(userId: string, sessionId: string, apiCsrfToken?: string) {
+  return {
+    userId,
+    email: 'a@b.com',
+    sessionId,
+    createdAt: 0,
+    ...(apiCsrfToken ? { apiCsrfToken } : {}),
+  };
 }
 
 describe('/consents JSON API', () => {
@@ -81,17 +92,12 @@ describe('/consents JSON API', () => {
     expect(state.statusCode).toBe(401);
   });
 
-  it('GET /consents lists active consents for the user', async () => {
+  it('GET /consents lists active consents and returns a CSRF token', async () => {
     const { fastify, ctx } = makeFastify();
     await consentsRoute(fastify);
     const { signSessionId } = await import('../../helpers/session-cookie');
     const signed = signSessionId('s1');
-    (fastify.sessionUtils.getSession as unknown as Mock).mockResolvedValue({
-      userId: 'u1',
-      email: 'a@b.com',
-      sessionId: 's1',
-      createdAt: 0,
-    });
+    (fastify.sessionUtils.getSession as unknown as Mock).mockResolvedValue(sessionWith('u1', 's1'));
     (
       fastify.repositories.oauthConsents.listActiveForUserWithClient as unknown as Mock
     ).mockResolvedValue([
@@ -111,19 +117,90 @@ describe('/consents JSON API', () => {
     expect(state.body).toMatchObject({
       consents: [{ id: 'c1', clientId: 'app-123', clientName: 'Cool App', scopes: ['email'] }],
     });
+    // The response MUST include a CSRF token for the caller to echo back.
+    expect((state.body as any).csrfToken).toEqual(expect.any(String));
+    expect((state.body as any).csrfToken.length).toBeGreaterThan(0);
+    // The minted token MUST have been persisted to the session.
+    expect(fastify.sessionUtils.setSession).toHaveBeenCalled();
   });
 
-  it('DELETE /consents/:id revokes when the consent belongs to the user', async () => {
+  it('GET /consents reuses the existing apiCsrfToken without re-minting', async () => {
+    const { fastify, ctx } = makeFastify();
+    await consentsRoute(fastify);
+    const { signSessionId } = await import('../../helpers/session-cookie');
+    const signed = signSessionId('s1');
+    (fastify.sessionUtils.getSession as unknown as Mock).mockResolvedValue(
+      sessionWith('u1', 's1', 'pre-existing-token')
+    );
+    (
+      fastify.repositories.oauthConsents.listActiveForUserWithClient as unknown as Mock
+    ).mockResolvedValue([]);
+
+    const { reply, state } = createReply();
+    await ctx.get!({ headers: { cookie: `__Host-qauth_session=${signed}` } }, reply);
+    // Existing token is reused — no re-mint / no session write.
+    expect((state.body as any).csrfToken).toBe('pre-existing-token');
+    expect(fastify.sessionUtils.setSession).not.toHaveBeenCalled();
+  });
+
+  it('DELETE /consents/:id rejects when the X-CSRF-Token header is missing', async () => {
     const { fastify, ctx } = makeFastify();
     await consentsRoute(fastify);
     const { signSessionId } = await import('../../helpers/session-cookie');
     const signed = signSessionId('s2');
-    (fastify.sessionUtils.getSession as unknown as Mock).mockResolvedValue({
-      userId: 'u1',
-      email: 'a@b.com',
-      sessionId: 's2',
-      createdAt: 0,
-    });
+    (fastify.sessionUtils.getSession as unknown as Mock).mockResolvedValue(
+      sessionWith('u1', 's2', 'valid-token')
+    );
+
+    const { reply } = createReply();
+    await expect(
+      ctx.delete!(
+        {
+          headers: { cookie: `__Host-qauth_session=${signed}` },
+          params: { id: 'c1' },
+          ip: '1.1.1.1',
+        },
+        reply
+      )
+    ).rejects.toThrow(BadRequestError);
+    expect(fastify.repositories.oauthConsents.revoke).not.toHaveBeenCalled();
+    // Audit logs the CSRF failure.
+    expect(fastify.repositories.auditLogs.create).toHaveBeenCalledWith(
+      expect.objectContaining({ event: 'consents.revoke.csrf_failure', success: false })
+    );
+  });
+
+  it('DELETE /consents/:id rejects when the X-CSRF-Token header mismatches', async () => {
+    const { fastify, ctx } = makeFastify();
+    await consentsRoute(fastify);
+    const { signSessionId } = await import('../../helpers/session-cookie');
+    const signed = signSessionId('s2');
+    (fastify.sessionUtils.getSession as unknown as Mock).mockResolvedValue(
+      sessionWith('u1', 's2', 'valid-token')
+    );
+
+    const { reply } = createReply();
+    await expect(
+      ctx.delete!(
+        {
+          headers: { cookie: `__Host-qauth_session=${signed}`, 'x-csrf-token': 'wrong-token' },
+          params: { id: 'c1' },
+          ip: '1.1.1.1',
+        },
+        reply
+      )
+    ).rejects.toThrow(BadRequestError);
+    expect(fastify.repositories.oauthConsents.revoke).not.toHaveBeenCalled();
+  });
+
+  it('DELETE /consents/:id revokes when the CSRF token matches and the consent belongs to the user', async () => {
+    const { fastify, ctx } = makeFastify();
+    await consentsRoute(fastify);
+    const { signSessionId } = await import('../../helpers/session-cookie');
+    const signed = signSessionId('s2');
+    (fastify.sessionUtils.getSession as unknown as Mock).mockResolvedValue(
+      sessionWith('u1', 's2', 'valid-token')
+    );
     (fastify.repositories.oauthConsents.listActiveForUser as unknown as Mock).mockResolvedValue([
       { id: 'c1', oauthClientId: 'cli1', scopes: ['email'], grantedAt: 1, revokedAt: null },
     ]);
@@ -132,7 +209,7 @@ describe('/consents JSON API', () => {
     const { reply, state } = createReply();
     await ctx.delete!(
       {
-        headers: { cookie: `__Host-qauth_session=${signed}` },
+        headers: { cookie: `__Host-qauth_session=${signed}`, 'x-csrf-token': 'valid-token' },
         params: { id: 'c1' },
         ip: '1.1.1.1',
       },
@@ -140,7 +217,9 @@ describe('/consents JSON API', () => {
     );
     expect(state.statusCode).toBe(204);
     expect(fastify.repositories.oauthConsents.revoke).toHaveBeenCalledWith('c1');
-    expect(fastify.repositories.auditLogs.create).toHaveBeenCalled();
+    expect(fastify.repositories.auditLogs.create).toHaveBeenCalledWith(
+      expect.objectContaining({ event: 'oauth.consent.revoked', success: true })
+    );
   });
 
   it('DELETE /consents/:id rejects revocation for a different user', async () => {
@@ -148,19 +227,16 @@ describe('/consents JSON API', () => {
     await consentsRoute(fastify);
     const { signSessionId } = await import('../../helpers/session-cookie');
     const signed = signSessionId('s3');
-    (fastify.sessionUtils.getSession as unknown as Mock).mockResolvedValue({
-      userId: 'u-other',
-      email: 'x@y.com',
-      sessionId: 's3',
-      createdAt: 0,
-    });
+    (fastify.sessionUtils.getSession as unknown as Mock).mockResolvedValue(
+      sessionWith('u-other', 's3', 'valid-token')
+    );
     (fastify.repositories.oauthConsents.listActiveForUser as unknown as Mock).mockResolvedValue([]);
 
     const { reply } = createReply();
     await expect(
       ctx.delete!(
         {
-          headers: { cookie: `__Host-qauth_session=${signed}` },
+          headers: { cookie: `__Host-qauth_session=${signed}`, 'x-csrf-token': 'valid-token' },
           params: { id: 'c1' },
           ip: '1.1.1.1',
         },

--- a/apps/auth-server/src/app/routes/consents/index.ts
+++ b/apps/auth-server/src/app/routes/consents/index.ts
@@ -3,7 +3,13 @@ import type { FastifyInstance } from 'fastify';
 import { ZodTypeProvider } from 'fastify-type-provider-zod';
 import { z } from 'zod';
 
+import { env } from '../../../config/env';
 import { resolveBrowserSession } from '../../helpers/browser-session';
+import {
+  type BrowserSessionData,
+  csrfTokensEqual,
+  generateCsrfToken,
+} from '../../helpers/session-cookie';
 
 /**
  * Consent management JSON API (issue #150).
@@ -13,8 +19,19 @@ import { resolveBrowserSession } from '../../helpers/browser-session';
  * operation and all callers are the developer portal (same-origin) or a
  * future first-party settings UI.
  *
- *   GET    /consents           — list the active consents for the current user
- *   DELETE /consents/:id       — revoke one by id (ownership-checked)
+ * CSRF protection: `DELETE /consents/:id` is state-changing and cookie-
+ * authed, so it is vulnerable to CSRF. The session-cookie is `SameSite=Lax`
+ * (blocks cross-site POST/DELETE) but that is a browser control, not a token;
+ * an XSS on the same origin or a future SameSite-Lax top-level navigation
+ * trick could still reach it. Defense-in-depth: the GET mints (or reuses) a
+ * per-session `apiCsrfToken`, returns it in the response body, and the DELETE
+ * MUST echo it back via the `X-CSRF-Token` request header. The custom header
+ * forces a CORS preflight (which fails for cross-origin callers without an
+ * explicit CORS allowlist), and the timing-safe token comparison closes the
+ * gap even for same-origin XSS-driven calls that cannot read the response.
+ *
+ *   GET    /consents           — list active consents + return the CSRF token
+ *   DELETE /consents/:id       — revoke one by id (ownership + CSRF-checked)
  */
 
 const consentRowSchema = z.object({
@@ -27,11 +44,35 @@ const consentRowSchema = z.object({
 
 const listResponseSchema = z.object({
   consents: z.array(consentRowSchema),
+  /** Per-session CSRF token the caller MUST echo back as `X-CSRF-Token` on DELETE. */
+  csrfToken: z.string(),
 });
 
 const unauthorizedResponseSchema = z.object({
   consents: z.array(consentRowSchema),
 });
+
+/** Header name carrying the CSRF token on state-changing JSON requests. */
+const CSRF_HEADER = 'x-csrf-token';
+
+/**
+ * Ensure the session carries an `apiCsrfToken`; mint + persist one if absent.
+ * The token is long-lived (per session) so concurrent / multi-tab usage works.
+ * Returns the token to embed in a response.
+ */
+async function ensureApiCsrfToken(
+  fastify: FastifyInstance,
+  session: BrowserSessionData
+): Promise<string> {
+  if (session.apiCsrfToken) return session.apiCsrfToken;
+  const token = generateCsrfToken();
+  await fastify.sessionUtils.setSession<BrowserSessionData>(
+    session.sessionId,
+    { ...session, apiCsrfToken: token },
+    env.SESSION_COOKIE_TTL
+  );
+  return token;
+}
 
 export default async function (fastify: FastifyInstance) {
   fastify.withTypeProvider<ZodTypeProvider>().get(
@@ -39,7 +80,7 @@ export default async function (fastify: FastifyInstance) {
     {
       schema: {
         description:
-          'List the active OAuth consents for the currently signed-in user. Drives the developer portal revocation screen (issue #150).',
+          'List the active OAuth consents for the currently signed-in user. Drives the developer portal revocation screen (issue #150). The response also carries a per-session CSRF token that the caller MUST echo back as the `X-CSRF-Token` header on `DELETE /consents/:id`.',
         tags: ['Consents'],
         response: { 200: listResponseSchema, 401: unauthorizedResponseSchema },
       },
@@ -50,6 +91,8 @@ export default async function (fastify: FastifyInstance) {
         reply.code(401);
         return reply.send({ consents: [] });
       }
+
+      const csrfToken = await ensureApiCsrfToken(fastify, session);
 
       const rows = await fastify.repositories.oauthConsents.listActiveForUserWithClient(
         session.userId
@@ -63,7 +106,7 @@ export default async function (fastify: FastifyInstance) {
         grantedAt: row.grantedAt,
       }));
 
-      return reply.send({ consents });
+      return reply.send({ consents, csrfToken });
     }
   );
 
@@ -71,7 +114,8 @@ export default async function (fastify: FastifyInstance) {
     '/consents/:id',
     {
       schema: {
-        description: 'Revoke an OAuth consent row owned by the currently signed-in user.',
+        description:
+          'Revoke an OAuth consent row owned by the currently signed-in user. Requires a valid `X-CSRF-Token` header whose value matches the session CSRF token returned by `GET /consents`.',
         tags: ['Consents'],
         params: z.object({ id: z.string().uuid() }),
         response: { 204: z.null(), 401: z.null() },
@@ -82,6 +126,25 @@ export default async function (fastify: FastifyInstance) {
       if (!session) {
         reply.code(401);
         return reply.send(null);
+      }
+
+      // CSRF defence-in-depth (F-02): the caller MUST echo the per-session
+      // CSRF token via the `X-CSRF-Token` header. The custom header forces a
+      // CORS preflight for cross-origin attempts; the timing-safe comparison
+      // closes the same-origin XSS gap that SameSite=Lax does not address.
+      const provided = request.headers[CSRF_HEADER] as string | undefined;
+      if (!csrfTokensEqual(provided, session.apiCsrfToken)) {
+        await fastify.repositories.auditLogs.create({
+          userId: session.userId,
+          oauthClientId: null,
+          event: 'consents.revoke.csrf_failure',
+          eventType: 'security',
+          success: false,
+          ipAddress: request.ip,
+          userAgent: request.headers['user-agent'] || null,
+          metadata: { reason: 'missing_or_mismatched_csrf_token' },
+        });
+        throw new BadRequestError('invalid_csrf_token');
       }
 
       const { id } = request.params as { id: string };


### PR DESCRIPTION
## Summary

Fixes **F-02** — the sole remaining High from the deep code review (`local-docs/deep-review.md`), and the only finding with genuine exploit potential. An external review (Claude) confirmed: of the original 4 Highs, the 3 doc-drift ones (F-01/F-03/F-04) were resolved in PR #216, leaving this CSRF gap as the real priority — *"a reader skimming 4 High might not realize 3 are paperwork"*.

## The problem

`DELETE /consents/:id` is state-changing and cookie-authed (`resolveBrowserSession`), but had **no CSRF** token — the UI consent POST (`/ui/consent`) already has one (session-bound double-submit at `ui/consent.ts:532`); this JSON API did not. The `__Host-qauth_session` cookie is `SameSite=Lax`, which blocks cross-site POST/DELETE but is a browser control, not a token, and does not defend against an XSS on the same origin that can read/mint requests with the cookie.

## The fix — defense-in-depth, mirroring the existing pattern

- **`GET /consents`** mints (or reuses) a per-session `apiCsrfToken`, persists it into the Redis session payload via `setSession`, and returns it in the `200` response body (`{ consents, csrfToken }`). Long-lived per session so concurrent / multi-tab usage works; **distinct** from the consent screen's `csrfToken` (which that flow burns after use) so the two flows do not invalidate each other.
- **`DELETE /consents/:id`** requires the caller to echo the token back via the `X-CSRF-Token` request header, validated timing-safe with the existing `csrfTokensEqual`. The custom header forces a CORS preflight for any cross-origin caller (which fails without an explicit `CORS_ORIGIN` allowlist), blocking naive CSRF **before** the token comparison even runs. CSRF failures are audit-logged as `consents.revoke.csrf_failure`.

`BrowserSessionData` gains a documented optional `apiCsrfToken` field. The Zod `200` response schema now carries `csrfToken: string`.

## Why this severity / approach
- `SameSite=Lax` is the primary defense; this is **defense-in-depth** — the second layer the OWASP CSRF cheat sheet calls for on cookie-authed state-changing endpoints.
- Per-session (not per-request) token: avoids breaking concurrent calls (e.g. a developer revoking multiple consents in rapid succession in the portal). The token is only readable same-origin (the session cookie is `HttpOnly` and the JSON body requires auth), so theft requires an XSS that is already a worse compromise.
- A custom header (`X-CSRF-Token`) over a body field: headers trigger CORS preflight, which is the actual CSRF-blocking property — token validation is the second gate.

## Verification
- `pnpm nx run auth-server:typecheck --skip-nx-cache` — ✅
- `pnpm nx run auth-server:lint --skip-nx-cache` — ✅ (0 errors, 186 pre-existing warnings)
- `pnpm prettier --write` on all 3 changed files — ✅
- `pnpm vitest run` on `consents/consents.test.ts`, `session-cookie.test.ts`, `session-cookie-secure.test.ts` — **17/17 pass**

## Test coverage added
The consents test suite grows from 4 → 7 tests:
- existing `GET` returns 401 when no session *(unchanged)*
- existing `GET` lists active consents — **now also asserts the response carries a `csrfToken` and that the minted token is persisted**
- **NEW** — `GET` reuses the existing `apiCsrfToken` without re-minting (no `setSession` call)
- **NEW** — `DELETE` rejects when `X-CSRF-Token` is missing (audit-logs `consents.revoke.csrf_failure`, no revoke)
- **NEW** — `DELETE` rejects when the header mismatches (no revoke)
- existing `DELETE` revokes — **now sends the matching `X-CSRF-Token` header**
- existing `DELETE` rejects for a different user — **now sends the header**

## Files changed
- `apps/auth-server/src/app/helpers/session-cookie.ts` — `BrowserSessionData.apiCsrfToken` doc
- `apps/auth-server/src/app/routes/consents/index.ts` — CSRF mint on GET, validation on DELETE, schema + audit-logging
- `apps/auth-server/src/app/routes/consents/consents.test.ts` — test suite update (4 → 7 tests)

## Tracking
- Deep review report: `local-docs/deep-review.md` (gitignored). F-02 marked resolved in the next report append.
- Reprioritised per external review feedback: F-02 was already the sole remaining High; this PR closes it. Remaining open items: 11 Medium, 10 Low, 6 Info.