### PR TITLE
fix(oauth): JWT claim safety — decode client_credentials tokens (F-09) + validate verified claim shape (F-10)

### DIFF
--- a/libs/server/jwt/package.json
+++ b/libs/server/jwt/package.json
@@ -5,7 +5,8 @@
   "main": "src/index.ts",
   "dependencies": {
     "@qauth-labs/shared-errors": "workspace:*",
-    "jose": "catalog:"
+    "jose": "catalog:",
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@vitest/coverage-v8": "catalog:",

--- a/libs/server/jwt/src/lib/access-token-claims.ts
+++ b/libs/server/jwt/src/lib/access-token-claims.ts
@@ -1,0 +1,61 @@
+import { z } from 'zod';
+
+import type { JWTPayload } from '../types/jwt-service';
+
+/**
+ * Runtime claim-shape validation for verified access tokens.
+ *
+ * `jose`'s {@link jwtVerify} verifies the JWT *signature* and the registered
+ * temporal/issuer/audience claims — it does NOT assert that application claims
+ * have the shape this server expects. A token can therefore be cryptographically
+ * valid yet carry, say, a numeric `sub` or an `email` that is not a string. Casting
+ * such a payload with `as string` (the previous behaviour) silently mis-types it
+ * and pushes the corruption downstream.
+ *
+ * This schema runs AFTER signature verification and rejects a malformed-but-signed
+ * token, so consumers always receive a well-typed {@link JWTPayload}. It is kept
+ * intentionally minimal and aligned with the QAuth token claim model:
+ *
+ * - `sub` is the only always-present claim (RFC 7519 §4.1.2).
+ * - `email` / `email_verified` are OMITTED for client_credentials tokens, so they
+ *   are optional; when present they must be a well-formed email / boolean.
+ * - All registered/optional claims are validated only for type, not presence,
+ *   except `sub`.
+ *
+ * Unknown claims are passed through untouched (`.passthrough()` semantics via
+ * `.loose()`) — this validator narrows the claims QAuth consumes, it is not an
+ * allowlist of permitted claims.
+ */
+const actClaimSchema: z.ZodType<NonNullable<JWTPayload['act']>> = z.lazy(() =>
+  z.object({
+    sub: z.string(),
+    act: actClaimSchema.optional(),
+  })
+);
+
+export const accessTokenClaimsSchema = z.looseObject({
+  // RFC 7519 §4.1.2 — subject. Always present on tokens this server mints.
+  sub: z.string(),
+  // OIDC identity claims. Omitted entirely for client_credentials tokens, so
+  // optional; a present-but-malformed value is rejected rather than coerced.
+  email: z.email().optional(),
+  email_verified: z.boolean().optional(),
+  // OAuth client identifier (`client_id` claim).
+  client_id: z.string().optional(),
+  // Space-separated granted scopes (omitted when none granted).
+  scope: z.string().optional(),
+  // RFC 8707 audience — single or multiple.
+  aud: z.union([z.string(), z.array(z.string())]).optional(),
+  // RFC 8693 §4.1 delegation actor (nested chain).
+  act: actClaimSchema.optional(),
+  // Registered temporal/issuer claims.
+  iat: z.number().optional(),
+  exp: z.number().optional(),
+  iss: z.string().optional(),
+  // RFC 7519 §4.1.7 unique token id (RFC 7009 revocation support).
+  jti: z.string().optional(),
+  // Token-use marker (token-confusion defence).
+  token_use: z.string().optional(),
+});
+
+export type AccessTokenClaims = z.infer<typeof accessTokenClaimsSchema>;

--- a/libs/server/jwt/src/lib/jose-utils.test.ts
+++ b/libs/server/jwt/src/lib/jose-utils.test.ts
@@ -1,0 +1,46 @@
+import { JWTInvalidError } from '@qauth-labs/shared-errors';
+import { describe, expect, it } from 'vitest';
+
+import { decodeJwtUnsafe } from './jose-utils';
+import { signAccessToken } from './jwt-service';
+import { generateEdDSAKeyPair } from './key-management';
+
+describe('decodeJwtUnsafe', () => {
+  it('decodes a full user access token with email claims', async () => {
+    const { privateKey } = await generateEdDSAKeyPair();
+    const token = await signAccessToken(
+      { sub: 'user-1', email: 'user@example.com', email_verified: true, clientId: 'client-1' },
+      privateKey,
+      'https://auth.example.com',
+      900
+    );
+
+    const decoded = decodeJwtUnsafe(token);
+    expect(decoded.sub).toBe('user-1');
+    expect(decoded.email).toBe('user@example.com');
+    expect(decoded.email_verified).toBe(true);
+    expect(decoded.clientId).toBe('client-1');
+  });
+
+  it('decodes a client_credentials token that OMITS email/email_verified (F-09)', async () => {
+    const { privateKey } = await generateEdDSAKeyPair();
+    // client_credentials tokens have no end-user: signAccessToken omits
+    // email/email_verified. decodeJwtUnsafe must still decode them.
+    const token = await signAccessToken(
+      { sub: 'service-client', clientId: 'service-client' },
+      privateKey,
+      'https://auth.example.com',
+      900
+    );
+
+    const decoded = decodeJwtUnsafe(token);
+    expect(decoded.sub).toBe('service-client');
+    expect(decoded.email).toBeUndefined();
+    expect(decoded.email_verified).toBeUndefined();
+    expect(decoded.clientId).toBe('service-client');
+  });
+
+  it('throws JWTInvalidError when the token is structurally malformed', () => {
+    expect(() => decodeJwtUnsafe('not.a.jwt')).toThrow(JWTInvalidError);
+  });
+});

--- a/libs/server/jwt/src/lib/jose-utils.ts
+++ b/libs/server/jwt/src/lib/jose-utils.ts
@@ -29,18 +29,21 @@ export function decodeJwtUnsafe(token: string) {
   try {
     const decoded = joseDecodeJwt(token);
 
-    if (
-      typeof decoded.sub !== 'string' ||
-      typeof decoded['email'] !== 'string' ||
-      typeof decoded['email_verified'] !== 'boolean'
-    ) {
+    // `sub` is the only claim every token this server mints is guaranteed to
+    // carry. `email` / `email_verified` are deliberately OMITTED from
+    // client_credentials access tokens (no end-user) — see `signAccessToken` —
+    // so they are treated as optional here and surfaced only when present and
+    // well-typed. Requiring them would make this util unable to decode a valid
+    // client_credentials token.
+    if (typeof decoded.sub !== 'string') {
       throw new JWTInvalidError('Invalid JWT payload claims');
     }
 
     return {
       sub: decoded.sub,
-      email: decoded['email'],
-      email_verified: decoded['email_verified'],
+      email: typeof decoded['email'] === 'string' ? decoded['email'] : undefined,
+      email_verified:
+        typeof decoded['email_verified'] === 'boolean' ? decoded['email_verified'] : undefined,
       clientId: typeof decoded['client_id'] === 'string' ? decoded['client_id'] : 'unknown-client',
       iat: decoded.iat,
       exp: decoded.exp,

--- a/libs/server/jwt/src/lib/jwt-service.test.ts
+++ b/libs/server/jwt/src/lib/jwt-service.test.ts
@@ -1,5 +1,5 @@
 import { JWTExpiredError, JWTInvalidError } from '@qauth-labs/shared-errors';
-import { jwtVerify } from 'jose';
+import { jwtVerify, SignJWT } from 'jose';
 import { describe, expect, it } from 'vitest';
 
 import { signAccessToken, signIdToken, verifyAccessToken } from './jwt-service';
@@ -289,6 +289,70 @@ describe('verifyAccessToken', () => {
     });
     expect(decoded.sub).toBe('user-iss-ok');
     expect(decoded.iss).toBe('https://auth.example.com');
+  });
+});
+
+describe('verifyAccessToken runtime claim-shape validation (F-10)', () => {
+  /**
+   * Mint a JWT directly via jose (bypassing signAccessToken) so we can forge an
+   * arbitrary — including malformed — claim set that is still correctly SIGNED.
+   * This models a token whose signature verifies but whose claim shape is wrong.
+   */
+  async function signRawClaims(
+    claims: Record<string, unknown>,
+    privateKey: Parameters<typeof signAccessToken>[1]
+  ): Promise<string> {
+    return new SignJWT(claims)
+      .setProtectedHeader({ alg: 'EdDSA' })
+      .setIssuedAt()
+      .setExpirationTime('900s')
+      .setIssuer('https://auth.example.com')
+      .setAudience('client-mal')
+      .sign(privateKey);
+  }
+
+  it('rejects a correctly-signed token whose sub is not a string', async () => {
+    const { privateKey, publicKey } = await generateEdDSAKeyPair();
+    // `sub` is numeric — jose verifies the signature, but the claim shape is
+    // invalid, so the previous `as string` cast would have silently mis-typed it.
+    const token = await signRawClaims({ sub: 12345, client_id: 'client-mal' }, privateKey);
+
+    await expect(verifyAccessToken(token, publicKey)).rejects.toThrow(JWTInvalidError);
+  });
+
+  it('rejects a correctly-signed token whose email is not a valid email', async () => {
+    const { privateKey, publicKey } = await generateEdDSAKeyPair();
+    const token = await signRawClaims(
+      { sub: 'user-mal', client_id: 'client-mal', email: 'not-an-email' },
+      privateKey
+    );
+
+    await expect(verifyAccessToken(token, publicKey)).rejects.toThrow(JWTInvalidError);
+  });
+
+  it('rejects a correctly-signed token whose email_verified is not a boolean', async () => {
+    const { privateKey, publicKey } = await generateEdDSAKeyPair();
+    const token = await signRawClaims(
+      { sub: 'user-mal', client_id: 'client-mal', email_verified: 'yes' },
+      privateKey
+    );
+
+    await expect(verifyAccessToken(token, publicKey)).rejects.toThrow(JWTInvalidError);
+  });
+
+  it('accepts a well-formed client_credentials token without email claims', async () => {
+    const { privateKey, publicKey } = await generateEdDSAKeyPair();
+    const token = await signAccessToken(
+      { sub: 'service-client', clientId: 'service-client' },
+      privateKey,
+      'https://auth.example.com',
+      900
+    );
+
+    const decoded = await verifyAccessToken(token, publicKey);
+    expect(decoded.sub).toBe('service-client');
+    expect(decoded.email).toBeUndefined();
+    expect(decoded.email_verified).toBeUndefined();
   });
 });
 

--- a/libs/server/jwt/src/lib/jwt-service.ts
+++ b/libs/server/jwt/src/lib/jwt-service.ts
@@ -5,6 +5,7 @@ import { jwtVerify, SignJWT } from 'jose';
 
 import type { JWTPayload, SignAccessTokenPayload, SignIdTokenPayload } from '../types/jwt-service';
 import type { KeyLike } from '../types/key-management';
+import { accessTokenClaimsSchema } from './access-token-claims';
 
 /**
  * Sign an access token
@@ -184,35 +185,16 @@ export async function verifyAccessToken(
   publicKey: KeyLike,
   options: { audience?: string | string[]; issuer?: string } = {}
 ): Promise<JWTPayload> {
+  let payload: Awaited<ReturnType<typeof jwtVerify>>['payload'];
   try {
-    const { payload } = await jwtVerify(token, publicKey, {
+    ({ payload } = await jwtVerify(token, publicKey, {
       algorithms: ['EdDSA'],
       // RFC 9700 / mix-up defence: when the caller supplies the expected
       // issuer, jose asserts the `iss` claim matches and rejects otherwise.
       // The alg stays pinned to EdDSA so `none`/alg-confusion is impossible.
       ...(options.issuer !== undefined ? { issuer: options.issuer } : {}),
       ...(options.audience !== undefined ? { audience: options.audience } : {}),
-    });
-
-    return {
-      sub: payload.sub as string,
-      email: payload['email'] as string | undefined,
-      email_verified: payload['email_verified'] as boolean | undefined,
-      clientId: payload['client_id'] as string,
-      scope: payload['scope'] as string | undefined,
-      aud: payload.aud as string | string[] | undefined,
-      // RFC 8693 §4.1: surface any existing `act` chain so a subject token
-      // already carrying a delegation can be nested under the new actor.
-      act: payload['act'] as JWTPayload['act'],
-      iat: payload.iat as number | undefined,
-      exp: payload.exp as number | undefined,
-      iss: payload.iss as string | undefined,
-      // RFC 7009 revocation: surface the unique token id so the auth-server
-      // layer can denylist a specific access token. The lib stays pure — it
-      // never consults any revocation store itself.
-      jti: payload.jti as string | undefined,
-      token_use: payload['token_use'] as string | undefined,
-    };
+    }));
   } catch (error) {
     if (error instanceof Error) {
       // 'jose' errors have a `code` property, and `JWTExpired` is a specific error name.
@@ -230,4 +212,37 @@ export async function verifyAccessToken(
     // Fallback for unknown errors
     throw new JWTInvalidError('Invalid JWT token');
   }
+
+  // `jose` verifies the SIGNATURE and the registered temporal/issuer/audience
+  // claims only — it does not assert the SHAPE of application claims. Without
+  // this step a signed-but-malformed token (e.g. a numeric `sub` or a non-string
+  // `email`) would be blindly cast and silently mis-typed downstream. Validate
+  // the claim shape at runtime and reject anything that does not match the token
+  // claim model before returning typed claims. Runs OUTSIDE the verify try/catch
+  // so the malformed-claims error is not re-wrapped with the jose-error message.
+  const result = accessTokenClaimsSchema.safeParse(payload);
+  if (!result.success) {
+    throw new JWTInvalidError('Invalid JWT token: malformed claims');
+  }
+  const claims = result.data;
+
+  return {
+    sub: claims.sub,
+    email: claims.email,
+    email_verified: claims.email_verified,
+    clientId: claims.client_id as string,
+    scope: claims.scope,
+    aud: claims.aud,
+    // RFC 8693 §4.1: surface any existing `act` chain so a subject token already
+    // carrying a delegation can be nested under the new actor.
+    act: claims.act,
+    iat: claims.iat,
+    exp: claims.exp,
+    iss: claims.iss,
+    // RFC 7009 revocation: surface the unique token id so the auth-server layer
+    // can denylist a specific access token. The lib stays pure — it never
+    // consults any revocation store itself.
+    jti: claims.jti,
+    token_use: claims.token_use,
+  };
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -769,6 +769,9 @@ importers:
       jose:
         specifier: 'catalog:'
         version: 6.1.3
+      zod:
+        specifier: 'catalog:'
+        version: 4.2.1
     devDependencies:
       '@vitest/coverage-v8':
         specifier: 'catalog:'


### PR DESCRIPTION
## Summary

Fixes two Medium findings from the JWT deep code review, scoped entirely to `libs/server/jwt/**`.

### F-09 — `decodeJwtUnsafe` cannot decode client_credentials tokens
`decodeJwtUnsafe` required `email` (string) **and** `email_verified` (boolean) or it threw. But `signAccessToken` deliberately **omits** these for `client_credentials` tokens (no end-user). The util was therefore unable to decode a valid client_credentials access token — inconsistent with the access-token design, and reachable via `fastify.jwtUtils.decodeTokenUnsafe` (used by `auth/logout`).

**Fix:** `sub` stays the only required claim; `email` / `email_verified` are now optional and surfaced only when present and well-typed. Backward-compatible — the consumer interface (`JWTPayload`) already types both as optional, and `logout.ts` only reads `sub`.

### F-10 — verified JWT claim shapes were cast without runtime validation
After `jose` verifies the **signature**, it does not assert the **shape** of application claims. `verifyAccessToken` cast them blindly (`payload.sub as string`, `email_verified as boolean`, …), so a cryptographically-valid token carrying, e.g., a numeric `sub` or a non-string `email` would be silently mis-typed and pushed downstream.

**Fix:** a minimal Zod v4 claim-shape schema (`access-token-claims.ts`, standalone `z.email()` per the validation convention) runs **after** signature verification and **outside** the jose try/catch. A signed-but-malformed token is now rejected as `JWTInvalidError` instead of mis-typed. The schema is `loose` (unknown claims pass through) — it narrows the claims QAuth consumes, it is not an allowlist.

## Were the findings already fixed?
No — both still applied against current code at review time and were reproduced before fixing.

## Tests (also helps the F-16 test-gap finding)
- New `jose-utils.test.ts`: full user token decodes; **client_credentials token decodes without email/email_verified** (F-09); malformed token throws.
- Extended `jwt-service.test.ts` (F-10): correctly-signed tokens with a non-string `sub`, an invalid `email`, or a non-boolean `email_verified` are all rejected; a well-formed client_credentials token verifies.

## Dependencies
Adds `zod` (`catalog:` → 4.2.1) to the `server-jwt` lib. Already in the workspace catalog and used by other libs; lockfile change is the single importer entry.

## Local verification (cloud-free)
```
NX_CLOUD_ACCESS_TOKEN= NX_NO_CLOUD=true pnpm exec nx run-many -t lint typecheck test \
  -p server-jwt fastify-plugin-jwt --skip-nx-cache
```
Result: **lint, typecheck, test all green** — `server-jwt` 51 tests pass, `fastify-plugin-jwt` 7 tests pass, 0 lint errors.

Also verified the consumer was not broken:
```
nx run-many -t typecheck test -p auth-server --skip-nx-cache  # green
```