### PR TITLE
ci: drop Nx Cloud connection so CI runs lint/typecheck/test/build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,3 @@ jobs:
       # the whole fast unit suite. The Docker-backed integration suite (#167,
       # `*.integration.test.ts`) is excluded, so no Postgres/Redis is needed.
       - run: pnpm exec vitest run --coverage
-
-      # Nx Cloud recommends fixes for failures to help you get CI green faster. Learn more: https://nx.dev/ci/features/self-healing-ci
-      - run: pnpm exec nx fix-ci
-        if: always()

--- a/apps/developer-portal/src/server/session-cookie.ts
+++ b/apps/developer-portal/src/server/session-cookie.ts
@@ -13,7 +13,16 @@ export interface PortalSessionPayload {
 const SEPARATOR = '.';
 
 function hmac(value: string): string {
-  return createHmac('sha256', env.PORTAL_SESSION_SECRET).update(value).digest('base64url');
+  // `config.ts` throws on startup (SSR) if this is unset, but the exported type
+  // stays `string | undefined` because the bundler can pull this server-only
+  // module into a client chunk where process.env is empty. This module is only
+  // reached on the server, so re-assert here to satisfy the type checker and
+  // fail loudly rather than HMAC with an undefined key.
+  const secret = env.PORTAL_SESSION_SECRET;
+  if (!secret) {
+    throw new Error('PORTAL_SESSION_SECRET is not configured');
+  }
+  return createHmac('sha256', secret).update(value).digest('base64url');
 }
 
 export function signSession(payload: PortalSessionPayload): string {

--- a/nx.json
+++ b/nx.json
@@ -1,6 +1,5 @@
 {
   "$schema": "./node_modules/nx/schemas/nx-schema.json",
-  "nxCloudId": "68ed5766d0a8584639447f54",
   "plugins": [
     {
       "plugin": "@nx/eslint/plugin",
@@ -109,5 +108,6 @@
   },
   "sync": {
     "disabledTaskSyncGenerators": ["@nx/js:typescript-sync"]
-  }
+  },
+  "analytics": false
 }


### PR DESCRIPTION
## Problem

The Nx Cloud org was disabled for exceeding the free plan, so every `nx affected` run failed at the cloud-authorization step before running any task:

```
NX   Nx Cloud: Workspace is unable to be authorized. Exiting run.
This Nx Cloud organization has been disabled due to exceeding the FREE plan.
##[error]Process completed with exit code 1.
```

The `main` CI check was red on **every** PR (#216, #217, #218 all merged with the check failing), meaning no real lint/typecheck/test/build gating ran in CI — only local runs verified those PRs.

## Fix

- Remove `nxCloudId` from `nx.json` → Nx runs locally. `affected`, local caching, and all targets work without the cloud; only remote caching/distribution is lost (unused here).
- Drop the `nx fix-ci` step from `ci.yml` — a Nx Cloud self-healing feature that requires a connection.
- Keep `analytics: false` to disable Nx telemetry.

## Validation

This PR's own `main` CI check should go **green** for the first time (it runs against this PR's cloud-free `nx.json`), which is the real proof the fix works. Locally, `nx run server-config:lint` no longer attempts cloud authorization.