### PR TITLE
fix: validate cached reads and route infra logs through injectable logger

### DIFF
--- a/libs/fastify/plugins/cache/src/lib/fastify-plugin-cache.ts
+++ b/libs/fastify/plugins/cache/src/lib/fastify-plugin-cache.ts
@@ -42,17 +42,19 @@ export const CACHE_PLUGIN_NAME = packageJson.name;
  */
 export const cachePlugin = fp<CachePluginOptions>(
   async (fastify: FastifyInstance, options: CachePluginOptions) => {
-    // Create Redis instance using factory
-    const redis = createRedisConnection(options.config);
+    // Create Redis instance using factory. Inject the Fastify logger so cache
+    // diagnostics flow through pino (levels + request-id correlation) instead
+    // of bare `console`.
+    const redis = createRedisConnection({ ...options.config, logger: fastify.log });
 
-    // Create session utilities
-    const sessionUtils = createSessionUtils(redis);
+    // Create session utilities (same injected logger for validation warnings)
+    const sessionUtils = createSessionUtils(redis, fastify.log);
 
     fastify.decorate('redis', redis);
     fastify.decorate('sessionUtils', sessionUtils);
 
     fastify.addHook('onReady', async () => {
-      const isConnected = await testRedisConnection(redis);
+      const isConnected = await testRedisConnection(redis, fastify.log);
       if (!isConnected) {
         fastify.log.warn('Redis connection test failed on ready');
       } else {

--- a/libs/fastify/plugins/db/src/lib/fastify-plugin-db.ts
+++ b/libs/fastify/plugins/db/src/lib/fastify-plugin-db.ts
@@ -65,8 +65,10 @@ declare module 'fastify' {
  */
 export const databasePlugin = fp<DatabasePluginOptions>(
   async (fastify: FastifyInstance, options: DatabasePluginOptions) => {
-    // Create database instance using factory
-    const database = createDatabase(options.config);
+    // Create database instance using factory. Inject the Fastify logger so DB
+    // diagnostics flow through pino (levels + request-id correlation) instead
+    // of bare `console`.
+    const database = createDatabase({ ...options.config, logger: fastify.log });
 
     fastify.decorate('db', database.db);
     fastify.decorate('dbPool', database.pool);

--- a/libs/infra/cache/package.json
+++ b/libs/infra/cache/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "main": "src/index.ts",
   "dependencies": {
-    "ioredis": "catalog:"
+    "ioredis": "catalog:",
+    "zod": "catalog:"
   }
 }

--- a/libs/infra/cache/src/lib/redis.test.ts
+++ b/libs/infra/cache/src/lib/redis.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { CacheClient, Logger } from '../types';
+import { createRedisConnection } from './redis';
+
+function createSpyLogger(): Logger {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  };
+}
+
+describe('createRedisConnection logger injection (F-13)', () => {
+  let client: CacheClient | undefined;
+
+  afterEach(() => {
+    // lazyConnect keeps the socket closed, but disconnect() is safe regardless
+    // and prevents background reconnect timers from leaking between tests.
+    client?.disconnect();
+    client = undefined;
+  });
+
+  it('routes connection-event diagnostics through the injected logger', () => {
+    const logger = createSpyLogger();
+    // lazyConnect (default) means no socket is opened by construction.
+    client = createRedisConnection({ host: '127.0.0.1', port: 6379, logger });
+
+    client.emit('connect');
+    client.emit('ready');
+    client.emit('reconnecting');
+    client.emit('close');
+    client.emit('end');
+    client.emit('error', new Error('boom'));
+
+    expect(logger.info).toHaveBeenCalled();
+    expect(logger.error).toHaveBeenCalledWith('Redis: Connection error:', expect.any(Error));
+  });
+});

--- a/libs/infra/cache/src/lib/redis.ts
+++ b/libs/infra/cache/src/lib/redis.ts
@@ -1,8 +1,8 @@
 import Redis, { RedisOptions } from 'ioredis';
 
-import type { CacheClient, RedisConfig } from '../types';
+import type { CacheClient, Logger, RedisConfig } from '../types';
 
-export type { CacheClient, RedisConfig };
+export type { CacheClient, Logger, RedisConfig };
 
 /**
  * Default Redis configuration values
@@ -53,6 +53,9 @@ export function createRedisConnection(config: RedisConfig): CacheClient {
     ...config,
   };
 
+  // Logger defaults to `console` so existing callers keep working unchanged.
+  const logger: Logger = mergedConfig.logger ?? console;
+
   // Build ioredis options
   const redisOptions: RedisOptions = {};
 
@@ -87,27 +90,27 @@ export function createRedisConnection(config: RedisConfig): CacheClient {
 
   // Connection event handlers for logging
   redis.on('connect', () => {
-    console.log('Redis: Connected');
+    logger.info('Redis: Connected');
   });
 
   redis.on('ready', () => {
-    console.log('Redis: Ready to accept commands');
+    logger.info('Redis: Ready to accept commands');
   });
 
   redis.on('error', (error) => {
-    console.error('Redis: Connection error:', error);
+    logger.error('Redis: Connection error:', error);
   });
 
   redis.on('close', () => {
-    console.log('Redis: Connection closed');
+    logger.info('Redis: Connection closed');
   });
 
   redis.on('reconnecting', () => {
-    console.log('Redis: Reconnecting...');
+    logger.info('Redis: Reconnecting...');
   });
 
   redis.on('end', () => {
-    console.log('Redis: Connection ended');
+    logger.info('Redis: Connection ended');
   });
 
   return redis;
@@ -117,9 +120,13 @@ export function createRedisConnection(config: RedisConfig): CacheClient {
  * Test Redis connection
  *
  * @param redis - Redis client instance to test
+ * @param logger - Optional logger for diagnostics (defaults to `console`)
  * @returns true if connection is successful, false otherwise
  */
-export async function testRedisConnection(redis: CacheClient): Promise<boolean> {
+export async function testRedisConnection(
+  redis: CacheClient,
+  logger: Logger = console
+): Promise<boolean> {
   try {
     // Connect if not already connected (lazyConnect: true)
     if (redis.status === 'wait') {
@@ -128,7 +135,7 @@ export async function testRedisConnection(redis: CacheClient): Promise<boolean> 
     await redis.ping();
     return true;
   } catch (error) {
-    console.error('Redis connection test failed:', error);
+    logger.error('Redis connection test failed:', error);
     return false;
   }
 }

--- a/libs/infra/cache/src/lib/utils.test.ts
+++ b/libs/infra/cache/src/lib/utils.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+
+import type { CacheClient, Logger } from '../types';
+import { createCacheUtils, createSessionUtils, createUserUtils, KEY_PREFIXES } from './utils';
+
+/**
+ * Minimal in-memory fake of the bits of the Redis client these utilities use.
+ * Only `get`/`setex` are exercised by the validation paths under test.
+ */
+function createFakeClient(initial: Record<string, string> = {}): {
+  client: CacheClient;
+  store: Map<string, string>;
+} {
+  const store = new Map<string, string>(Object.entries(initial));
+  const client = {
+    get: vi.fn(async (key: string) => store.get(key) ?? null),
+    setex: vi.fn(async (key: string, _ttl: number, value: string) => {
+      store.set(key, value);
+      return 'OK' as const;
+    }),
+  } as unknown as CacheClient;
+  return { client, store };
+}
+
+function createSpyLogger(): Logger {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  };
+}
+
+describe('cache deserialization validation (F-11)', () => {
+  let logger: Logger;
+
+  beforeEach(() => {
+    logger = createSpyLogger();
+  });
+
+  describe('createCacheUtils.getCache', () => {
+    it('returns the parsed value without a schema (backward compatible)', async () => {
+      const { client } = createFakeClient({
+        [`${KEY_PREFIXES.CACHE}k`]: JSON.stringify({ a: 1 }),
+      });
+      const utils = createCacheUtils(client, logger);
+
+      await expect(utils.getCache('k')).resolves.toEqual({ a: 1 });
+      expect(logger.warn).not.toHaveBeenCalled();
+    });
+
+    it('returns the validated value when the schema matches', async () => {
+      const schema = z.object({ a: z.number() });
+      const { client } = createFakeClient({
+        [`${KEY_PREFIXES.CACHE}k`]: JSON.stringify({ a: 1 }),
+      });
+      const utils = createCacheUtils(client, logger);
+
+      await expect(utils.getCache('k', schema)).resolves.toEqual({ a: 1 });
+      expect(logger.warn).not.toHaveBeenCalled();
+    });
+
+    it('treats a schema-validation failure as a cache miss and warns', async () => {
+      const schema = z.object({ a: z.number() });
+      const { client } = createFakeClient({
+        [`${KEY_PREFIXES.CACHE}k`]: JSON.stringify({ a: 'not-a-number' }),
+      });
+      const utils = createCacheUtils(client, logger);
+
+      await expect(utils.getCache('k', schema)).resolves.toBeNull();
+      expect(logger.warn).toHaveBeenCalledTimes(1);
+    });
+
+    it('treats malformed JSON as a cache miss and warns', async () => {
+      const { client } = createFakeClient({
+        [`${KEY_PREFIXES.CACHE}k`]: '{not valid json',
+      });
+      const utils = createCacheUtils(client, logger);
+
+      await expect(utils.getCache('k')).resolves.toBeNull();
+      expect(logger.warn).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns null on a genuine miss without warning', async () => {
+      const { client } = createFakeClient();
+      const utils = createCacheUtils(client, logger);
+
+      await expect(utils.getCache('missing')).resolves.toBeNull();
+      expect(logger.warn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('createCacheUtils.getOrSetCache', () => {
+    it('recomputes via fallback when the cached value fails validation', async () => {
+      const schema = z.object({ a: z.number() });
+      const { client, store } = createFakeClient({
+        [`${KEY_PREFIXES.CACHE}k`]: JSON.stringify({ a: 'bad' }),
+      });
+      const utils = createCacheUtils(client, logger);
+      const fallback = vi.fn(async () => ({ a: 42 }));
+
+      await expect(utils.getOrSetCache('k', fallback, 60, schema)).resolves.toEqual({ a: 42 });
+      expect(fallback).toHaveBeenCalledTimes(1);
+      expect(logger.warn).toHaveBeenCalledTimes(1);
+      // The recomputed value should have been written back to the cache.
+      expect(store.get(`${KEY_PREFIXES.CACHE}k`)).toBe(JSON.stringify({ a: 42 }));
+    });
+  });
+
+  describe('createSessionUtils.getSession', () => {
+    it('treats a schema-validation failure as a miss and warns', async () => {
+      const schema = z.object({ userId: z.string() });
+      const { client } = createFakeClient({
+        [`${KEY_PREFIXES.SESSION}s`]: JSON.stringify({ userId: 123 }),
+      });
+      const utils = createSessionUtils(client, logger);
+
+      await expect(utils.getSession('s', schema)).resolves.toBeNull();
+      expect(logger.warn).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('createUserUtils.getUserData', () => {
+    it('returns the validated value when the schema matches', async () => {
+      const schema = z.object({ email: z.email() });
+      const { client } = createFakeClient({
+        [`${KEY_PREFIXES.USER}u`]: JSON.stringify({ email: 'a@b.com' }),
+      });
+      const utils = createUserUtils(client, logger);
+
+      await expect(utils.getUserData('u', schema)).resolves.toEqual({ email: 'a@b.com' });
+      expect(logger.warn).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/libs/infra/cache/src/lib/utils.ts
+++ b/libs/infra/cache/src/lib/utils.ts
@@ -1,6 +1,9 @@
+import type { ZodType } from 'zod';
+
 import type {
   CacheClient,
   CacheUtilsInstance,
+  Logger,
   RateLimitResult,
   RateLimitStatus,
   RateLimitUtilsInstance,
@@ -13,6 +16,7 @@ import type {
 
 export type {
   CacheUtilsInstance,
+  Logger,
   RateLimitResult,
   RateLimitStatus,
   RateLimitUtilsInstance,
@@ -22,6 +26,57 @@ export type {
   UserData,
   UserUtilsInstance,
 };
+
+/**
+ * Safely deserialize a raw cache string into a typed value.
+ *
+ * Without a schema this preserves the historical behaviour (`JSON.parse` cast
+ * to `T`) but no longer lets a malformed JSON string throw an uncaught error:
+ * a parse failure is treated as a cache MISS (returns `null`) and logged.
+ *
+ * With a schema the parsed value is validated; on failure the entry is treated
+ * as a cache MISS so corrupted or attacker-injected values can never surface as
+ * a wrong-shaped object.
+ *
+ * @param raw - Raw string read from the cache (or `null` for a miss)
+ * @param key - Cache key, used only for diagnostic logging
+ * @param logger - Logger used to warn on malformed/invalid entries
+ * @param schema - Optional Zod schema to validate the parsed value
+ * @returns The typed value, or `null` on a miss/parse/validation failure
+ */
+function parseCached<T>(
+  raw: string | null,
+  key: string,
+  logger: Logger,
+  schema?: ZodType<T>
+): T | null {
+  if (raw === null) {
+    return null;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    logger.warn(`Cache: malformed JSON for key "${key}", treating as miss`, error);
+    return null;
+  }
+
+  if (!schema) {
+    return parsed as T;
+  }
+
+  const result = schema.safeParse(parsed);
+  if (!result.success) {
+    logger.warn(
+      `Cache: value for key "${key}" failed schema validation, treating as miss`,
+      result.error.issues
+    );
+    return null;
+  }
+
+  return result.data;
+}
 
 /**
  * Key prefixes for different data types
@@ -49,9 +104,13 @@ export const DEFAULT_TTL = {
  * Create session utilities with the given Redis client
  *
  * @param client - Redis client instance
+ * @param logger - Optional logger for diagnostics (defaults to `console`)
  * @returns Session utilities object
  */
-export function createSessionUtils(client: CacheClient): SessionUtilsInstance {
+export function createSessionUtils(
+  client: CacheClient,
+  logger: Logger = console
+): SessionUtilsInstance {
   return {
     async setSession<T extends SessionData>(
       sessionId: string,
@@ -62,10 +121,13 @@ export function createSessionUtils(client: CacheClient): SessionUtilsInstance {
       await client.setex(key, ttl, JSON.stringify(data));
     },
 
-    async getSession<T extends SessionData>(sessionId: string): Promise<T | null> {
+    async getSession<T extends SessionData>(
+      sessionId: string,
+      schema?: ZodType<T>
+    ): Promise<T | null> {
       const key = `${KEY_PREFIXES.SESSION}${sessionId}`;
       const data = await client.get(key);
-      return data ? (JSON.parse(data) as T) : null;
+      return parseCached(data, key, logger, schema);
     },
 
     async deleteSession(sessionId: string): Promise<void> {
@@ -138,19 +200,23 @@ export function createRateLimitUtils(client: CacheClient): RateLimitUtilsInstanc
  * Create cache utilities with the given Redis client
  *
  * @param client - Redis client instance
+ * @param logger - Optional logger for diagnostics (defaults to `console`)
  * @returns Cache utilities object
  */
-export function createCacheUtils(client: CacheClient): CacheUtilsInstance {
+export function createCacheUtils(
+  client: CacheClient,
+  logger: Logger = console
+): CacheUtilsInstance {
   const utils: CacheUtilsInstance = {
     async setCache<T>(key: string, data: T, ttl: number = DEFAULT_TTL.CACHE): Promise<void> {
       const cacheKey = `${KEY_PREFIXES.CACHE}${key}`;
       await client.setex(cacheKey, ttl, JSON.stringify(data));
     },
 
-    async getCache<T>(key: string): Promise<T | null> {
+    async getCache<T>(key: string, schema?: ZodType<T>): Promise<T | null> {
       const cacheKey = `${KEY_PREFIXES.CACHE}${key}`;
       const data = await client.get(cacheKey);
-      return data ? (JSON.parse(data) as T) : null;
+      return parseCached(data, cacheKey, logger, schema);
     },
 
     async deleteCache(key: string): Promise<void> {
@@ -166,9 +232,10 @@ export function createCacheUtils(client: CacheClient): CacheUtilsInstance {
     async getOrSetCache<T>(
       key: string,
       fallback: () => Promise<T>,
-      ttl: number = DEFAULT_TTL.CACHE
+      ttl: number = DEFAULT_TTL.CACHE,
+      schema?: ZodType<T>
     ): Promise<T> {
-      const cached = await utils.getCache<T>(key);
+      const cached = await utils.getCache<T>(key, schema);
       if (cached !== null) {
         return cached;
       }
@@ -186,9 +253,10 @@ export function createCacheUtils(client: CacheClient): CacheUtilsInstance {
  * Create user data utilities with the given Redis client
  *
  * @param client - Redis client instance
+ * @param logger - Optional logger for diagnostics (defaults to `console`)
  * @returns User utilities object
  */
-export function createUserUtils(client: CacheClient): UserUtilsInstance {
+export function createUserUtils(client: CacheClient, logger: Logger = console): UserUtilsInstance {
   return {
     async setUserData<T extends UserData>(
       userId: string,
@@ -199,10 +267,10 @@ export function createUserUtils(client: CacheClient): UserUtilsInstance {
       await client.setex(key, ttl, JSON.stringify(data));
     },
 
-    async getUserData<T extends UserData>(userId: string): Promise<T | null> {
+    async getUserData<T extends UserData>(userId: string, schema?: ZodType<T>): Promise<T | null> {
       const key = `${KEY_PREFIXES.USER}${userId}`;
       const data = await client.get(key);
-      return data ? (JSON.parse(data) as T) : null;
+      return parseCached(data, key, logger, schema);
     },
 
     async deleteUserData(userId: string): Promise<void> {

--- a/libs/infra/cache/src/types/cache.ts
+++ b/libs/infra/cache/src/types/cache.ts
@@ -1,10 +1,28 @@
+import type { ZodType } from 'zod';
+
 /**
  * Cache utilities interface
  */
 export interface CacheUtilsInstance {
   setCache<T>(key: string, data: T, ttl?: number): Promise<void>;
-  getCache<T>(key: string): Promise<T | null>;
+  /**
+   * Read a cached value. When `schema` is provided, the parsed value is
+   * validated against it; a validation failure (or malformed JSON) is treated
+   * as a cache MISS — the method returns `null` and logs a warning rather than
+   * returning a mis-typed object or throwing.
+   */
+  getCache<T>(key: string, schema?: ZodType<T>): Promise<T | null>;
   deleteCache(key: string): Promise<void>;
   hasCache(key: string): Promise<boolean>;
-  getOrSetCache<T>(key: string, fallback: () => Promise<T>, ttl?: number): Promise<T>;
+  /**
+   * Return the cached value or compute, store, and return it. When `schema` is
+   * provided it validates the cached value on read; an invalid cache entry is
+   * treated as a miss and the fallback recomputes the value.
+   */
+  getOrSetCache<T>(
+    key: string,
+    fallback: () => Promise<T>,
+    ttl?: number,
+    schema?: ZodType<T>
+  ): Promise<T>;
 }

--- a/libs/infra/cache/src/types/redis.ts
+++ b/libs/infra/cache/src/types/redis.ts
@@ -7,6 +7,21 @@ import type Redis from 'ioredis';
 export type CacheClient = Redis;
 
 /**
+ * Minimal logger interface (pino-compatible).
+ *
+ * Lets callers inject a structured logger (e.g. `fastify.log`) so cache
+ * messages flow through proper log levels and request-id correlation instead
+ * of `console`. The global `console` object satisfies this shape, so it is the
+ * default when no logger is provided.
+ */
+export interface Logger {
+  info(...args: unknown[]): void;
+  warn(...args: unknown[]): void;
+  error(...args: unknown[]): void;
+  debug(...args: unknown[]): void;
+}
+
+/**
  * Redis connection configuration interface
  */
 export interface RedisConfig {
@@ -28,4 +43,10 @@ export interface RedisConfig {
   commandTimeout?: number;
   /** Whether to use lazy connection (connect on first command) @default true */
   lazyConnect?: boolean;
+  /**
+   * Optional logger for connection diagnostics. Defaults to `console`.
+   * Inject `fastify.log` (or any pino-compatible logger) for structured,
+   * level-aware, request-correlated logging.
+   */
+  logger?: Logger;
 }

--- a/libs/infra/cache/src/types/session.ts
+++ b/libs/infra/cache/src/types/session.ts
@@ -1,3 +1,5 @@
+import type { ZodType } from 'zod';
+
 /**
  * Session data type - can be extended by consumers
  */
@@ -10,7 +12,13 @@ export interface SessionData {
  */
 export interface SessionUtilsInstance {
   setSession<T extends SessionData>(sessionId: string, data: T, ttl?: number): Promise<void>;
-  getSession<T extends SessionData>(sessionId: string): Promise<T | null>;
+  /**
+   * Read a session. When `schema` is provided, the parsed value is validated
+   * against it; a validation failure (or malformed JSON) is treated as a cache
+   * MISS — the method returns `null` and logs a warning rather than returning a
+   * mis-typed object or throwing.
+   */
+  getSession<T extends SessionData>(sessionId: string, schema?: ZodType<T>): Promise<T | null>;
   deleteSession(sessionId: string): Promise<void>;
   extendSession(sessionId: string, ttl?: number): Promise<void>;
   hasSession(sessionId: string): Promise<boolean>;

--- a/libs/infra/cache/src/types/user.ts
+++ b/libs/infra/cache/src/types/user.ts
@@ -1,3 +1,5 @@
+import type { ZodType } from 'zod';
+
 /**
  * User data type - can be extended by consumers
  */
@@ -10,6 +12,12 @@ export interface UserData {
  */
 export interface UserUtilsInstance {
   setUserData<T extends UserData>(userId: string, data: T, ttl?: number): Promise<void>;
-  getUserData<T extends UserData>(userId: string): Promise<T | null>;
+  /**
+   * Read cached user data. When `schema` is provided, the parsed value is
+   * validated against it; a validation failure (or malformed JSON) is treated
+   * as a cache MISS — the method returns `null` and logs a warning rather than
+   * returning a mis-typed object or throwing.
+   */
+  getUserData<T extends UserData>(userId: string, schema?: ZodType<T>): Promise<T | null>;
   deleteUserData(userId: string): Promise<void>;
 }

--- a/libs/infra/cache/vitest.config.ts
+++ b/libs/infra/cache/vitest.config.ts
@@ -1,0 +1,3 @@
+import baseConfig from '../../../vitest.config';
+
+export default baseConfig;

--- a/libs/infra/db/src/lib/db.test.ts
+++ b/libs/infra/db/src/lib/db.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { DatabaseInstance, Logger } from '../types';
+import { createDatabase } from './db';
+
+function createSpyLogger(): Logger {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  };
+}
+
+describe('createDatabase logger injection (F-13)', () => {
+  let database: DatabaseInstance | undefined;
+
+  afterEach(async () => {
+    await database?.close().catch(() => undefined);
+    database = undefined;
+  });
+
+  it('routes connection-failure diagnostics through the injected logger', async () => {
+    const logger = createSpyLogger();
+    // Point at a closed port with a tiny connect timeout so testConnection
+    // fails fast without needing a real database.
+    database = createDatabase({
+      connectionString: 'postgresql://user:pass@127.0.0.1:1/db',
+      pool: { connectionTimeoutMillis: 200, min: 0 },
+      logger,
+    });
+
+    await expect(database.testConnection()).resolves.toBe(false);
+    expect(logger.error).toHaveBeenCalledWith(
+      'Database connection test failed:',
+      expect.anything()
+    );
+  });
+});

--- a/libs/infra/db/src/lib/db.ts
+++ b/libs/infra/db/src/lib/db.ts
@@ -7,9 +7,17 @@ import type {
   DatabasePool,
   DatabasePoolConfig,
   DbClient,
+  Logger,
 } from '../types';
 
-export type { DatabaseConfig, DatabaseInstance, DatabasePool, DatabasePoolConfig, DbClient };
+export type {
+  DatabaseConfig,
+  DatabaseInstance,
+  DatabasePool,
+  DatabasePoolConfig,
+  DbClient,
+  Logger,
+};
 
 /**
  * Default pool configuration values
@@ -45,6 +53,9 @@ export const DEFAULT_POOL_CONFIG: Required<DatabasePoolConfig> = {
  * ```
  */
 export function createDatabase(config: DatabaseConfig): DatabaseInstance {
+  // Logger defaults to `console` so existing callers keep working unchanged.
+  const logger: Logger = config.logger ?? console;
+
   // Merge pool config with defaults
   const poolConfig = {
     ...DEFAULT_POOL_CONFIG,
@@ -78,7 +89,7 @@ export function createDatabase(config: DatabaseConfig): DatabaseInstance {
         client.release();
         return true;
       } catch (error) {
-        console.error('Database connection test failed:', error);
+        logger.error('Database connection test failed:', error);
         return false;
       }
     },

--- a/libs/infra/db/src/types/database.ts
+++ b/libs/infra/db/src/types/database.ts
@@ -24,6 +24,21 @@ export interface DatabasePoolConfig {
 }
 
 /**
+ * Minimal logger interface (pino-compatible).
+ *
+ * Lets callers inject a structured logger (e.g. `fastify.log`) so infra
+ * messages flow through proper log levels and request-id correlation instead
+ * of `console`. The global `console` object satisfies this shape, so it is the
+ * default when no logger is provided.
+ */
+export interface Logger {
+  info(...args: unknown[]): void;
+  warn(...args: unknown[]): void;
+  error(...args: unknown[]): void;
+  debug(...args: unknown[]): void;
+}
+
+/**
  * Database configuration interface
  */
 export interface DatabaseConfig {
@@ -31,6 +46,12 @@ export interface DatabaseConfig {
   connectionString: string;
   /** Pool configuration options (optional) */
   pool?: DatabasePoolConfig;
+  /**
+   * Optional logger for diagnostic messages. Defaults to `console`.
+   * Inject `fastify.log` (or any pino-compatible logger) for structured,
+   * level-aware, request-correlated logging.
+   */
+  logger?: Logger;
 }
 
 /**

--- a/libs/infra/db/vitest.config.ts
+++ b/libs/infra/db/vitest.config.ts
@@ -1,0 +1,3 @@
+import baseConfig from '../../../vitest.config';
+
+export default baseConfig;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -513,52 +513,6 @@ importers:
         specifier: 'catalog:'
         version: 8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
 
-  apps/developer-portal/dist/client:
-    dependencies:
-      '@qauth-labs/ui':
-        specifier: workspace:*
-        version: link:../../../../libs/ui
-      '@tailwindcss/vite':
-        specifier: 'catalog:'
-        version: 4.2.1(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
-      '@tanstack/nitro-v2-vite-plugin':
-        specifier: 'catalog:'
-        version: 1.155.0(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.16.0)(pg@8.16.3))(rolldown@1.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(webpack@5.105.2(@swc/core@1.15.43(@swc/helpers@0.5.23))(esbuild@0.28.1)(postcss@8.5.15))
-      '@tanstack/react-router':
-        specifier: 'catalog:'
-        version: 1.170.16(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@tanstack/react-start':
-        specifier: 'catalog:'
-        version: 1.168.26(esbuild@0.28.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rolldown@1.0.3)(rollup@4.62.2)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(webpack@5.105.2(@swc/core@1.15.43(@swc/helpers@0.5.23))(esbuild@0.28.1)(postcss@8.5.15))
-      react:
-        specifier: 'catalog:'
-        version: 19.2.4
-      react-dom:
-        specifier: 'catalog:'
-        version: 19.2.4(react@19.2.4)
-      tailwindcss:
-        specifier: 'catalog:'
-        version: 4.2.1
-    devDependencies:
-      '@types/node':
-        specifier: 'catalog:'
-        version: 26.0.0
-      '@types/react':
-        specifier: 'catalog:'
-        version: 19.2.14
-      '@types/react-dom':
-        specifier: 'catalog:'
-        version: 19.2.3(@types/react@19.2.14)
-      '@vitejs/plugin-react':
-        specifier: 'catalog:'
-        version: 6.0.2(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
-      typescript:
-        specifier: ~6.0.3
-        version: 6.0.3
-      vite:
-        specifier: 'catalog:'
-        version: 8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
-
   libs/fastify/plugins/cache:
     dependencies:
       '@qauth-labs/infra-cache':
@@ -677,6 +631,9 @@ importers:
       ioredis:
         specifier: 'catalog:'
         version: 5.8.2
+      zod:
+        specifier: 'catalog:'
+        version: 4.2.1
 
   libs/infra/db:
     dependencies:
@@ -5986,6 +5943,7 @@ packages:
   git-raw-commits@5.0.1:
     resolution: {integrity: sha512-Y+csSm2GD/PCSh6Isd/WiMjNAydu0VBiG9J7EdQsNA5P9uXvLayqjmTsNlK5Gs9IhblFZqOU0yid5Il5JPoLiQ==}
     engines: {node: '>=18'}
+    deprecated: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
     hasBin: true
 
   glob-parent@5.1.2:


### PR DESCRIPTION
Fixes two Medium findings from the QAuth deep code review.

## F-11 — Unsafe cache deserialization (Medium)
The cache helpers read Redis values with `JSON.parse(data) as T` and **no validation**, so a corrupted or attacker-injected entry surfaced as a wrong-shaped object, and malformed JSON threw an uncaught error.

- `getSession`, `getCache`, `getUserData`, and `getOrSetCache` now accept an **optional** Zod `ZodType` schema.
- On read, the parsed value is validated; a parse failure **or** schema-validation failure is treated as a **cache MISS** — the helper returns `null` and logs a warning instead of returning a mis-typed object or throwing.
- `getOrSetCache` forwards the schema and recomputes via the fallback when the cached entry is invalid.
- The schema is optional, so all existing callers are unchanged (malformed JSON now degrades to a miss rather than throwing — a strict improvement).

## F-13 — Infra libs logged via `console` (Medium)
`createDatabase` and `createRedisConnection` logged through `console.log`/`console.error`, bypassing pino, log levels, and request-id correlation.

- `DatabaseConfig` and `RedisConfig` now take an optional `logger` field (a minimal pino-compatible `{ info; warn; error; debug }` interface).
- Defaults to `console` when not provided, so nothing breaks for existing callers.
- `testRedisConnection` also accepts an optional logger (defaults to `console`).
- **Plugins wired**: the Fastify `db` and `cache` plugins now inject `fastify.log`, so infra diagnostics flow through the request logger. This was small and clean, so it was included rather than deferred.

## Tests (helps F-16 test-gap)
New unit suites for `infra-cache` (`utils.test.ts`, `redis.test.ts`) and `infra-db` (`db.test.ts`):
- invalid/malformed cached values return `null` and warn; valid values pass through;
- `getOrSetCache` recomputes on an invalid entry;
- injected loggers receive the factory/connection diagnostics.

(Each lib gained a `vitest.config.ts` re-exporting the root config so Nx infers a `test` target.)

## Verification
`nx run-many -t lint typecheck test -p infra-cache infra-db fastify-plugin-cache fastify-plugin-db` — all green (lint 0 errors, typecheck clean, 9 cache + 1 db unit tests pass). The Docker-gated `infra-db` integration test is untouched.