### PR TITLE
fix: add code field to the four error classes missing it (F-14)

### DIFF
--- a/libs/shared/errors/src/lib/auth/token-already-used.error.ts
+++ b/libs/shared/errors/src/lib/auth/token-already-used.error.ts
@@ -3,6 +3,7 @@
  */
 export class TokenAlreadyUsedError extends Error {
   readonly statusCode = 409;
+  readonly code = 'TOKEN_ALREADY_USED';
 
   constructor(message = 'Token has already been used') {
     super(message);

--- a/libs/shared/errors/src/lib/common/bad-request.error.ts
+++ b/libs/shared/errors/src/lib/common/bad-request.error.ts
@@ -4,6 +4,7 @@
  */
 export class BadRequestError extends Error {
   readonly statusCode = 400;
+  readonly code = 'BAD_REQUEST';
 
   constructor(message: string) {
     super(message);

--- a/libs/shared/errors/src/lib/common/error-fields.test.ts
+++ b/libs/shared/errors/src/lib/common/error-fields.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+
+import { TokenAlreadyUsedError } from '../auth/token-already-used.error';
+import { BadRequestError } from './bad-request.error';
+import { NotFoundError } from './not-found.error';
+import { TooManyRequestsError } from './too-many-requests.error';
+
+/**
+ * Contract tests for the four error classes that previously shipped without a
+ * `code` field (F-14). Every domain error in this package is expected to carry
+ * a stable `statusCode` + UPPER_SNAKE_CASE `code` so consumers (and the global
+ * error handler) can branch on `error.code` without a defensive `'code' in`
+ * guard. These tests lock that contract in.
+ */
+describe('error code/statusCode contract (F-14)', () => {
+  it('BadRequestError', () => {
+    const err = new BadRequestError('bad input');
+    expect(err).toBeInstanceOf(BadRequestError);
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe('BadRequestError');
+    expect(err.message).toBe('bad input');
+    expect(err.statusCode).toBe(400);
+    expect(err.code).toBe('BAD_REQUEST');
+  });
+
+  it('NotFoundError', () => {
+    const err = new NotFoundError('User', 'abc-123');
+    expect(err).toBeInstanceOf(NotFoundError);
+    expect(err.name).toBe('NotFoundError');
+    expect(err.message).toBe('User with id abc-123 not found');
+    expect(err.statusCode).toBe(404);
+    expect(err.code).toBe('NOT_FOUND');
+  });
+
+  it('TooManyRequestsError', () => {
+    const err = new TooManyRequestsError();
+    expect(err).toBeInstanceOf(TooManyRequestsError);
+    expect(err.name).toBe('TooManyRequestsError');
+    expect(err.message).toBe('Too many requests');
+    expect(err.statusCode).toBe(429);
+    expect(err.code).toBe('TOO_MANY_REQUESTS');
+  });
+
+  it('TokenAlreadyUsedError', () => {
+    const err = new TokenAlreadyUsedError();
+    expect(err).toBeInstanceOf(TokenAlreadyUsedError);
+    expect(err.name).toBe('TokenAlreadyUsedError');
+    expect(err.message).toBe('Token has already been used');
+    expect(err.statusCode).toBe(409);
+    expect(err.code).toBe('TOKEN_ALREADY_USED');
+  });
+
+  it('codes are unique across these classes', () => {
+    const codes = [
+      new BadRequestError('x').code,
+      new NotFoundError('E', 'id').code,
+      new TooManyRequestsError().code,
+      new TokenAlreadyUsedError().code,
+    ];
+    expect(new Set(codes).size).toBe(codes.length);
+  });
+});

--- a/libs/shared/errors/src/lib/common/not-found.error.ts
+++ b/libs/shared/errors/src/lib/common/not-found.error.ts
@@ -4,6 +4,7 @@
  */
 export class NotFoundError extends Error {
   readonly statusCode = 404;
+  readonly code = 'NOT_FOUND';
 
   constructor(entity: string, id: string) {
     super(`${entity} with id ${id} not found`);

--- a/libs/shared/errors/src/lib/common/too-many-requests.error.ts
+++ b/libs/shared/errors/src/lib/common/too-many-requests.error.ts
@@ -4,6 +4,7 @@
  */
 export class TooManyRequestsError extends Error {
   readonly statusCode = 429;
+  readonly code = 'TOO_MANY_REQUESTS';
 
   constructor(message = 'Too many requests') {
     super(message);


### PR DESCRIPTION
## F-14 (Medium) — error-model consistency

`BadRequestError`, `NotFoundError`, `TooManyRequestsError`, and `TokenAlreadyUsedError` were the only 4 of 20 domain error classes without a `code` field. The global error handler carried a defensive `'code' in error && error.code` workaround to cope, and any consumer branching on `error.code` got an inconsistent shape.

### Changes
- Add UPPER_SNAKE_CASE `code` to the 4 classes (`BAD_REQUEST`, `NOT_FOUND`, `TOO_MANY_REQUESTS`, `TOKEN_ALREADY_USED`), matching the existing convention (e.g. `UNIQUE_CONSTRAINT_VIOLATION`).
- Purely **additive**: these flow through the handler's `SimpleErrorClasses` branch, so responses now include `code`. They are **not** OAuth-spec error responses (those use distinct `InvalidScopeError` etc. branches), so no spec impact.
- Add contract tests (statusCode/code/name/message + code uniqueness) — also chips at the `shared/errors` test gap (F-16).

### Verification
Local (cloud-free): `lint typecheck test` green for `shared-errors` + `auth-server` (15 dependent tasks); new test 5/5.

Part of the deep-review remediation series (after #216 docs, #217 CSRF, #218 env, #219 CI).