### PR TITLE
refactor(oauth): eliminate as-unknown-as double-casts in client helpers

### DIFF
--- a/apps/auth-server/src/app/helpers/client-auth.ts
+++ b/apps/auth-server/src/app/helpers/client-auth.ts
@@ -206,7 +206,9 @@ export async function authenticateClientPublicOrConfidential(
     // Confidential client missing its secret.
     throw new InvalidClientError();
   }
-  return client as unknown as OAuthClientLike;
+  // `ResolvedClient` is a structural superset of `OAuthClientLike`, so the
+  // resolved row is assignable directly — no cast required.
+  return client;
 }
 
 /**

--- a/apps/auth-server/src/app/helpers/client-resolution.ts
+++ b/apps/auth-server/src/app/helpers/client-resolution.ts
@@ -84,9 +84,8 @@ export function isCimdClient(client: { metadata: Record<string, unknown> | null 
  * raw field. Nothing gates on it yet.
  *
  * Fail-closed by design: returns true ONLY for a strict `isAgent === true`,
- * so a missing / null / undefined field (e.g. an object built via the
- * `as unknown as ResolvedClient` casts above, or a partially-shaped object)
- * reads as NOT an agent rather than throwing. This is the safe default for a
+ * so a missing / null / undefined field (e.g. a partially-shaped object that
+ * omits the flag) reads as NOT an agent rather than throwing. This is the safe default for a
  * classification gate. It does NOT make `is_agent` trustworthy — the value is
  * self-asserted client input (see the schema column note); downstream gating
  * must still verify rather than trust, and the escalation risk is a client
@@ -139,7 +138,7 @@ export async function resolveClient(
   //    CIMD client also lives here once its first authorize succeeded.
   const persisted = await fastify.repositories.oauthClients.findByClientId(realmId, clientId);
   if (persisted) {
-    return { client: persisted as unknown as ResolvedClient };
+    return { client: persisted };
   }
 
   // 2. CIMD — URL-formatted client_id resolved + materialised on demand.
@@ -155,7 +154,7 @@ export async function resolveClient(
 
       const insert = toCimdClientInsert(realmId, clientId, doc, sentinelSecretHash);
       const row = await fastify.repositories.oauthClients.upsertCimdClient(insert);
-      return { client: row as unknown as ResolvedClient };
+      return { client: row };
     } catch (err) {
       const reason = err instanceof InvalidClientError ? err.message : 'cimd_resolution_failed';
       return { client: null, reason };

--- a/apps/auth-server/src/app/routes/oauth/authorize.ts
+++ b/apps/auth-server/src/app/routes/oauth/authorize.ts
@@ -21,7 +21,7 @@ import {
   parsePromptMode,
   stepUpErrorForPromptNone,
 } from '../../helpers/step-up';
-import { type AuthorizeQuery, authorizeQuerySchema } from '../../schemas/oauth';
+import { authorizeQuerySchema } from '../../schemas/oauth';
 
 /**
  * RFC 8707: parse every `resource=` query param directly from the request
@@ -86,7 +86,9 @@ export default async function (fastify: FastifyInstance) {
       },
     },
     async (request, reply) => {
-      const query = request.query as AuthorizeQuery;
+      // `request.query` is already typed by the Zod type provider from the
+      // route's `querystring: authorizeQuerySchema` schema — no cast needed.
+      const query = request.query;
       const redirectUri = query.redirect_uri;
       const state = query.state;
 


### PR DESCRIPTION
## Summary

Fixes **F-15 (Medium)** from the deep code review: `as unknown as` double-casts defeat type safety, and a manual query cast bypassed the Zod type provider's inferred type.

The four cast sites flagged in the review all still applied. Each is now removed without any runtime behaviour change — this is a pure type-safety refactor.

## Changes

- **`client-resolution.ts:142,158`** — `resolveClient` returned the persisted and CIMD-materialised rows via `as unknown as ResolvedClient`. The repository (`findByClientId` / `upsertCimdClient`) returns the Drizzle-inferred `OAuthClient` select model, which is **structurally assignable** to `ResolvedClient` (enum-narrowed fields like `grantTypes`/`environment` satisfy the wider local types). Both casts removed; the rows are returned directly. Also updated a stale JSDoc reference to the now-deleted casts in `isAgentClient`.
- **`client-auth.ts:209`** — `authenticateClientPublicOrConfidential` cast its `ResolvedClient` to `OAuthClientLike` via `as unknown as`. `ResolvedClient` is a structural superset of `OAuthClientLike`, so the value is assignable directly. Cast removed (replaced with a one-line explaining comment).
- **`authorize.ts:89`** — the handler did `request.query as AuthorizeQuery`, bypassing the type provider. The route already registers `querystring: authorizeQuerySchema` under `withTypeProvider<ZodTypeProvider>()`, so `request.query` is already typed as the inferred output. Cast removed and the now-unused `AuthorizeQuery` import dropped.

## Constraints honoured

- Only `apps/auth-server/**` touched; lib types were read but not edited. No lib change was required — the inferred `OAuthClient` was already assignable to both local types, so no normalizer was needed.
- No behaviour change; no new tests required.

## Verification

`NX_CLOUD_ACCESS_TOKEN= NX_NO_CLOUD=true pnpm exec nx run-many -t lint typecheck test -p auth-server --skip-nx-cache`

- lint: 0 errors (pre-existing warnings only)
- typecheck: clean
- test: all auth-server tests pass